### PR TITLE
style(tool): gofmt ghostty + iterm2 files (replaces #1897)

### DIFF
--- a/internal/tool/ghostty.go
+++ b/internal/tool/ghostty.go
@@ -118,7 +118,7 @@ func (g *GhosttyTool) Execute(ctx context.Context, input json.RawMessage) (Resul
 
 	// Status doesn't require Ghostty to be running — it reports detection.
 	if action == "status" {
-		return g.executeStatus(ctx, ), nil
+		return g.executeStatus(ctx), nil
 	}
 
 	if !ghosttyAvailable() {
@@ -127,7 +127,7 @@ func (g *GhosttyTool) Execute(ctx context.Context, input json.RawMessage) (Resul
 
 	switch action {
 	case "list":
-		return g.executeList(ctx, ), nil
+		return g.executeList(ctx), nil
 	case "split":
 		return g.executeSplit(ctx, args.TerminalID, args.Direction, args.Size, args.Command, args.WorkingDir), nil
 	case "new_tab":

--- a/internal/tool/ghostty_darwin.go
+++ b/internal/tool/ghostty_darwin.go
@@ -143,7 +143,7 @@ func ghosttyBinaryPath() string {
 
 // ── Action implementations (macOS) ──────────────────────────────────────────
 
-func (g *GhosttyTool) executeStatus(ctx context.Context, ) Result {
+func (g *GhosttyTool) executeStatus(ctx context.Context) Result {
 	if !ghosttyAvailable() {
 		return Result{Content: "ghostty: not detected (TERM_PROGRAM != ghostty)"}
 	}
@@ -173,7 +173,7 @@ func (g *GhosttyTool) executeStatus(ctx context.Context, ) Result {
 	return Result{Content: b.String()}
 }
 
-func (g *GhosttyTool) executeList(ctx context.Context, ) Result {
+func (g *GhosttyTool) executeList(ctx context.Context) Result {
 	script := `
 tell application "Ghostty"
 	set output to ""

--- a/internal/tool/ghostty_other.go
+++ b/internal/tool/ghostty_other.go
@@ -13,14 +13,14 @@ import (
 
 func ghosttyBinaryPath() string { return "" }
 
-func (g *GhosttyTool) executeStatus(ctx context.Context, ) Result {
+func (g *GhosttyTool) executeStatus(ctx context.Context) Result {
 	if !ghosttyAvailable() {
 		return Result{Content: "ghostty: not detected (TERM_PROGRAM != ghostty)"}
 	}
 	return Result{Content: fmt.Sprintf("ghostty: detected but platform %s/%s is not supported (only darwin and linux)", runtime.GOOS, runtime.GOARCH)}
 }
 
-func (g *GhosttyTool) executeList(ctx context.Context, ) Result {
+func (g *GhosttyTool) executeList(ctx context.Context) Result {
 	return unsupportedResult()
 }
 

--- a/internal/tool/iterm2.go
+++ b/internal/tool/iterm2.go
@@ -149,7 +149,7 @@ func (t *Iterm2Tool) Execute(ctx context.Context, input json.RawMessage) (Result
 
 	switch action {
 	case "list":
-		return t.executeList(ctx, ), nil
+		return t.executeList(ctx), nil
 	case "split":
 		return t.executeSplit(ctx, args.SessionID, args.Direction, args.Size, args.Command, args.WorkingDir), nil
 	case "new_tab":

--- a/internal/tool/iterm2_darwin.go
+++ b/internal/tool/iterm2_darwin.go
@@ -119,7 +119,7 @@ func (t *Iterm2Tool) executeStatus(ctx context.Context) Result {
 	return Result{Content: b.String()}
 }
 
-func (t *Iterm2Tool) executeList(ctx context.Context, ) Result {
+func (t *Iterm2Tool) executeList(ctx context.Context) Result {
 	script := `
 tell application "iTerm"
 	set output to ""


### PR DESCRIPTION
Per #1897 review: that branch accidentally carried aad84217 (iterm2 ctx, #1894's own work) and its 88+/88- mixed gofmt with real edits. This branch is **gofmt-only across six files** (ghostty ×3 from 931913ff's scripted threading + iterm2 ×2 + ghostty_linux), built on origin/main in an isolated worktree.

Verified: gofmt -l clean repo-wide for internal/tool, package builds, no other commits on the branch (single style commit).

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)