### PR TITLE
fix(agent,memory): detector accuracy quartet - version context, JSON5, authoritative YAML dup keys, ident scope (#1773)

### DIFF
--- a/internal/agent/config_syntax_check.go
+++ b/internal/agent/config_syntax_check.go
@@ -57,8 +57,16 @@ func configSyntaxCheck(filePath, content string) string {
 	switch ext {
 	case ".json":
 		return validateJSON(filePath, content)
-	case ".jsonc", ".json5":
+	case ".jsonc":
 		return validateJSONC(filePath, content)
+	case ".json5":
+		// #1773 case 2: JSON5 is a SUPERSET of JSON - unquoted keys, single
+		// quotes, trailing commas, hex numbers, +Infinity. stripJSONComments
+		// only handles // and /**/, so routing .json5 through the JSONC→JSON
+		// gauntlet reported every legal JSON5 file as broken with the false
+		// claim that it "will cause failures at runtime". Skip until a real
+		// JSON5 parser is wired in.
+		return ""
 	case ".yaml", ".yml":
 		return validateYAML(filePath, content)
 	case ".toml":
@@ -173,15 +181,28 @@ func stripJSONComments(s string) (string, error) {
 func validateYAML(filePath, content string) string {
 	// First check for duplicate keys by parsing the raw YAML text
 	// yaml.Unmarshal silently merges duplicates, so we need a different approach
-	if dupKeys := findYAMLDuplicateKeys(content); len(dupKeys) > 0 {
-		return fmt.Sprintf("YAML duplicate key(s) in %s: %s — fix before proceeding, "+
-			"this causes data loss (later keys overwrite earlier ones).",
-			filePath, strings.Join(dupKeys, ", "))
-	}
-
 	var node yaml.Node
 	if err := yaml.Unmarshal([]byte(content), &node); err != nil {
 		return formatConfigError(filePath, "YAML", err)
+	}
+	// #1773 case 3: duplicate keys must come from the AUTHORITATIVE parser,
+	// not the hand-rolled scanner. The scanner missed flow mappings
+	// (`{a: 1, a: 2}`) and list-item keys (`- key: val`), and its early
+	// return also suppressed the full syntax validation above. Decoding a
+	// mapping document into a map makes yaml.v3 itself report "mapping
+	// key ... already defined at line N" with real line numbers; non-mapping
+	// roots (sequences, scalars) simply have no mapping keys to duplicate.
+	if len(node.Content) > 0 && node.Content[0].Kind == yaml.MappingNode {
+		var into map[string]interface{}
+		if err := node.Decode(&into); err != nil {
+			// yaml.v3 phrases it "mapping key ... already defined at line N";
+			// keep the historical "duplicate key" phrasing callers and tests
+			// match on while surfacing the authoritative line numbers.
+			if strings.Contains(err.Error(), "already defined") {
+				return fmt.Sprintf("YAML duplicate key in %s: %v — this causes data loss (later keys overwrite earlier ones), fix before proceeding", filePath, err)
+			}
+			return formatConfigError(filePath, "YAML", err)
+		}
 	}
 
 	return ""

--- a/internal/agent/cross_file_impact.go
+++ b/internal/agent/cross_file_impact.go
@@ -416,6 +416,10 @@ func findSiblingGoFiles(dir, editedFile string, max int) []string {
 // referencesAnyImpactSymbol checks whether the given Go source references any
 // of the removed symbols.
 func referencesAnyImpactSymbol(src string, removed []impactRemovedSymbol) bool {
+	if len(removed) == 0 {
+		return false
+	}
+	names := make(map[string]bool, len(removed))
 	for _, s := range removed {
 		var name string
 		switch s.category {
@@ -427,14 +431,48 @@ func referencesAnyImpactSymbol(src string, removed []impactRemovedSymbol) bool {
 		default:
 			name = s.name
 		}
-		if name == "" {
-			continue
-		}
-		if containsGoIdent(src, name) {
-			return true
+		if name != "" {
+			names[name] = true
 		}
 	}
-	return false
+	if len(names) == 0 {
+		return false
+	}
+	// #1773 case 5: scope discrimination. The old text scan matched a
+	// sibling's LOCAL variable that happens to share the deleted
+	// package-level symbol's name - an advisory claiming the agent
+	// "affected a file you did NOT edit" when the local shadow cannot
+	// break compilation. Parse the sibling and only count occurrences
+	// the resolver leaves UNRESOLVED: an ident with Obj != nil is defined
+	// in this file (local var/param/func/receiver), so it does not
+	// reference the cross-file symbol at all. Unparsable siblings fall
+	// back to the conservative text scan.
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sibling.go", src, 0)
+	if err != nil {
+		for name := range names {
+			if containsGoIdent(src, name) {
+				return true
+			}
+		}
+		return false
+	}
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		id, ok := n.(*ast.Ident)
+		if !ok || !names[id.Name] {
+			return true
+		}
+		if id.Obj == nil {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }
 
 // containsGoIdent checks if name appears as a Go identifier in src.

--- a/internal/agent/cross_file_impact_test.go
+++ b/internal/agent/cross_file_impact_test.go
@@ -215,3 +215,25 @@ func TestCheckCrossFileImpact_FiresOnce(t *testing.T) {
 		t.Error("expected empty on second call (already fired)")
 	}
 }
+
+// #1773 case 5: a sibling LOCAL variable sharing the deleted
+// package-level symbol name is not a cross-file impact.
+func TestReferencesAnyImpactSymbolScopeDiscrimination(t *testing.T) {
+	removed := []impactRemovedSymbol{{name: "userCount", category: "var"}}
+	local := "package b\n\nfunc f() int {\n\tuserCount := 3\n\treturn userCount\n}\n"
+	if referencesAnyImpactSymbol(local, removed) {
+		t.Fatal("locally-defined ident must not count as an impact reference")
+	}
+	real := "package b\n\nfunc g() int {\n\treturn userCount\n}\n"
+	if !referencesAnyImpactSymbol(real, removed) {
+		t.Fatal("unresolved (cross-file) ident must count as an impact reference")
+	}
+}
+
+// #1773 case 2: JSON5 is a superset of JSON - legal JSON5 must not be
+// reported as broken config.
+func TestConfigSyntaxJSON5Skipped(t *testing.T) {
+	if w := configSyntaxCheck("config.json5", "{unquoted: single, trailing: [1,2,],}"); w != "" {
+		t.Fatalf("legal JSON5 must be skipped, got %q", w)
+	}
+}

--- a/internal/memory/contradiction_check.go
+++ b/internal/memory/contradiction_check.go
@@ -376,8 +376,14 @@ func isOppositeValue(a, b string) bool {
 	return false
 }
 
-// versionNumRe extracts version-like or numeric tokens from a value.
-var versionNumRe = regexp.MustCompile(`\d+(?:\.\d+)*`)
+// versionNumRe extracts version-like numeric tokens from a value.
+// #1773 case 1: dotted numbers only (1.27, 2.0.1). Bare integers are
+// usually non-version context - "go 1.27 (issue 4532)" vs "go 1.27
+// (fixed in 4533)" used to compare {1.27,4532} vs {1.27,4533}, mutual
+// absence flagged a conflict between two statements whose CORE version
+// is identical. Bare-number drift ("3 retries" vs "5 retries") is a
+// deliberate miss: without context those are just counts.
+var versionNumRe = regexp.MustCompile(`\d+\.\d+(?:\.\d+)*`)
 
 // numericConflict detects when two values contain different version numbers or
 // numeric specifications, suggesting a version drift.

--- a/internal/memory/contradiction_check_test.go
+++ b/internal/memory/contradiction_check_test.go
@@ -205,3 +205,14 @@ func TestClaimsConflict_PolarityGate(t *testing.T) {
 		t.Fatal("identical target with opposite polarity must conflict")
 	}
 }
+
+// #1773 case 1: bare integers in non-version context (issue/PR numbers)
+// must not join the version set.
+func TestNumericConflictBareIntegersAreNotVersions(t *testing.T) {
+	if numericConflict("go 1.27 (issue 4532)", "go 1.27 (fixed in 4533)") {
+		t.Fatal("bare issue numbers must not count as version members")
+	}
+	if !numericConflict("go 1.27", "go 1.28") {
+		t.Fatal("real dotted version drift must still conflict")
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1773 (remaining cases 1/2/3/5; cases 4 and 6 landed in-flight earlier — wait_command verify wiring, fired-after-real-output — both confirmed in place).

- **Case 1 (FP)**: `versionNumRe` accepted bare integers — "go 1.27 (issue 4532)" vs "go 1.27 (fixed in 4533)" compared {1.27,4532} vs {1.27,4533} and flagged a contradiction between identical core versions. Dotted-only tokens now; bare-number drift is a deliberate miss.
- **Case 2 (FP)**: `.json5` routed through JSONC strip-then-strict-JSON — legal JSON5 reported broken with the false "will cause failures at runtime" claim. Skipped until a real JSON5 parser is wired.
- **Case 3 (FN)**: YAML duplicate keys from a hand-rolled scanner (missed flow mappings + list-item keys; early return suppressed full syntax validation). Now authoritative: decode mapping docs into a map so yaml.v3 reports "already defined at line N" with real line numbers; historical "duplicate key" phrasing preserved; scanner retired from the production path (kept for its #725 tests).
- **Case 5 (FP)**: cross_file_impact text-matched a sibling's LOCAL variable sharing the deleted package-level symbol's name. `referencesAnyImpactSymbol` now parses the sibling and counts only resolver-UNRESOLVED occurrences (`Obj == nil`); unparsable siblings fall back to the conservative text scan.

## Verification evidence (review)
Isolated worktree at main 21a9e339 + this change:
- `go test -tags goolm -count=1 ./internal/agent/ ./internal/memory/` → **ok 38.6s / 0.5s**
- Three new pins: bare-int non-conflict + dotted drift still conflicts; JSON5 skip; local-shadow non-reference + unresolved-id reference.

Closes #1773

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)
