### PR TITLE
fix(tool): iterm2 threads Execute ctx to every AppleScript call (#1894)

### DIFF
--- a/internal/tool/iterm2.go
+++ b/internal/tool/iterm2.go
@@ -140,7 +140,7 @@ func (t *Iterm2Tool) Execute(ctx context.Context, input json.RawMessage) (Result
 
 	// Status doesn't require iTerm2 to be running — it reports detection.
 	if action == "status" {
-		return t.executeStatus(), nil
+		return t.executeStatus(ctx), nil
 	}
 
 	if !iterm2Available() {
@@ -149,43 +149,43 @@ func (t *Iterm2Tool) Execute(ctx context.Context, input json.RawMessage) (Result
 
 	switch action {
 	case "list":
-		return t.executeList(), nil
+		return t.executeList(ctx, ), nil
 	case "split":
-		return t.executeSplit(args.SessionID, args.Direction, args.Size, args.Command, args.WorkingDir), nil
+		return t.executeSplit(ctx, args.SessionID, args.Direction, args.Size, args.Command, args.WorkingDir), nil
 	case "new_tab":
-		return t.executeNewTab(args.Command, args.WorkingDir), nil
+		return t.executeNewTab(ctx, args.Command, args.WorkingDir), nil
 	case "new_window":
-		return t.executeNewWindow(args.Command, args.WorkingDir), nil
+		return t.executeNewWindow(ctx, args.Command, args.WorkingDir), nil
 	case "focus":
-		return t.executeFocus(args.SessionID), nil
+		return t.executeFocus(ctx, args.SessionID), nil
 	case "close":
-		return t.executeClose(args.SessionID), nil
+		return t.executeClose(ctx, args.SessionID), nil
 	case "select_tab":
-		return t.executeSelectTab(args.TabIndex), nil
+		return t.executeSelectTab(ctx, args.TabIndex), nil
 	case "input":
-		return t.executeInput(args.SessionID, args.Text), nil
+		return t.executeInput(ctx, args.SessionID, args.Text), nil
 	case "send_key":
-		return t.executeSendKey(args.SessionID, args.Key, args.Modifiers), nil
+		return t.executeSendKey(ctx, args.SessionID, args.Key, args.Modifiers), nil
 	case "resize":
-		return t.executeResize(args.SessionID, args.Axis, args.Increment), nil
+		return t.executeResize(ctx, args.SessionID, args.Axis, args.Increment), nil
 	case "get_text":
-		return t.executeGetText(args.SessionID), nil
+		return t.executeGetText(ctx, args.SessionID), nil
 	case "set_title":
-		return t.executeSetTitle(args.SessionID, args.Text), nil
+		return t.executeSetTitle(ctx, args.SessionID, args.Text), nil
 	case "profile":
-		return t.executeProfile(args.SessionID, args.Text), nil
+		return t.executeProfile(ctx, args.SessionID, args.Text), nil
 	case "badge":
-		return t.executeBadge(args.SessionID, args.Text), nil
+		return t.executeBadge(ctx, args.SessionID, args.Text), nil
 	case "broadcast":
-		return t.executeBroadcast(args.Text), nil
+		return t.executeBroadcast(ctx, args.Text), nil
 	case "mark":
-		return t.executeMark(args.Text), nil
+		return t.executeMark(ctx, args.Text), nil
 	case "clear":
-		return t.executeClear(args.SessionID), nil
+		return t.executeClear(ctx, args.SessionID), nil
 	case "action":
-		return t.executeMenuAction(args.Text), nil
+		return t.executeMenuAction(ctx, args.Text), nil
 	case "reload_config":
-		return t.executeReloadConfig(), nil
+		return t.executeReloadConfig(ctx), nil
 	default:
 		return Result{IsError: true, Content: fmt.Sprintf("unsupported iterm2 action %q", args.Action)}, nil
 	}

--- a/internal/tool/iterm2_darwin.go
+++ b/internal/tool/iterm2_darwin.go
@@ -37,7 +37,7 @@ func iterm2SessionSpecifier(sessionID string) string {
 // iterm2SessionLookup returns AppleScript traversal code that finds a session by ID.
 // Returns empty string for current session (no lookup needed).
 // The found session is stored in variable "theSession".
-func iterm2SessionLookup(sessionID string) string {
+func iterm2SessionLookup(ctx context.Context, sessionID string) string {
 	if sessionID == "" {
 		return ""
 	}
@@ -62,9 +62,9 @@ func iterm2SessionLookup(sessionID string) string {
 // iterm2WriteText writes text to a session using iTerm2's native AppleScript.
 // Unlike Warp/Ghostty, iTerm2 has a native "write text" command that types
 // directly into the target session without needing System Events.
-func iterm2WriteText(sessionID, text string) error {
+func iterm2WriteText(ctx context.Context, sessionID, text string) error {
 	spec := iterm2SessionSpecifier(sessionID)
-	lookup := iterm2SessionLookup(sessionID)
+	lookup := iterm2SessionLookup(ctx, sessionID)
 	script := fmt.Sprintf(`
 tell application "iTerm"
 	activate%s
@@ -72,13 +72,13 @@ tell application "iTerm"
 		write text "%s"
 	end tell
 end tell`, lookup, spec, escapeAS(text))
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	return err
 }
 
 // ── Action implementations (macOS) ───────────────────────────────────────────
 
-func (t *Iterm2Tool) executeStatus() Result {
+func (t *Iterm2Tool) executeStatus(ctx context.Context) Result {
 	if !iterm2Available() {
 		return Result{Content: "iterm2: not detected (TERM_PROGRAM != iTerm.app)"}
 	}
@@ -88,38 +88,38 @@ func (t *Iterm2Tool) executeStatus() Result {
 	b.WriteString(fmt.Sprintf("platform: %s/%s\n", runtime.GOOS, runtime.GOARCH))
 
 	// iTerm2 version
-	if v, err := runAppleScript(context.Background(), `tell application "iTerm" to get version`); err == nil {
+	if v, err := runAppleScript(ctx, `tell application "iTerm" to get version`); err == nil {
 		b.WriteString(fmt.Sprintf("version: %s\n", v))
 	}
 
 	// App path
-	if p, err := runAppleScript(context.Background(), `tell application "iTerm" to get path to`); err == nil && p != "" {
+	if p, err := runAppleScript(ctx, `tell application "iTerm" to get path to`); err == nil && p != "" {
 		b.WriteString(fmt.Sprintf("app path: %s\n", p))
 	}
 
 	// Current session info
-	if name, err := runAppleScript(context.Background(), `tell application "iTerm" to get name of current session of current tab of front window`); err == nil {
+	if name, err := runAppleScript(ctx, `tell application "iTerm" to get name of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("current session name: %s\n", name))
 	}
-	if tty, err := runAppleScript(context.Background(), `tell application "iTerm" to get tty of current session of current tab of front window`); err == nil {
+	if tty, err := runAppleScript(ctx, `tell application "iTerm" to get tty of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("current session tty: %s\n", tty))
 	}
-	if cols, err := runAppleScript(context.Background(), `tell application "iTerm" to get columns of current session of current tab of front window`); err == nil {
+	if cols, err := runAppleScript(ctx, `tell application "iTerm" to get columns of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("columns: %s\n", cols))
 	}
-	if rows, err := runAppleScript(context.Background(), `tell application "iTerm" to get rows of current session of current tab of front window`); err == nil {
+	if rows, err := runAppleScript(ctx, `tell application "iTerm" to get rows of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("rows: %s\n", rows))
 	}
 
 	// Session ID (iTerm2 assigns a numeric ID to each session)
-	if sid, err := runAppleScript(context.Background(), `tell application "iTerm" to get id of current session of current tab of front window`); err == nil {
+	if sid, err := runAppleScript(ctx, `tell application "iTerm" to get id of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("current session ID: %s", sid))
 	}
 
 	return Result{Content: b.String()}
 }
 
-func (t *Iterm2Tool) executeList() Result {
+func (t *Iterm2Tool) executeList(ctx context.Context, ) Result {
 	script := `
 tell application "iTerm"
 	set output to ""
@@ -166,14 +166,14 @@ tell application "iTerm"
 	return output
 end tell`
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 list failed: %v", err)}
 	}
 	return Result{Content: out}
 }
 
-func (t *Iterm2Tool) executeSplit(sessionID, direction string, size int, command, workingDir string) Result {
+func (t *Iterm2Tool) executeSplit(ctx context.Context, sessionID, direction string, size int, command, workingDir string) Result {
 	dir := strings.ToLower(strings.TrimSpace(direction))
 	if dir == "" {
 		dir = "right"
@@ -213,7 +213,7 @@ func (t *Iterm2Tool) executeSplit(sessionID, direction string, size int, command
 	// Build the script
 	var script string
 	targetSpec := iterm2SessionSpecifier(sessionID)
-	lookup := iterm2SessionLookup(sessionID)
+	lookup := iterm2SessionLookup(ctx, sessionID)
 
 	if strings.TrimSpace(command) != "" {
 		script = fmt.Sprintf(`
@@ -241,7 +241,7 @@ tell application "iTerm"
 end tell`, lookup, targetSpec, splitCmd, escapeAS(escapeShellSingleQuote(wd)))
 	}
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 split failed: %v", err)}
 	}
@@ -258,7 +258,7 @@ end tell`, lookup, targetSpec, splitCmd, escapeAS(escapeShellSingleQuote(wd)))
 	return Result{Content: fmt.Sprintf("iterm2 split created: direction=%s, session_id=%s", dir, out)}
 }
 
-func (t *Iterm2Tool) executeNewTab(command, workingDir string) Result {
+func (t *Iterm2Tool) executeNewTab(ctx context.Context, command, workingDir string) Result {
 	wd := strings.TrimSpace(workingDir)
 	if wd == "" {
 		wd = t.workingDir()
@@ -288,7 +288,7 @@ tell application "iTerm"
 end tell`
 	}
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 new_tab failed: %v", err)}
 	}
@@ -296,7 +296,7 @@ end tell`
 	return Result{Content: fmt.Sprintf("iterm2 tab created: session_id=%s", out)}
 }
 
-func (t *Iterm2Tool) executeNewWindow(command, workingDir string) Result {
+func (t *Iterm2Tool) executeNewWindow(ctx context.Context, command, workingDir string) Result {
 	wd := strings.TrimSpace(workingDir)
 	if wd == "" {
 		wd = t.workingDir()
@@ -322,7 +322,7 @@ tell application "iTerm"
 end tell`
 	}
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 new_window failed: %v", err)}
 	}
@@ -330,9 +330,9 @@ end tell`
 	return Result{Content: fmt.Sprintf("iterm2 window created: session_id=%s", out)}
 }
 
-func (t *Iterm2Tool) executeFocus(sessionID string) Result {
+func (t *Iterm2Tool) executeFocus(ctx context.Context, sessionID string) Result {
 	spec := iterm2SessionSpecifier(sessionID)
-	lookup := iterm2SessionLookup(sessionID)
+	lookup := iterm2SessionLookup(ctx, sessionID)
 	script := fmt.Sprintf(`
 tell application "iTerm"
 	activate%s
@@ -340,7 +340,7 @@ tell application "iTerm"
 	return "focused"
 end tell`, lookup, spec)
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 focus failed: %v", err)}
 	}
@@ -352,9 +352,9 @@ end tell`, lookup, spec)
 	return Result{Content: fmt.Sprintf("iterm2 focused: %s", label)}
 }
 
-func (t *Iterm2Tool) executeClose(sessionID string) Result {
+func (t *Iterm2Tool) executeClose(ctx context.Context, sessionID string) Result {
 	spec := iterm2SessionSpecifier(sessionID)
-	lookup := iterm2SessionLookup(sessionID)
+	lookup := iterm2SessionLookup(ctx, sessionID)
 	script := fmt.Sprintf(`
 tell application "iTerm"
 %s
@@ -362,7 +362,7 @@ tell application "iTerm"
 	return "closed"
 end tell`, lookup, spec)
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 close failed: %v", err)}
 	}
@@ -374,7 +374,7 @@ end tell`, lookup, spec)
 	return Result{Content: fmt.Sprintf("iterm2 closed: %s", label)}
 }
 
-func (t *Iterm2Tool) executeSelectTab(tabIndex int) Result {
+func (t *Iterm2Tool) executeSelectTab(ctx context.Context, tabIndex int) Result {
 	if tabIndex < 1 {
 		return Result{IsError: true, Content: "tab_index must be >= 1 (1-based)"}
 	}
@@ -389,7 +389,7 @@ tell application "iTerm"
 	end tell
 end tell`, tabIndex)
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 select_tab failed: %v", err)}
 	}
@@ -397,12 +397,12 @@ end tell`, tabIndex)
 	return Result{Content: fmt.Sprintf("iterm2 selected tab: %d", tabIndex)}
 }
 
-func (t *Iterm2Tool) executeInput(sessionID, text string) Result {
+func (t *Iterm2Tool) executeInput(ctx context.Context, sessionID, text string) Result {
 	if strings.TrimSpace(text) == "" {
 		return Result{IsError: true, Content: "text is required for input action"}
 	}
 
-	err := iterm2WriteText(sessionID, text)
+	err := iterm2WriteText(ctx, sessionID, text)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 input failed: %v", err)}
 	}
@@ -418,7 +418,7 @@ func (t *Iterm2Tool) executeInput(sessionID, text string) Result {
 	return Result{Content: fmt.Sprintf("iterm2 input sent to %s: %s", label, preview)}
 }
 
-func (t *Iterm2Tool) executeSendKey(sessionID, key, modifiers string) Result {
+func (t *Iterm2Tool) executeSendKey(ctx context.Context, sessionID, key, modifiers string) Result {
 	if strings.TrimSpace(key) == "" {
 		return Result{IsError: true, Content: "key is required for send_key action"}
 	}
@@ -464,7 +464,7 @@ func (t *Iterm2Tool) executeSendKey(sessionID, key, modifiers string) Result {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 send_key: unknown key %q (supported: enter, escape, tab, space, backspace, arrow keys, home, end, pageup, pagedown, f1-f12, single characters)", key)}
 	}
 
-	if err := t.iterm2WriteToTTY(sessionID, data); err != nil {
+	if err := t.iterm2WriteToTTY(ctx, sessionID, data); err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 send_key failed: %v", err)}
 	}
 
@@ -479,7 +479,7 @@ func (t *Iterm2Tool) executeSendKey(sessionID, key, modifiers string) Result {
 	return Result{Content: fmt.Sprintf("iterm2 key sent to %s: %s", label, keyDesc)}
 }
 
-func (t *Iterm2Tool) executeResize(sessionID, axis string, increment int) Result {
+func (t *Iterm2Tool) executeResize(ctx context.Context, sessionID, axis string, increment int) Result {
 	if increment == 0 {
 		increment = 20
 	}
@@ -498,7 +498,7 @@ func (t *Iterm2Tool) executeResize(sessionID, axis string, increment int) Result
 
 	// Focus target session
 	if sessionID != "" {
-		t.executeFocus(sessionID)
+		t.executeFocus(ctx, sessionID)
 	} else {
 		exec.Command("osascript", "-e", `tell application "iTerm" to activate`).Run()
 	}
@@ -512,7 +512,7 @@ func (t *Iterm2Tool) executeResize(sessionID, axis string, increment int) Result
 	// Use iTerm2's native AppleScript to adjust columns/rows directly.
 	// This avoids the need for Accessibility/System Events permissions.
 	spec := iterm2SessionSpecifier(sessionID)
-	lookup := iterm2SessionLookup(sessionID)
+	lookup := iterm2SessionLookup(ctx, sessionID)
 	var script string
 	if ax == "horizontal" {
 		script = fmt.Sprintf(`
@@ -534,7 +534,7 @@ tell application "iTerm"
 end tell`, lookup, spec, increment)
 	}
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 resize failed: %v", err)}
 	}
@@ -553,9 +553,9 @@ func absInt(n int) int {
 	return n
 }
 
-func (t *Iterm2Tool) executeGetText(sessionID string) Result {
+func (t *Iterm2Tool) executeGetText(ctx context.Context, sessionID string) Result {
 	spec := iterm2SessionSpecifier(sessionID)
-	lookup := iterm2SessionLookup(sessionID)
+	lookup := iterm2SessionLookup(ctx, sessionID)
 	script := fmt.Sprintf(`
 tell application "iTerm"
 %s
@@ -572,7 +572,7 @@ tell application "iTerm"
 	end tell
 end tell`, lookup, spec)
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		// Fallback: try using capture() which may not be available in all versions
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 get_text failed: %v", err)}
@@ -581,13 +581,13 @@ end tell`, lookup, spec)
 	return Result{Content: out}
 }
 
-func (t *Iterm2Tool) executeSetTitle(sessionID, title string) Result {
+func (t *Iterm2Tool) executeSetTitle(ctx context.Context, sessionID, title string) Result {
 	if strings.TrimSpace(title) == "" {
 		return Result{IsError: true, Content: "text (title) is required for set_title action"}
 	}
 
 	spec := iterm2SessionSpecifier(sessionID)
-	lookup := iterm2SessionLookup(sessionID)
+	lookup := iterm2SessionLookup(ctx, sessionID)
 	script := fmt.Sprintf(`
 tell application "iTerm"
 %s
@@ -596,7 +596,7 @@ tell application "iTerm"
 	end tell
 end tell`, lookup, spec, escapeAS(title))
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 set_title failed: %v", err)}
 	}
@@ -604,7 +604,7 @@ end tell`, lookup, spec, escapeAS(title))
 	return Result{Content: fmt.Sprintf("iterm2 session title set: %s", title)}
 }
 
-func (t *Iterm2Tool) executeProfile(sessionID, profileName string) Result {
+func (t *Iterm2Tool) executeProfile(ctx context.Context, sessionID, profileName string) Result {
 	if strings.TrimSpace(profileName) == "" {
 		return Result{IsError: true, Content: "text (profile name) is required for profile action"}
 	}
@@ -613,7 +613,7 @@ func (t *Iterm2Tool) executeProfile(sessionID, profileName string) Result {
 	// Use the proprietary escape sequence ESC]1337;SetProfile=Name BEL
 	// to switch the profile for the target session.
 	esc := fmt.Sprintf("\x1b]1337;SetProfile=%s\x07", profileName)
-	if err := t.iterm2WriteToTTY(sessionID, esc); err != nil {
+	if err := t.iterm2WriteToTTY(ctx, sessionID, esc); err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 profile switch failed: %v", err)}
 	}
 
@@ -623,9 +623,9 @@ func (t *Iterm2Tool) executeProfile(sessionID, profileName string) Result {
 // iterm2WriteToTTY writes a raw string directly to the session's TTY device,
 // bypassing both System Events and the shell. This is used for escape
 // sequences (badge, mark, clear) that must not be interpreted by the shell.
-func (t *Iterm2Tool) iterm2WriteToTTY(sessionID, data string) error {
+func (t *Iterm2Tool) iterm2WriteToTTY(ctx context.Context, sessionID, data string) error {
 	spec := iterm2SessionSpecifier(sessionID)
-	lookup := iterm2SessionLookup(sessionID)
+	lookup := iterm2SessionLookup(ctx, sessionID)
 	ttyScript := fmt.Sprintf(`
 tell application "iTerm"
 %s
@@ -634,7 +634,7 @@ tell application "iTerm"
 	end tell
 end tell`, lookup, spec)
 
-	tty, err := runAppleScript(context.Background(), ttyScript)
+	tty, err := runAppleScript(ctx, ttyScript)
 	if err != nil {
 		return fmt.Errorf("failed to get session tty: %w", err)
 	}
@@ -654,21 +654,21 @@ end tell`, lookup, spec)
 	return nil
 }
 
-func (t *Iterm2Tool) executeBadge(sessionID, badgeText string) Result {
+func (t *Iterm2Tool) executeBadge(ctx context.Context, sessionID, badgeText string) Result {
 	// iTerm2 supports per-session badges via the OSC 1337 escape sequence:
 	// ESC ] 1337 ; SetBadgeFormat = BASE64(text) BEL
 	// We write the escape sequence directly to the session's TTY device
 	// to avoid interference from the shell or TUI raw mode.
 
 	if badgeText == "" {
-		err := t.iterm2WriteToTTY(sessionID, "\033]1337;SetBadgeFormat=\007")
+		err := t.iterm2WriteToTTY(ctx, sessionID, "\033]1337;SetBadgeFormat=\007")
 		if err != nil {
 			return Result{IsError: true, Content: fmt.Sprintf("iterm2 badge clear failed: %v", err)}
 		}
 		return Result{Content: "iterm2 badge cleared"}
 	}
 
-	err := t.iterm2WriteToTTY(sessionID, fmt.Sprintf("\033]1337;SetBadgeFormat=%s\007", badgeText))
+	err := t.iterm2WriteToTTY(ctx, sessionID, fmt.Sprintf("\033]1337;SetBadgeFormat=%s\007", badgeText))
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 badge failed: %v", err)}
 	}
@@ -680,7 +680,7 @@ func (t *Iterm2Tool) executeBadge(sessionID, badgeText string) Result {
 	return Result{Content: fmt.Sprintf("iterm2 badge set: %s", preview)}
 }
 
-func (t *Iterm2Tool) executeBroadcast(subAction string) Result {
+func (t *Iterm2Tool) executeBroadcast(ctx context.Context, subAction string) Result {
 	sub := strings.ToLower(strings.TrimSpace(subAction))
 	if sub == "" {
 		sub = "toggle"
@@ -711,7 +711,7 @@ end tell`
 		return Result{IsError: true, Content: fmt.Sprintf("invalid broadcast sub-action %q (use toggle/on/off)", subAction)}
 	}
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 broadcast failed: %v", err)}
 	}
@@ -719,7 +719,7 @@ end tell`
 	return Result{Content: fmt.Sprintf("iterm2 broadcast: %s", sub)}
 }
 
-func (t *Iterm2Tool) executeMark(subAction string) Result {
+func (t *Iterm2Tool) executeMark(ctx context.Context, subAction string) Result {
 	sub := strings.ToLower(strings.TrimSpace(subAction))
 	if sub == "" {
 		sub = "set"
@@ -729,7 +729,7 @@ func (t *Iterm2Tool) executeMark(subAction string) Result {
 	case "set":
 		// Use OSC 1337 escape sequence written directly to TTY - no
 		// Accessibility permission needed.
-		err := t.iterm2WriteToTTY("", "\033]1337;SetMark\007")
+		err := t.iterm2WriteToTTY(ctx, "", "\033]1337;SetMark\007")
 		if err != nil {
 			return Result{IsError: true, Content: fmt.Sprintf("iterm2 mark set failed: %v", err)}
 		}
@@ -752,7 +752,7 @@ tell application "System Events"
 	end tell
 end tell`, sub, sub, sub)
 
-		_, err := runAppleScript(context.Background(), script)
+		_, err := runAppleScript(ctx, script)
 		if err != nil {
 			return Result{IsError: true, Content: fmt.Sprintf("iterm2 mark %s failed (needs Accessibility permission for keyboard shortcuts): %v", sub, err)}
 		}
@@ -763,18 +763,18 @@ end tell`, sub, sub, sub)
 	}
 }
 
-func (t *Iterm2Tool) executeClear(sessionID string) Result {
+func (t *Iterm2Tool) executeClear(ctx context.Context, sessionID string) Result {
 	// Clear screen + scrollback via escape sequence written to TTY.
 	// ESC[2J = clear screen, ESC[3J = clear scrollback, ESC[H = cursor home.
 	// No Accessibility permission needed.
-	err := t.iterm2WriteToTTY(sessionID, "\033[2J\033[3J\033[H")
+	err := t.iterm2WriteToTTY(ctx, sessionID, "\033[2J\033[3J\033[H")
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 clear failed: %v", err)}
 	}
 	return Result{Content: "iterm2 buffer cleared"}
 }
 
-func (t *Iterm2Tool) executeMenuAction(menuItem string) Result {
+func (t *Iterm2Tool) executeMenuAction(ctx context.Context, menuItem string) Result {
 	if strings.TrimSpace(menuItem) == "" {
 		return Result{IsError: true, Content: "text (menu item name) is required for action"}
 	}
@@ -805,7 +805,7 @@ tell application "System Events"
 end tell
 return "not found"`, menuItem)
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 action %q failed: %v", menuItem, err)}
 	}
@@ -817,7 +817,7 @@ return "not found"`, menuItem)
 	return Result{Content: fmt.Sprintf("iterm2: %s", menuItem)}
 }
 
-func (t *Iterm2Tool) executeReloadConfig() Result {
+func (t *Iterm2Tool) executeReloadConfig(ctx context.Context) Result {
 	// iTerm2 does not have a native AppleScript command to reload preferences.
 	// System Events UI scripting requires Accessibility permissions.
 	// Best effort: try the menu item; if it fails, inform the user.
@@ -839,7 +839,7 @@ tell application "System Events"
 	end tell
 end tell`
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 reload_config failed: %v", err)}
 	}


### PR DESCRIPTION
## Summary
Closes #1894. The #1686 ghostty fix left the sibling iterm2 tool untouched by its own stated scope limitation: `Iterm2Tool.Execute` received ctx and dropped it while all 23 `runAppleScript` call sites hardcoded `context.Background()` — a session cancel kept osascript running to completion in the user's terminal, with no deadline propagation.

Plumbing-only change: all 20 `execute*` methods take ctx first; `iterm2WriteText`/`iterm2SessionLookup`/`iterm2WriteToTTY` thread it through; every `runAppleScript(context.Background())` becomes `runAppleScript(ctx)` (already `exec.CommandContext` from #1686, so cancel/timeout now actually interrupt osascript here too). No behavior change on the happy path.

## Verification evidence (review)
- Isolated clean worktree at HEAD + this diff (main tree carries unrelated in-flight conflict markers in hooks/extract — not in this PR's files):
  - `go test -tags goolm -count=1 ./internal/tool/` → **ok 36.587s**
- Mechanical transformation only; compile-driven completion (each missed call site was a compile error, none remain).

Closes #1894

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)
