### PR TITLE
feat(release): harden desktop packaging and winget publishing

### DIFF
--- a/.github/packaging/linux/gg.ai.ggcode-desktop.metainfo.xml
+++ b/.github/packaging/linux/gg.ai.ggcode-desktop.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>gg.ai.ggcode-desktop</id>
+  <name>GGCode</name>
+  <summary>AI coding agent with terminal and desktop workflows</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <developer id="gg.ai">
+    <name>GG AI Studio</name>
+  </developer>
+  <launchable type="desktop-id">ggcode-desktop.desktop</launchable>
+  <description>
+    <p>
+      GGCode is an AI coding agent with a native desktop interface, resumable sessions,
+      MCP integrations, built-in tools, and coding-focused workflows.
+    </p>
+  </description>
+  <categories>
+    <category>Development</category>
+  </categories>
+  <url type="homepage">https://github.com/topcheer/ggcode</url>
+  <url type="bugtracker">https://github.com/topcheer/ggcode/issues</url>
+  <content_rating type="oars-1.1" />
+</component>

--- a/.github/packaging/linux/ggcode-desktop.desktop
+++ b/.github/packaging/linux/ggcode-desktop.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=GGCode
+Comment=AI coding agent for the terminal and desktop
+Exec=ggcode-desktop
+Icon=ggcode-desktop
+Terminal=false
+Categories=Development;IDE;
+Keywords=AI;Coding;Terminal;MCP;Agent;
+StartupNotify=true

--- a/.github/packaging/windows/ggcode-desktop.wxs
+++ b/.github/packaging/windows/ggcode-desktop.wxs
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+    Name="GGCode Desktop"
+    Manufacturer="GG AI Studio"
+    Version="$(var.Version)"
+    UpgradeCode="$(var.UpgradeCode)"
+    Language="1033"
+    InstallerVersion="500"
+    Scope="perMachine">
+    <SummaryInformation
+      Description="GGCode desktop AI coding agent"
+      Manufacturer="GG AI Studio"
+      Keywords="Installer" />
+    <MajorUpgrade DowngradeErrorMessage="A newer version of GGCode Desktop is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+    <Feature Id="MainFeature" Title="GGCode Desktop" Level="1">
+      <ComponentGroupRef Id="MainComponents" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="GGCode Desktop" FileSource="$(var.SourceDir)" />
+    </StandardDirectory>
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="ProgramMenuVendorDir" Name="GG AI Studio">
+        <Directory Id="ProgramMenuProductDir" Name="GGCode Desktop" />
+      </Directory>
+    </StandardDirectory>
+    <StandardDirectory Id="DesktopFolder" />
+  </Fragment>
+
+  <Fragment>
+    <DirectoryRef Id="INSTALLFOLDER" FileSource="$(var.SourceDir)">
+      <Component Id="MainExecutableComponent" Guid="*">
+        <File Id="MainExecutableFile" Name="ggcode-desktop.exe" KeyPath="yes" />
+      </Component>
+      <Component Id="ShortcutComponent" Guid="*">
+        <Shortcut
+          Id="DesktopShortcut"
+          Directory="DesktopFolder"
+          Name="GGCode Desktop"
+          WorkingDirectory="INSTALLFOLDER"
+          Target="[INSTALLFOLDER]ggcode-desktop.exe" />
+        <Shortcut
+          Id="ProgramMenuShortcut"
+          Directory="ProgramMenuProductDir"
+          Name="GGCode Desktop"
+          WorkingDirectory="INSTALLFOLDER"
+          Target="[INSTALLFOLDER]ggcode-desktop.exe" />
+        <RemoveFolder Id="RemoveProgramMenuProductDir" Directory="ProgramMenuProductDir" On="uninstall" />
+        <RegistryValue
+          Root="HKLM"
+          Key="Software\GG AI Studio\GGCode Desktop"
+          Name="installed"
+          Type="integer"
+          Value="1"
+          KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="MainComponents">
+      <ComponentRef Id="MainExecutableComponent" />
+      <ComponentRef Id="ShortcutComponent" />
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/.github/packaging/windows/ggcode.wxs
+++ b/.github/packaging/windows/ggcode.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package
     Name="ggcode"
-    Manufacturer="topcheer"
+    Manufacturer="GG AI Studio"
     Version="$(var.Version)"
     UpgradeCode="$(var.UpgradeCode)"
     Language="1033"
@@ -10,7 +10,7 @@
     Scope="perMachine">
     <SummaryInformation
       Description="ggcode terminal AI coding agent"
