### PR TITLE
fix(tool): iterm2 non-darwin stub matches ctx-threaded signatures (unblocks red main)

### DIFF
--- a/internal/tool/iterm2_other.go
+++ b/internal/tool/iterm2_other.go
@@ -3,6 +3,7 @@
 package tool
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 )
@@ -10,86 +11,86 @@ import (
 // ── Stub for unsupported platforms (Linux, Windows, etc.) ────────────────────
 // iTerm2 is macOS-only, so all actions return an error on other platforms.
 
-func (t *Iterm2Tool) executeStatus() Result {
+func (t *Iterm2Tool) executeStatus(ctx context.Context) Result {
 	if !iterm2Available() {
 		return Result{Content: "iterm2: not detected (TERM_PROGRAM != iTerm.app)"}
 	}
 	return Result{Content: fmt.Sprintf("iterm2: detected but platform %s/%s is not supported (iTerm2 is macOS-only)", runtime.GOOS, runtime.GOARCH)}
 }
 
-func (t *Iterm2Tool) executeList() Result {
+func (t *Iterm2Tool) executeList(ctx context.Context) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeSplit(sessionID, direction string, size int, command, workingDir string) Result {
+func (t *Iterm2Tool) executeSplit(ctx context.Context, sessionID, direction string, size int, command, workingDir string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeNewTab(command, workingDir string) Result {
+func (t *Iterm2Tool) executeNewTab(ctx context.Context, command, workingDir string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeNewWindow(command, workingDir string) Result {
+func (t *Iterm2Tool) executeNewWindow(ctx context.Context, command, workingDir string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeFocus(sessionID string) Result {
+func (t *Iterm2Tool) executeFocus(ctx context.Context, sessionID string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeClose(sessionID string) Result {
+func (t *Iterm2Tool) executeClose(ctx context.Context, sessionID string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeSelectTab(tabIndex int) Result {
+func (t *Iterm2Tool) executeSelectTab(ctx context.Context, tabIndex int) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeInput(sessionID, text string) Result {
+func (t *Iterm2Tool) executeInput(ctx context.Context, sessionID, text string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeSendKey(sessionID, key, modifiers string) Result {
+func (t *Iterm2Tool) executeSendKey(ctx context.Context, sessionID, key, modifiers string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeResize(sessionID, axis string, increment int) Result {
+func (t *Iterm2Tool) executeResize(ctx context.Context, sessionID, axis string, increment int) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeGetText(sessionID string) Result {
+func (t *Iterm2Tool) executeGetText(ctx context.Context, sessionID string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeSetTitle(sessionID, title string) Result {
+func (t *Iterm2Tool) executeSetTitle(ctx context.Context, sessionID, title string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeProfile(sessionID, profileName string) Result {
+func (t *Iterm2Tool) executeProfile(ctx context.Context, sessionID, profileName string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeBadge(sessionID, badgeText string) Result {
+func (t *Iterm2Tool) executeBadge(ctx context.Context, sessionID, badgeText string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeBroadcast(subAction string) Result {
+func (t *Iterm2Tool) executeBroadcast(ctx context.Context, subAction string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeMark(subAction string) Result {
+func (t *Iterm2Tool) executeMark(ctx context.Context, subAction string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeClear(sessionID string) Result {
+func (t *Iterm2Tool) executeClear(ctx context.Context, sessionID string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeMenuAction(menuItem string) Result {
+func (t *Iterm2Tool) executeMenuAction(ctx context.Context, menuItem string) Result {
 	return iterm2UnsupportedResult()
 }
 
-func (t *Iterm2Tool) executeReloadConfig() Result {
+func (t *Iterm2Tool) executeReloadConfig(ctx context.Context) Result {
 	return iterm2UnsupportedResult()
 }
 


### PR DESCRIPTION
0165a86a's Test job fails to BUILD: iterm2.go dispatches every execute* with ctx (the #1894 threading) while the `!darwin` stub kept the old signatures - every non-macOS CI compile dies with 'too many arguments'. The stub methods now take ctx (ignored - they return unsupported-platform errors immediately).

Verified in isolated worktree: darwin/linux/windows GOOS builds all OK, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)