### PR TITLE
fix(agent): read-path recorder isolates url/directory/source keys; failed tools never record reads (#1619 case C)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4179,25 +4179,32 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 				// target). Legal back-references WITHOUT intervening edits
 				// keep the exemption.
 				a.phantomVerify.invalidateEdits()
-			} else if readPaths := extractFilePathsFromArgs(tc.Arguments, tc.Name); len(readPaths) > 0 {
-				// #500: batch-aware — multi_file_read carries N paths but the
-				// old single-path extraction recorded only files[0], suppressing
-				// the cross-file stale-read warning (minReadsBeforeWarning) and
-				// starving expired-read/futile-cycle for the same reason.
-				for _, p := range readPaths {
-					a.futileCycle.recordRead(p)
-					// Expired-read: track reads for self-invalidation detection.
-					a.expiredRead.recordRead(p)
-					a.wtInvalidation.recordRead(p)
+			} else if !result.IsError {
+				// #1619-C: failed tools never touched the files they named -
+				// a failed edit recorded its target as READ, so the legitimate
+				// recovery re-read (edit_fail_recovery's own advice) inflated
+				// the futile/expired signals - the read-side mirror of the
+				// #953 write-side fix above.
+				if readPaths := extractFilePathsFromArgs(tc.Arguments, tc.Name); len(readPaths) > 0 {
+					// #500: batch-aware — multi_file_read carries N paths but the
+					// old single-path extraction recorded only files[0], suppressing
+					// the cross-file stale-read warning (minReadsBeforeWarning) and
+					// starving expired-read/futile-cycle for the same reason.
+					for _, p := range readPaths {
+						a.futileCycle.recordRead(p)
+						// Expired-read: track reads for self-invalidation detection.
+						a.expiredRead.recordRead(p)
+						a.wtInvalidation.recordRead(p)
+					}
+					// Post-edit re-read check: warn if re-reading shortly after edit.
+					// First path only — each hint appends, N hints would spam.
+					if hint := a.expiredRead.checkPostEditReread(readPaths[0]); hint != "" {
+						a.appendGuidance(&result, hint)
+					}
+					// Search-result invalidation: record search-type tool results
+					// for later invalidation detection on file edits.
+					a.searchInvalidation.recordSearchResult(tc.Name, result.Content)
 				}
-				// Post-edit re-read check: warn if re-reading shortly after edit.
-				// First path only — each hint appends, N hints would spam.
-				if hint := a.expiredRead.checkPostEditReread(readPaths[0]); hint != "" {
-					a.appendGuidance(&result, hint)
-				}
-				// Search-result invalidation: record search-type tool results
-				// for later invalidation detection on file edits.
-				a.searchInvalidation.recordSearchResult(tc.Name, result.Content)
 			}
 			// Working-tree invalidation: detect cross-file stale reads after git mutations
 			if isWTMutatingTool(tc.Name) && !result.IsError {

--- a/internal/agent/path_extract_helpers.go
+++ b/internal/agent/path_extract_helpers.go
@@ -12,12 +12,19 @@ import (
 // and wt_invalidation_check.go.
 
 // extractFilePathsFromArgs extracts file paths from tool call arguments.
+// #1619-C: url/directory/source removed from the key set - the read-path
+// recorder consumed them, so web_fetch/browser URLs entered the file-read
+// set (wt_invalidation printed "stale file(s): https://..." and expiredRead
+// warned about "re-reading" a URL) and grep's directory argument inflated
+// the set. This is the mirror of the #953 write-side isolation;
+// verify_hint's own comment already admitted this function "would admit
+// url/directory noise".
 func extractFilePathsFromArgs(args json.RawMessage, _ string) []string {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(args, &raw); err != nil {
 		return nil
 	}
-	paths := extractStringKeys(raw, "path", "file_path", "file", "directory", "source", "notebook_path", "url")
+	paths := extractStringKeys(raw, "path", "file_path", "file", "notebook_path")
 	paths = append(paths, extractArrayPaths(raw)...)
 	return dedupPaths(paths)
 }

--- a/internal/agent/path_extract_helpers_test.go
+++ b/internal/agent/path_extract_helpers_test.go
@@ -1,0 +1,14 @@
+package agent
+
+import "testing"
+
+// #1619-C: the read-path extractor must not admit url/directory/source
+// keys - URLs entered the file-read set and grep's directory argument
+// inflated it (mirror of the #953 write-side isolation).
+func TestExtractFilePathsFromArgsExcludesURLAndDirectory(t *testing.T) {
+	args := []byte(`{"url":"https://example.com/x","directory":"/tmp/scan","source":"inline content","path":"/a.go"}`)
+	got := extractFilePathsFromArgs(args, "web_fetch")
+	if len(got) != 1 || got[0] != "/a.go" {
+		t.Fatalf("expected only /a.go, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
Closes case C of #1619 (cases A and B landed in-flight earlier — anchored empty-result patterns, init method Recv guard — both confirmed in place).

The read-path recorder is the mirror of the #953 write-side isolation:
- `extractFilePathsFromArgs` drops the `url`/`directory`/`source` keys — URLs from web_fetch/browser entered the file-read set (wt_invalidation printed `stale file(s): https://...`, expiredRead warned about "re-reading" a URL); grep directory arguments inflated the set.
- The read-recording branch is gated on `!result.IsError` — a failed edit recorded its target as READ, so the recovery re-read that edit_fail_recovery itself advises inflated the futile/expired signals.

## Verification evidence (review)
- Isolated clean worktree at HEAD + this diff (main tree carries unrelated in-flight conflict markers in hooks/extract/write_file from another agent — this PR's files are not among them):
  - `go test -tags goolm -count=1 ./internal/agent/` → **ok 24.464s**
  - Pin `TestExtractFilePathsFromArgsExcludesURLAndDirectory` → **PASS** (url+directory+source args yield only the real `path`)

Closes #1619 (case C; A/B already on main)

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)