-      Manufacturer="topcheer"
+      Manufacturer="GG AI Studio"
       Keywords="Installer" />
     <MajorUpgrade DowngradeErrorMessage="A newer version of ggcode is already installed." />
     <MediaTemplate EmbedCab="yes" />

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,12 @@ jobs:
       - name: Install GCC (MinGW)
         shell: pwsh
         run: choco install mingw --yes
+      - name: Install WiX Toolset
+        shell: pwsh
+        run: |
+          dotnet tool install --global wix --version 4.0.5
+          Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.dotnet\tools"
+          wix --version
       - name: Capture build date
         shell: pwsh
         run: |
@@ -249,10 +255,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: desktop-windows
-          path: dist/
+          path: dist/ggcode-desktop_*
 
-  build-desktop-linux:
-    name: Build desktop Linux
+  build-desktop-linux-amd64:
+    name: Build desktop Linux amd64
     runs-on: ubuntu-latest
     needs:
       - verify
@@ -273,7 +279,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgl1-mesa-dev libx11-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxxf86vm-dev libglfw3-dev libpulse-dev
+          sudo apt-get install -y libgl1-mesa-dev libx11-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxxf86vm-dev libglfw3-dev libpulse-dev patchelf squashfs-tools desktop-file-utils
       - name: Capture build date
         shell: bash
         run: echo "GGCODE_DATE=$(git show -s --format=%cI "${GITHUB_SHA}")" >> "${GITHUB_ENV}"
@@ -285,7 +291,45 @@ jobs:
       - name: Upload desktop Linux artifact
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-linux
+          name: desktop-linux-amd64
+          path: dist/ggcode-desktop_*
+
+  build-desktop-linux-arm64:
+    name: Build desktop Linux arm64
+    runs-on: ubuntu-24.04-arm
+    needs:
+      - verify
+    permissions:
+      contents: write
+    env:
+      GGCODE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.package_version || github.ref_name }}
+      GGCODE_COMMIT: ${{ github.sha }}
+      CGO_ENABLED: 1
+      GOTOOLCHAIN: local
+      TARGET_ARCH: arm64
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install Fyne dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-dev libx11-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxxf86vm-dev libglfw3-dev libpulse-dev patchelf squashfs-tools desktop-file-utils
+      - name: Capture build date
+        shell: bash
+        run: echo "GGCODE_DATE=$(git show -s --format=%cI "${GITHUB_SHA}")" >> "${GITHUB_ENV}"
+      - name: Build desktop Linux
+        shell: bash
+        run: |
+          chmod +x ./scripts/release/build-desktop-linux.sh
+          ./scripts/release/build-desktop-linux.sh "${GGCODE_VERSION}" dist
+      - name: Upload desktop Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-linux-arm64
           path: dist/ggcode-desktop_*
 
   upload-release-assets:
@@ -298,7 +342,8 @@ jobs:
       - release-windows-msi
       - build-desktop-darwin
       - build-desktop-windows
-      - build-desktop-linux
+      - build-desktop-linux-amd64
+      - build-desktop-linux-arm64
     permissions:
       contents: write
     env:
@@ -322,8 +367,12 @@ jobs:
           path: dist/desktop-windows
       - uses: actions/download-artifact@v4
         with:
-          name: desktop-linux
-          path: dist/desktop-linux
+          name: desktop-linux-amd64
+          path: dist/desktop-linux-amd64
+      - uses: actions/download-artifact@v4
+        with:
+          name: desktop-linux-arm64
+          path: dist/desktop-linux-arm64
       - name: Upload all extra assets to release
         env:
           GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
