### PR TITLE
fix(swarm): DeleteTeam re-entrant lock deadlock (unblocks red main CI)

### DIFF
--- a/internal/swarm/manager.go
+++ b/internal/swarm/manager.go
@@ -200,7 +200,11 @@ func (m *Manager) DeleteTeam(teamID string) error {
 		if tm.cancel != nil {
 			tm.cancel()
 		}
-		tm.setStatus(TeammateShuttingDown)
+		// Set status DIRECTLY: the caller already holds tm.mu, and
+		// setStatus re-locks it - a same-goroutine re-entrant lock on a
+		// Go mutex DEADLOCKS (the 931913ff CI hang: DeleteTeam -> setStatus
+		// -> t.mu.Lock under the already-held tm.mu).
+		tm.Status = TeammateShuttingDown
 		if tm.done != nil {
 			doneChs = append(doneChs, tm.done)
 		}


### PR DESCRIPTION
## Root cause
`Manager.DeleteTeam` acquires `tm.mu` (manager.go L203) and then calls `tm.setStatus()`, which re-locks the **same mutex on the same goroutine**. Go mutexes are not re-entrant → deadlock whenever a teammate's own shutdown defer reaches DeleteTeam before the test's defer (timing-dependent, hence the bisect initially pointed elsewhere).

## Evidence
- 931913ff CI: `TestSendMessageToTeammateClarifiesUntrackedWork` hangs (4m36s → 5m timeout), goroutine dump: `DeleteTeam → setStatus → t.mu.Lock` under held `tm.mu`
- Pre-existing (bisected against 18760789/0649dfa4; swarm untouched in between — pure timing surface)
- Isolated-worktree verification (shared tree carries another agent's broken in-flight files): the hung test ×3 PASS; swarm + tool packages full PASS (115s)

## Fix
Set `TeammateShuttingDown` directly under the already-held lock instead of calling the re-locking setter. 4→8 lines incl. comment.

This PR also un-greens→greens main: 931913ff (#1728/#1686) is currently red on this deadlock alone.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)