### PR TITLE
fix(extract,tui): pdf marker off-by-one + null-page placeholder; ja i18n (#1729)

### DIFF
--- a/internal/extract/pdf.go
+++ b/internal/extract/pdf.go
@@ -25,6 +25,10 @@ func (pdfExtractor) Extract(data []byte) (TextResult, error) {
 	for i := 1; i <= numPages; i++ {
 		page := reader.Page(i)
 		if page.V.IsNull() {
+			// #1729 case 2: a null page object vanished silently while
+			// Pages still reported the total - the page-level twin of the
+			// masquerade #1542 fixed for corrupt pages (#686/#682 family).
+			fmt.Fprintf(&buf, "\n[page %d empty: page object missing]", i)
 			continue
 		}
 		text, err := page.GetPlainText(nil)
@@ -33,7 +37,10 @@ func (pdfExtractor) Extract(data []byte) (TextResult, error) {
 			// 49 with no page number and no marker while Pages still reported
 			// the total, the exact masquerade svg/tar/zip already fixed
 			// (#686/#682). Flag it honestly.
-			fmt.Fprintf(&buf, "\n[page %d unreadable: %v]", i+1, err)
+			// #1729 case 1: ledongthuc/pdf's Page(n) takes 1-BASED numbers
+			// (page.go num-- comment) - i is already the true page number;
+			// the old i+1 reported page numPages+1 for a corrupt LAST page.
+			fmt.Fprintf(&buf, "\n[page %d unreadable: %v]", i, err)
 			continue
 		}
 		text = strings.TrimSpace(text)

--- a/internal/tui/i18n_ja.go
+++ b/internal/tui/i18n_ja.go
@@ -318,7 +318,7 @@ func jaCatalog(key string) string {
 	case "lang.selection.hint":
 		return "言語を選択してください"
 	case "lang.first_use.title":
-		return " preferred言語を選択してください"
+		return "優先する言語を選択してください"
 	case "lang.first_use.body":
 		return " ggcodeが使用する言語を選択してください。"
 	case "lang.first_use.hint":
@@ -754,7 +754,7 @@ func jaCatalog(key string) string {
 	case "mcp.active_tools":
 		return "アクティブツール"
 	case "mcp.more":
-		return "… %d件更多 • /mcp"
+		return "… さらに%d件 • /mcp"
 	case "image.usage":
 		return "使用法: /image <ファイルパス> または /image paste\n"
 	case "image.formats":


### PR DESCRIPTION
## Case 1 (High)
The #1542 unreadable-page marker printed `i+1`, but ledongthuc/pdf's `Page(n)` takes **1-based** numbers (page.go `num--` comment) - `i` is already the true page number. A corrupt LAST page was reported as the nonexistent `page numPages+1`; page-5 damage was blamed on page 6.

## Case 2 (Med)
A null page object (`page.V.IsNull() → continue`) vanished silently while `Pages` still reported the total - the page-level twin of the masquerade #1542 fixed for corrupt pages (#686/#682 family). Now emits `[page %d empty: page object missing]`.

## Case 3 (Med)
ja lexicon: simplified-Chinese 更多 (→ さらに%d件) and untranslated ' preferred言語' with a leading space (→ 優先する言語を選択してください); en/de baselines localize correctly.

## Verification
Isolated worktree on origin/main: extract+tui build OK, extract package full PASS, gofmt clean. Supersedes the empty fix/1729-pdf-ja push (parent drift - that branch can be deleted).

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)