### PR TITLE
fix(tool,codehealth): review-diff ++ content lines, global MaxFiles, 200-byte isGenerated window, GUI OnPostExec, git stderr, quoted untracked paths (#1699)

### DIFF
--- a/internal/codehealth/complexity.go
+++ b/internal/codehealth/complexity.go
@@ -9,6 +9,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -132,12 +133,16 @@ func Analyze(dir string, opts Options) (*Report, error) {
 		if !strings.HasSuffix(path, ".go") {
 			return nil
 		}
-		// Skip generated files
+		// Skip generated files (excluded, not counted against the cap).
 		if isGenerated(path) {
 			return nil
 		}
 		if opts.MaxFiles > 0 && filesScanned >= opts.MaxFiles {
-			return filepath.SkipDir
+			// #1699 case 2: SkipDir on a FILE only skips the REST of that
+			// directory - sibling and parent-level directories kept scanning
+			// and the "cap" was routinely exceeded. SkipAll aborts the
+			// entire walk, making MaxFiles a real global limit.
+			return filepath.SkipAll
 		}
 
 		funcs, err := analyzeFile(path)
@@ -502,16 +507,20 @@ func isGenerated(path string) bool {
 		return true
 	}
 	// Check first line for "Code generated" comment
-	data, err := os.ReadFile(path)
+	// #1699 case 3: the comment promised a 200-byte window but ReadFile
+	// slurped the whole file; a long license header could also push the
+	// marker past the window. Read exactly the window.
+	f, err := os.Open(path)
 	if err != nil {
 		return false
 	}
-	// Only read first 200 bytes for performance
-	end := 200
-	if len(data) < end {
-		end = len(data)
+	defer f.Close()
+	buf := make([]byte, 200)
+	n, _ := io.ReadFull(f, buf)
+	if n == 0 {
+		return false
 	}
-	prefix := string(data[:end])
+	prefix := string(buf[:n])
 	return strings.Contains(prefix, "Code generated")
 }
 

--- a/internal/tool/review_changes.go
+++ b/internal/tool/review_changes.go
@@ -13,6 +13,7 @@ package tool
 //   - Structured report with categorized severity summary
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -158,8 +159,16 @@ func getReviewDiff(ctx context.Context, dir, scope string) (string, error) {
 // runReviewGit runs a git command and returns stdout.
 func runReviewGit(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	// #1699 case 5: cmd.Output() discards stderr - an unborn-HEAD exit 128
+	// surfaced as a bare "exit status 128" with the real git message
+	// ("does not have any commits yet") invisible in review diagnostics.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("%w: %s", err, msg)
+		}
 		return "", err
 	}
 	return string(out), nil
@@ -177,6 +186,12 @@ func getUntrackedFiles(ctx context.Context, dir string) []string {
 		if len(line) >= 3 {
 			status := line[:2]
 			file := strings.TrimSpace(line[2:])
+			// #1699 case 6: git quotes paths containing special characters
+			// C-style when core.quotePath is on; strip the quotes so the
+			// returned path is usable.
+			if len(file) >= 2 && file[0] == '"' && file[len(file)-1] == '"' {
+				file = file[1 : len(file)-1]
+			}
 			if strings.Contains(status, "?") {
 				untracked = append(untracked, file)
 			}
@@ -222,14 +237,23 @@ func parseReviewDiff(diff string) []*reviewDiffFile {
 			current.path = "(deleted)"
 		} else if strings.HasPrefix(line, "@@") {
 			newLineNum = parseReviewHunkStart(line)
-		} else if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+		} else if strings.HasPrefix(line, "+") {
+			// #1699 case 1: the header branches above already consumed the
+			// exact "+++ b/" / "+++ /dev/null" forms, so ANY remaining
+			// "+"-prefixed line is content. The old bare !HasPrefix("+++")
+			// guard skipped real content lines starting with ++ (a C-family
+			// "++i" in the diff), dropping them from added-count and
+			// comment-block detection while path extraction above used the
+			// exact form - two different judgments in one function.
 			current.addedLines = append(current.addedLines, reviewDiffLine{
 				lineNum: newLineNum,
 				content: line[1:],
 			})
 			current.addedCount++
 			newLineNum++
-		} else if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---") {
+		} else if strings.HasPrefix(line, "-") {
+			// Same for removals: "--- a/" was consumed above; a remaining
+			// "--x" decrement line is content.
 			current.removedCount++
 		} else if strings.HasPrefix(line, " ") || line == "" {
 			newLineNum++

--- a/internal/tool/review_changes_test.go
+++ b/internal/tool/review_changes_test.go
@@ -187,3 +187,18 @@ func TestCommentedCodePatterns(t *testing.T) {
 }
 
 // Note: contains and indexOf helpers are already defined in plan_mode_tools_test.go
+
+// #1699 case 1: content lines starting with ++ are additions, not headers.
+func TestParseReviewDiffDoublePlusContentLine(t *testing.T) {
+	diff := "diff --git a/x.c b/x.c\n--- a/x.c\n+++ b/x.c\n@@ -1,2 +1,3 @@\n int i;\n++i;\n return i;\n"
+	files := parseReviewDiff(diff)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0].addedCount != 1 {
+		t.Fatalf("++i content line must count as added, got %d", files[0].addedCount)
+	}
+	if len(files[0].addedLines) != 1 || files[0].addedLines[0].content != "+i;" {
+		t.Fatalf("content must be \"+i;\", got %+v", files[0].addedLines)
+	}
+}

--- a/internal/tool/run_command.go
+++ b/internal/tool/run_command.go
@@ -325,8 +325,19 @@ func (t RunCommand) Execute(ctx context.Context, input json.RawMessage) (Result,
 		// clock at all, so a long-lived editor is never killed by the tool
 		// call returning (#568) nor by a delayed timer (#1245).
 		safego.Go("tool.runCommand.guiWait", func() {
-			_ = cmd.Wait()
+			// #1699 case 4: the non-GUI success/failure paths both invoke
+			// OnPostExec, but the GUI path never did - hooks mounted on
+			// post-exec never saw GUI launches. Mirror the completion
+			// semantics once the app process exits.
+			waitErr := cmd.Wait()
 			cancel()
+			if t.OnPostExec != nil {
+				code := 0
+				if waitErr != nil {
+					code = -1
+				}
+				t.OnPostExec(code, waitErr)
+			}
 		})
 		return Result{Content: fmt.Sprintf("GUI application launched (pid %d).", cmd.Process.Pid)}, nil
 	}


### PR DESCRIPTION
## Summary
Closes #1699 — six confirmed cases from the #1510-deferred batch:

1. **parseReviewDiff** (Med): bare `!HasPrefix("+++")` skipped real content lines starting with `++` (C-family `++i`) — header branches now consume the exact `+++ b/` forms first, every remaining +/- line is content. Pinned.
2. **MaxFiles** (Med-Low): SkipDir on a file only skips that directory's remainder — `filepath.SkipAll` makes the cap global.
3. **isGenerated** (Low-Med): promised a 200-byte window but slurped whole files — reads exactly 200 bytes now (`io.ReadFull`).
4. **GUI OnPostExec** (Low): GUI launch path never invoked OnPostExec while both non-GUI paths do — guiWait fires it after the app exits.
5. **runReviewGit stderr** (Low): `cmd.Output()` discarded stderr — unborn-HEAD exit 128 now surfaces git's real message.
6. **Quoted untracked paths** (Low): C-style quoted porcelain paths unquoted before use.

## Verification evidence (review)
Isolated worktree at origin/main fc386b64:
- `go test -tags goolm -count=1 ./internal/tool/ ./internal/codehealth/` → **ok 40.7s / 0.75s**
- Pin: `TestParseReviewDiffDoublePlusContentLine` (content `++i;` counted as added, content preserved as `+i;`).

Closes #1699

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)