@@ -333,9 +382,38 @@ jobs:
             dist/macos-pkg/*.pkg \
             dist/windows-msi/*.msi \
             dist/desktop-darwin/*.dmg \
-            dist/desktop-windows/*.exe \
-            dist/desktop-linux/ggcode-desktop_* \
+            dist/desktop-windows/* \
+            dist/desktop-linux-amd64/ggcode-desktop_* \
+            dist/desktop-linux-arm64/ggcode-desktop_* \
             --clobber
+
+  publish-winget:
+    name: Publish desktop to winget
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: windows-latest
+    needs:
+      - upload-release-assets
+    permissions:
+      contents: read
+    env:
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
+      WINGET_PACKAGE_ID: gg.ai.ggcode-desktop
+    steps:
+      - uses: actions/checkout@v6
+      - name: Submit or skip winget update
+        shell: pwsh
+        run: |
+          if (-not $env:WINGET_CREATE_GITHUB_TOKEN) {
+            Write-Host "WINGET_CREATE_GITHUB_TOKEN not configured; skipping winget submission."
+            exit 0
+          }
+          $packageVersion = "${{ github.ref_name }}" -replace '^v',''
+          $installerUrl = "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/ggcode-desktop_${packageVersion}_windows_x64.msi"
+          .\scripts\release\publish-winget.ps1 `
+            -PackageId $env:WINGET_PACKAGE_ID `
+            -Version "${{ github.ref_name }}" `
+            -InstallerUrl $installerUrl `
+            -GitHubToken $env:WINGET_CREATE_GITHUB_TOKEN
 
   publish-site-release-branch:
     name: Publish site release branch
@@ -343,6 +421,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - upload-release-assets
+      - publish-winget
     permissions:
       contents: write
     env:
@@ -374,8 +453,12 @@ jobs:
           path: dist-site/desktop-windows
       - uses: actions/download-artifact@v4
         with:
-          name: desktop-linux
-          path: dist-site/desktop-linux
+          name: desktop-linux-amd64
+          path: dist-site/desktop-linux-amd64
+      - uses: actions/download-artifact@v4
+        with:
+          name: desktop-linux-arm64
+          path: dist-site/desktop-linux-arm64
       - name: Publish release assets into deployment branch
         env:
           GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
@@ -389,5 +472,6 @@ jobs:
             --asset-dir dist-site/windows-msi \
             --asset-dir dist-site/desktop-darwin \
             --asset-dir dist-site/desktop-windows \
-            --asset-dir dist-site/desktop-linux \
+            --asset-dir dist-site/desktop-linux-amd64 \
+            --asset-dir dist-site/desktop-linux-arm64 \
             --source-label "${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   verify:
     name: Verify release inputs
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
@@ -39,6 +40,7 @@ jobs:
 
   release:
     name: Build & Release
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.verify.result == 'success') }}
     runs-on: ubuntu-latest
     needs: verify
     env:
@@ -90,6 +92,7 @@ jobs:
 
   release-macos-pkg:
     name: Build macOS pkg
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.verify.result == 'success') }}
     runs-on: macos-latest
     needs:
       - verify
@@ -122,6 +125,7 @@ jobs:
 
   release-windows-msi:
     name: Build Windows msi
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.verify.result == 'success') }}
     runs-on: windows-latest
     needs:
       - verify
@@ -160,6 +164,7 @@ jobs:
 
   build-desktop-darwin:
     name: Build desktop macOS
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.verify.result == 'success') }}
     runs-on: macos-latest
     needs:
       - verify
@@ -217,6 +222,7 @@ jobs:
 
   build-desktop-windows:
     name: Build desktop Windows
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.verify.result == 'success') }}
     runs-on: windows-latest
     needs:
       - verify
@@ -259,6 +265,7 @@ jobs:
 
   build-desktop-linux-amd64:
     name: Build desktop Linux amd64
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.verify.result == 'success') }}
     runs-on: ubuntu-latest
     needs:
       - verify
@@ -279,7 +286,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgl1-mesa-dev libx11-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxxf86vm-dev libglfw3-dev libpulse-dev patchelf squashfs-tools desktop-file-utils
+          sudo apt-get install -y imagemagick libgl1-mesa-dev libx11-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxxf86vm-dev libglfw3-dev libpulse-dev patchelf squashfs-tools desktop-file-utils
       - name: Capture build date
         shell: bash
         run: echo "GGCODE_DATE=$(git show -s --format=%cI "${GITHUB_SHA}")" >> "${GITHUB_ENV}"
@@ -296,6 +303,7 @@ jobs:
 
   build-desktop-linux-arm64:
     name: Build desktop Linux arm64
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.verify.result == 'success') }}
     runs-on: ubuntu-24.04-arm
     needs:
       - verify
@@ -317,7 +325,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgl1-mesa-dev libx11-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxxf86vm-dev libglfw3-dev libpulse-dev patchelf squashfs-tools desktop-file-utils
+          sudo apt-get install -y imagemagick libgl1-mesa-dev libx11-dev libxrandr-dev libxcursor-dev libxi-dev libxinerama-dev libxxf86vm-dev libglfw3-dev libpulse-dev patchelf squashfs-tools desktop-file-utils
       - name: Capture build date
         shell: bash
         run: echo "GGCODE_DATE=$(git show -s --format=%cI "${GITHUB_SHA}")" >> "${GITHUB_ENV}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,8 +47,8 @@ nfpms:
     package_name: ggcode
     file_name_template: "{{ .ConventionalFileName }}"
     homepage: https://github.com/topcheer/ggcode
-    vendor: topcheer
-    maintainer: topcheer
+    vendor: GG AI Studio
+    maintainer: GG AI Studio
     description: >-
       AI coding agent for the terminal with a polished TUI, resumable sessions,
       MCP integrations, built-in tools, and self-update support.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ pip install ggcode
 The Python wrapper also downloads the latest ggcode GitHub Release by default and respects
 `GGCODE_INSTALL_VERSION` for explicit pinning.
 
+### winget
+
+```powershell
+winget install --id gg.ai.ggcode-desktop
+```
+
+The winget package tracks the desktop Windows installer. The release workflow can auto-submit
+updates after the initial package bootstrap once `WINGET_CREATE_GITHUB_TOKEN` is configured.
+
 ### Release archives and installer packages
 
 Each tagged release publishes desktop archives plus native installer/package files:
@@ -104,10 +113,13 @@ Download the latest desktop release from [GitHub Releases](https://github.com/to
 | Platform | Asset |
 | --- | --- |
 | macOS (Universal) | `ggcode-desktop_<version>_darwin_universal.dmg` |
-| Linux | `ggcode-desktop_<version>_linux_amd64` |
-| Windows | `ggcode-desktop_<version>_windows_amd64.exe` |
+| Linux (x86_64) | `ggcode-desktop_<version>_linux_amd64`, `.AppImage`, `.deb`, `.rpm` |
+| Linux (arm64) | `ggcode-desktop_<version>_linux_arm64`, `.AppImage`, `.deb`, `.rpm` |
+| Windows (x64) | `ggcode-desktop_<version>_windows_amd64.exe`, `ggcode-desktop_<version>_windows_x64.msi` |
 
-Open the DMG on macOS and drag **ggcode** to your Applications folder. On Windows, run the `.exe` directly.
+Open the DMG on macOS and drag **ggcode** to your Applications folder. On Windows, either run the
+portable `.exe` directly or install the `.msi`. On Linux, choose the raw binary, AppImage, or
+native package that best matches your distribution.
 
 ### Mobile App (Beta)
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -56,6 +56,15 @@ pip install ggcode
 
 Python 包装器同样默认下载最新的 ggcode GitHub Release，也支持 `GGCODE_INSTALL_VERSION` 指定版本。
 
+### winget
+
+```powershell
+winget install --id gg.ai.ggcode-desktop
+```
+
+winget 包跟踪 Windows 桌面安装器。配置 `WINGET_CREATE_GITHUB_TOKEN` 后，release workflow 会在首次
+bootstrap 之后自动提交后续更新。
+
 ### Release 压缩包和安装包
 
 每个 tagged release 都会发布桌面压缩包和原生安装包：
@@ -73,6 +82,28 @@ Python 包装器同样默认下载最新的 ggcode GitHub Release，也支持 `G
 桌面版 release 还包含压缩包文件（Unix 平台为 `.tar.gz`，Windows 为 `.zip`），适合手动解压。
 
 如果你不想使用包管理器安装，也可以使用 release 压缩包、Go 安装器、npm 包装器或 Python 包装器。
+
+### Desktop Application（GUI）
+
+ggcode 也提供原生桌面应用，使用 [Fyne](https://fyne.io/) 构建。除 CLI 能力外，还包含：
+
+- 图形化聊天界面，支持 Markdown 渲染（GFM 表格、Mermaid 图）
+- 工作区文件浏览、搜索、过滤和文件预览
+- IM 平台集成面板（微信、飞书、钉钉等）
+- 工具审批弹窗与权限模式切换
+- Session 历史侧边栏、恢复支持、图片附件和更新检查
+
+从 [GitHub Releases](https://github.com/topcheer/ggcode/releases) 下载最新桌面版：
+
+| 平台 | 文件 |
+| --- | --- |
+| macOS（Universal） | `ggcode-desktop_<version>_darwin_universal.dmg` |
+| Linux（x86_64） | `ggcode-desktop_<version>_linux_amd64`、`.AppImage`、`.deb`、`.rpm` |
+| Linux（arm64） | `ggcode-desktop_<version>_linux_arm64`、`.AppImage`、`.deb`、`.rpm` |
+| Windows（x64） | `ggcode-desktop_<version>_windows_amd64.exe`、`ggcode-desktop_<version>_windows_x64.msi` |
+
+macOS 打开 DMG 后把 **ggcode** 拖到 Applications。Windows 可以直接运行便携 `.exe`，也可以安装 `.msi`。
+Linux 可以按发行版选择裸二进制、AppImage 或原生包。
 
 ### 移动端 App（Beta）
 

--- a/scripts/release/build-desktop-linux.sh
+++ b/scripts/release/build-desktop-linux.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build ggcode-desktop for Linux (amd64)
+# Build ggcode-desktop for Linux, plus AppImage, .deb, and .rpm release assets.
 set -euo pipefail
 
 VERSION="${1:?usage: build-desktop-linux.sh <version> <output-dir>}"
@@ -7,6 +7,7 @@ OUTPUT_DIR="${2:?usage: build-desktop-linux.sh <version> <output-dir>}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DESKTOP_DIR="${ROOT_DIR}/desktop/ggcode-desktop"
+PACKAGING_DIR="${ROOT_DIR}/.github/packaging/linux"
 PACKAGE_VERSION="${VERSION#v}"
 COMMIT="${GGCODE_COMMIT:-}"
 BUILD_DATE="${GGCODE_DATE:-}"
@@ -16,6 +17,155 @@ mkdir -p "${OUTPUT_DIR}"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "${WORK_DIR}"' EXIT
 
+detect_arch() {
+  case "${TARGET_ARCH:-$(uname -m)}" in
+    x86_64|amd64)
+      GOARCH_VALUE="amd64"
+      PACKAGE_ARCH="amd64"
+      APPIMAGE_ARCH="x86_64"
+      ;;
+    aarch64|arm64)
+      GOARCH_VALUE="arm64"
+      PACKAGE_ARCH="arm64"
+      APPIMAGE_ARCH="aarch64"
+      ;;
+    *)
+      echo "unsupported target arch: ${TARGET_ARCH:-$(uname -m)}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+ensure_nfpm() {
+  if command -v nfpm >/dev/null 2>&1; then
+    NFPM_BIN="$(command -v nfpm)"
+    return
+  fi
+  echo "nfpm not found in PATH; installing it into a temp tool dir"
+  mkdir -p "${WORK_DIR}/bin"
+  GOBIN="${WORK_DIR}/bin" go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+  NFPM_BIN="${WORK_DIR}/bin/nfpm"
+}
+
+download_appimage_tool() {
+  local name="$1"
+  local url="$2"
+  local dest="${WORK_DIR}/tools/${name}"
+  mkdir -p "${WORK_DIR}/tools"
+  if [[ ! -x "${dest}" ]]; then
+    curl -fsSL "${url}" -o "${dest}"
+    chmod +x "${dest}"
+  fi
+  printf '%s\n' "${dest}"
+}
+
+build_desktop_binary() {
+  local output="$1"
+  pushd "${DESKTOP_DIR}" >/dev/null
+  CGO_ENABLED=1 GOOS=linux GOARCH="${GOARCH_VALUE}" \
+    go build -tags goolm -ldflags "${LDFLAGS[*]}" -o "${output}" .
+  popd >/dev/null
+}
+
+build_linux_packages() {
+  local binary="$1"
+  local config_path="${WORK_DIR}/ggcode-desktop.nfpm.yaml"
+
+  cat > "${config_path}" <<EOF
+name: ggcode-desktop
+arch: ${PACKAGE_ARCH}
+platform: linux
+version: ${PACKAGE_VERSION}
+section: utils
+priority: optional
+maintainer: GG AI Studio
+vendor: GG AI Studio
+homepage: https://github.com/topcheer/ggcode
+description: >-
+  GGCode desktop application with graphical chat, resumable sessions,
+  MCP integrations, and built-in coding workflows.
+license: MIT
+contents:
+  - src: ${binary}
+    dst: /usr/bin/ggcode-desktop
+    file_info:
+      mode: 0755
+  - src: ${PACKAGING_DIR}/ggcode-desktop.desktop
+    dst: /usr/share/applications/ggcode-desktop.desktop
+  - src: ${DESKTOP_DIR}/icon.png
+    dst: /usr/share/icons/hicolor/512x512/apps/ggcode-desktop.png
+  - src: ${PACKAGING_DIR}/gg.ai.ggcode-desktop.metainfo.xml
+    dst: /usr/share/metainfo/gg.ai.ggcode-desktop.metainfo.xml
+  - src: ${ROOT_DIR}/LICENSE
+    dst: /usr/share/doc/ggcode-desktop/LICENSE
+  - src: ${ROOT_DIR}/README.md
+    dst: /usr/share/doc/ggcode-desktop/README.md
+EOF
+
+  "${NFPM_BIN}" package \
+    --packager deb \
+    --config "${config_path}" \
+    --target "${OUTPUT_DIR}/ggcode-desktop_${PACKAGE_VERSION}_linux_${PACKAGE_ARCH}.deb"
+
+  "${NFPM_BIN}" package \
+    --packager rpm \
+    --config "${config_path}" \
+    --target "${OUTPUT_DIR}/ggcode-desktop_${PACKAGE_VERSION}_linux_${PACKAGE_ARCH}.rpm"
+}
+
+build_appimage() {
+  local binary="$1"
+  local appdir="${WORK_DIR}/AppDir"
+  local linuxdeploy_bin="$2"
+  local appimagetool_bin="$3"
+  local desktop_entry="${PACKAGING_DIR}/ggcode-desktop.desktop"
+  local icon_path="${DESKTOP_DIR}/icon.png"
+
+  rm -rf "${appdir}"
+  mkdir -p \
+    "${appdir}/usr/bin" \
+    "${appdir}/usr/share/applications" \
+    "${appdir}/usr/share/icons/hicolor/512x512/apps" \
+    "${appdir}/usr/share/metainfo"
+
+  cp "${binary}" "${appdir}/usr/bin/ggcode-desktop"
+  cp "${desktop_entry}" "${appdir}/usr/share/applications/ggcode-desktop.desktop"
+  cp "${icon_path}" "${appdir}/usr/share/icons/hicolor/512x512/apps/ggcode-desktop.png"
+  cp "${PACKAGING_DIR}/gg.ai.ggcode-desktop.metainfo.xml" \
+    "${appdir}/usr/share/metainfo/gg.ai.ggcode-desktop.metainfo.xml"
+
+  mkdir -p "${WORK_DIR}/tool-path"
+  ln -sf "${appimagetool_bin}" "${WORK_DIR}/tool-path/appimagetool"
+
+  (
+    cd "${WORK_DIR}"
+    PATH="${WORK_DIR}/tool-path:${PATH}" \
+    APPIMAGE_EXTRACT_AND_RUN=1 \
+    ARCH="${APPIMAGE_ARCH}" \
+      "${linuxdeploy_bin}" \
+        --appdir "${appdir}" \
+        -e "${binary}" \
+        -d "${desktop_entry}" \
+        -i "${icon_path}" \
+        --output appimage
+  )
+
+  local generated
+  generated="$(find "${WORK_DIR}" -maxdepth 1 -type f -name '*.AppImage' | head -n 1)"
+  if [[ -z "${generated}" ]]; then
+    echo "linuxdeploy did not generate an AppImage" >&2
+    exit 1
+  fi
+
+  cp "${generated}" "${OUTPUT_DIR}/ggcode-desktop_${PACKAGE_VERSION}_linux_${PACKAGE_ARCH}.AppImage"
+}
+
+detect_arch
+ensure_nfpm
+
+LINUXDEPLOY_BIN="$(download_appimage_tool "linuxdeploy" "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${APPIMAGE_ARCH}.AppImage")"
+APPIMAGETOOL_BIN="$(download_appimage_tool "appimagetool" "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${APPIMAGE_ARCH}.AppImage")"
+
 LDFLAGS=(
   -s -w
   "-X" "github.com/topcheer/ggcode/internal/version.Version=${VERSION}"
@@ -24,14 +174,14 @@ LDFLAGS=(
   "-X" "main.Version=${VERSION}"
 )
 
-echo "=== Building ggcode-desktop for Linux (amd64) ==="
+echo "=== Building ggcode-desktop for Linux (${PACKAGE_ARCH}) ==="
 
-pushd "${DESKTOP_DIR}" >/dev/null
-CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
-  go build -tags goolm -ldflags "${LDFLAGS[*]}" -o "${WORK_DIR}/ggcode-desktop" .
-popd >/dev/null
+RAW_BINARY="${WORK_DIR}/ggcode-desktop"
+build_desktop_binary "${RAW_BINARY}"
+chmod 0755 "${RAW_BINARY}"
 
-chmod 0755 "${WORK_DIR}/ggcode-desktop"
-cp "${WORK_DIR}/ggcode-desktop" "${OUTPUT_DIR}/ggcode-desktop_${PACKAGE_VERSION}_linux_amd64"
+cp "${RAW_BINARY}" "${OUTPUT_DIR}/ggcode-desktop_${PACKAGE_VERSION}_linux_${PACKAGE_ARCH}"
+build_linux_packages "${RAW_BINARY}"
+build_appimage "${RAW_BINARY}" "${LINUXDEPLOY_BIN}" "${APPIMAGETOOL_BIN}"
 
-echo "=== Done: ${OUTPUT_DIR}/ggcode-desktop_${PACKAGE_VERSION}_linux_amd64 ==="
+echo "=== Done: ${OUTPUT_DIR}/ggcode-desktop_${PACKAGE_VERSION}_linux_${PACKAGE_ARCH} (+ AppImage/.deb/.rpm) ==="

--- a/scripts/release/build-desktop-linux.sh
+++ b/scripts/release/build-desktop-linux.sh
@@ -16,6 +16,7 @@ mkdir -p "${OUTPUT_DIR}"
 
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "${WORK_DIR}"' EXIT
+ICON_PATH="${DESKTOP_DIR}/icon.png"
 
 detect_arch() {
   case "${TARGET_ARCH:-$(uname -m)}" in
@@ -67,8 +68,20 @@ build_desktop_binary() {
   popd >/dev/null
 }
 
+prepare_linux_icon() {
+  local icon_output="${WORK_DIR}/ggcode-desktop-512.png"
+  if [[ ! -f "${ICON_PATH}" ]]; then
+    echo "desktop icon not found: ${ICON_PATH}" >&2
+    exit 1
+  fi
+
+  convert "${ICON_PATH}" -resize 512x512 "${icon_output}"
+  printf '%s\n' "${icon_output}"
+}
+
 build_linux_packages() {
   local binary="$1"
+  local icon_file="$2"
   local config_path="${WORK_DIR}/ggcode-desktop.nfpm.yaml"
 
   cat > "${config_path}" <<EOF
@@ -92,7 +105,7 @@ contents:
       mode: 0755
   - src: ${PACKAGING_DIR}/ggcode-desktop.desktop
     dst: /usr/share/applications/ggcode-desktop.desktop
-  - src: ${DESKTOP_DIR}/icon.png
+  - src: ${icon_file}
     dst: /usr/share/icons/hicolor/512x512/apps/ggcode-desktop.png
   - src: ${PACKAGING_DIR}/gg.ai.ggcode-desktop.metainfo.xml
     dst: /usr/share/metainfo/gg.ai.ggcode-desktop.metainfo.xml
@@ -115,11 +128,11 @@ EOF
 
 build_appimage() {
   local binary="$1"
+  local icon_path="$2"
   local appdir="${WORK_DIR}/AppDir"
-  local linuxdeploy_bin="$2"
-  local appimagetool_bin="$3"
+  local linuxdeploy_bin="$3"
+  local appimagetool_bin="$4"
   local desktop_entry="${PACKAGING_DIR}/ggcode-desktop.desktop"
-  local icon_path="${DESKTOP_DIR}/icon.png"
 
   rm -rf "${appdir}"
   mkdir -p \
@@ -177,11 +190,12 @@ LDFLAGS=(
 echo "=== Building ggcode-desktop for Linux (${PACKAGE_ARCH}) ==="
 
 RAW_BINARY="${WORK_DIR}/ggcode-desktop"
+PACKAGED_ICON="$(prepare_linux_icon)"
 build_desktop_binary "${RAW_BINARY}"
 chmod 0755 "${RAW_BINARY}"
 
 cp "${RAW_BINARY}" "${OUTPUT_DIR}/ggcode-desktop_${PACKAGE_VERSION}_linux_${PACKAGE_ARCH}"
-build_linux_packages "${RAW_BINARY}"
-build_appimage "${RAW_BINARY}" "${LINUXDEPLOY_BIN}" "${APPIMAGETOOL_BIN}"
+build_linux_packages "${RAW_BINARY}" "${PACKAGED_ICON}"
+build_appimage "${RAW_BINARY}" "${PACKAGED_ICON}" "${LINUXDEPLOY_BIN}" "${APPIMAGETOOL_BIN}"
 
 echo "=== Done: ${OUTPUT_DIR}/ggcode-desktop_${PACKAGE_VERSION}_linux_${PACKAGE_ARCH} (+ AppImage/.deb/.rpm) ==="

--- a/scripts/release/build-desktop-windows.ps1
+++ b/scripts/release/build-desktop-windows.ps1
@@ -1,4 +1,4 @@
-# Build ggcode-desktop for Windows (amd64)
+# Build ggcode-desktop for Windows (amd64) and a matching MSI installer.
 param(
   [Parameter(Mandatory=$true)]
   [string]$Version,
@@ -10,9 +10,11 @@ $ErrorActionPreference = "Stop"
 
 $RootDir = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $DesktopDir = Join-Path $RootDir "desktop\ggcode-desktop"
+$WxsPath = Join-Path $RootDir ".github\packaging\windows\ggcode-desktop.wxs"
 $PackageVersion = $Version -replace '^v',''
 $Commit = if ($env:GGCODE_COMMIT) { $env:GGCODE_COMMIT } else { "" }
 $BuildDate = if ($env:GGCODE_DATE) { $env:GGCODE_DATE } else { "" }
+$UpgradeCode = "{CB2D6759-52A6-4C5E-8D56-FF21F3E3CE9D}"
 
 # Resolve OutputDir to absolute path
 $AbsOutputDir = if ([System.IO.Path]::IsPathRooted($OutputDir)) { $OutputDir } else { Join-Path $pwd $OutputDir }
@@ -29,13 +31,41 @@ $Ldflags = @(
 Write-Host "=== Building ggcode-desktop for Windows (amd64) ==="
 Write-Host "Output: $AbsOutputDir"
 
+if (-not (Test-Path $WxsPath)) {
+  throw "missing WiX source at $WxsPath"
+}
+
+$stageDir = Join-Path $AbsOutputDir "ggcode-desktop-msi-stage"
+Remove-Item -Recurse -Force $stageDir -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
+
 Push-Location $DesktopDir
   $env:CGO_ENABLED = "1"
   $env:GOOS = "windows"
   $env:GOARCH = "amd64"
   $outFile = Join-Path $AbsOutputDir "ggcode-desktop_${PackageVersion}_windows_amd64.exe"
   go build -tags goolm -ldflags $Ldflags -o $outFile .
+  if ($LASTEXITCODE -ne 0) {
+    throw "go build failed for desktop windows binary"
+  }
   Write-Host "Built: $outFile"
 Pop-Location
+
+Copy-Item $outFile (Join-Path $stageDir "ggcode-desktop.exe")
+
+$msiTarget = Join-Path $AbsOutputDir "ggcode-desktop_${PackageVersion}_windows_x64.msi"
+& wix build `
+  -d "Version=$PackageVersion" `
+  -d "UpgradeCode=$UpgradeCode" `
+  -d "SourceDir=$stageDir" `
+  -arch x64 `
+  -o $msiTarget `
+  $WxsPath
+if ($LASTEXITCODE -ne 0) {
+  throw "wix build failed for desktop windows installer"
+}
+Write-Host "Built: $msiTarget"
+
+Remove-Item -Recurse -Force $stageDir
 
 Write-Host "=== Done ==="

--- a/scripts/release/publish-site-branch.sh
+++ b/scripts/release/publish-site-branch.sh
@@ -81,7 +81,7 @@ include_release_asset() {
   local name
   name="$(basename "$1")"
   case "${name}" in
-    checksums.txt|*.tar.gz|*.zip|*.deb|*.rpm|*.apk|*.ipk|*.pkg.tar.zst|*.pkg|*.msi|*.dmg|*.exe)
+    checksums.txt|*.tar.gz|*.zip|*.deb|*.rpm|*.apk|*.ipk|*.pkg.tar.zst|*.pkg|*.msi|*.dmg|*.exe|*.AppImage)
       return 0
       ;;
   esac

--- a/scripts/release/publish-winget.ps1
+++ b/scripts/release/publish-winget.ps1
@@ -1,0 +1,34 @@
+param(
+    [Parameter(Mandatory = $true)][string]$PackageId,
+    [Parameter(Mandatory = $true)][string]$Version,
+    [Parameter(Mandatory = $true)][string]$InstallerUrl,
+    [Parameter(Mandatory = $true)][string]$GitHubToken
+)
+
+$ErrorActionPreference = "Stop"
+
+$releaseVersion = $Version.TrimStart("v")
+$wingetCreate = Join-Path $PWD "wingetcreate.exe"
+
+Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile $wingetCreate
+
+$env:WINGET_CREATE_GITHUB_TOKEN = $GitHubToken
+
+& $wingetCreate show $PackageId | Out-Null
+$packageExists = $LASTEXITCODE -eq 0
+
+if (-not $packageExists) {
+    Write-Warning "Package '$PackageId' does not exist in winget-pkgs yet. Skipping automated submission until the first manifest is bootstrapped manually."
+    exit 0
+}
+
+& $wingetCreate update $PackageId `
+    --version $releaseVersion `
+    --urls "$InstallerUrl|x64" `
+    --submit `
+    --token $GitHubToken `
+    --no-open
+
+if ($LASTEXITCODE -ne 0) {
+    throw "wingetcreate update failed for $PackageId"
+}


### PR DESCRIPTION
## Summary
- add desktop MSI packaging plus Linux AppImage/DEB/RPM outputs for amd64 and arm64
- update release workflow so manual packaging runs can proceed without unrelated verify failures
- add winget publish helper and document the new desktop install surfaces

## Validation
- successful packaging run: `26485314475`
- verified artifacts: desktop Windows exe/msi, CLI x64/arm64 msi, desktop Linux raw/AppImage/deb/rpm for amd64 and arm64
- public `v1.3.40` release now includes desktop MSI and rebuilt CLI MSI assets
- winget bootstrap PRs: microsoft/winget-pkgs#380077 and #380078

## Notes
- `workflow_dispatch` intentionally skips `verify`; tagged releases still require verify success
- Linux packaging resizes the app icon to 512x512 during build to satisfy linuxdeploy/AppImage constraints