### PR TITLE
fix(hooks): stripContentValues recurses into nested structures (#1730 case 1)

### DIFF
--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -794,14 +794,33 @@ func stripContentValues(rawInput string) string {
 	if err := json.Unmarshal([]byte(trimmed), &args); err != nil {
 		return ""
 	}
-	for _, k := range contentValueFields {
-		delete(args, k)
-	}
+	stripNested(args)
 	b, err := json.Marshal(args)
 	if err != nil {
 		return ""
 	}
 	return string(b)
+}
+
+// stripNested deletes content-like keys at EVERY depth (#1730 case 1):
+// multi_edit_file's edits[].new_text and multi_file_write's files[].content
+// nest under arrays - the top-level-only delete left them in the payload,
+// and a path-prefix miss let the secondary Contains match "internal/"
+// inside new_text -> exit-2 false positive.
+func stripNested(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		for _, k := range contentValueFields {
+			delete(t, k)
+		}
+		for _, child := range t {
+			stripNested(child)
+		}
+	case []any:
+		for _, child := range t {
+			stripNested(child)
+		}
+	}
 }
 
 // ExtractFilePath attempts to extract a file path from common tool argument patterns.

--- a/internal/hooks/strip_content_test.go
+++ b/internal/hooks/strip_content_test.go
@@ -1,0 +1,35 @@
+package hooks
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStripContentValuesRecursive pins #1730 case 1: content-like keys are
+// deleted at EVERY depth - multi_edit_file's edits[].new_text and
+// multi_file_write's files[].content nested under arrays used to survive
+// the top-level-only delete, feeding the secondary Contains a false
+// "internal/" match (exit-2 false positive).
+func TestStripContentValuesRecursive(t *testing.T) {
+	in := `{"file_path":"/other/x","edits":[{"old_text":"a","new_text":"see internal/agent fix"}]}`
+	out := stripContentValues(in)
+	if strings.Contains(out, "internal/") {
+		t.Fatalf("nested new_text must be stripped, got %s", out)
+	}
+	if strings.Contains(out, "old_text") {
+		t.Fatalf("old_text is not a content-like field? check contentValueFields - got %s", out)
+	}
+	// file_path must survive: path-prefix matching relies on it.
+	if !strings.Contains(out, "/other/x") {
+		t.Fatalf("file_path must survive the strip, got %s", out)
+	}
+	// multi_file_write shape.
+	in2 := `{"files":[{"path":"a.go","content":"internal/x"}]}`
+	out2 := stripContentValues(in2)
+	if strings.Contains(out2, "internal/") {
+		t.Fatalf("nested files[].content must be stripped, got %s", out2)
+	}
+	if !strings.Contains(out2, "a.go") {
+		t.Fatalf("files[].path must survive, got %s", out2)
+	}
+}


### PR DESCRIPTION
## Root cause
The content-value strip deleted content-like keys at the TOP level only. `multi_edit_file`'s `edits[].new_text` and `multi_file_write`'s `files[].content` nest under arrays - they survived the strip, and when the tool's file_path missed the protected-prefix list, the secondary Contains matched 'internal/' **inside new_text** → exit-2 false positive. #679/#1543's two-branch alignment never reached the nesting level.

## Fix
`stripNested` walks maps/slices deleting content-like keys at every depth; `file_path` / `files[].path` survive for path-prefix matching.

## Verification
Isolated worktree on origin/main (shared tree has an unrelated heredoc incident): hooks build + full package PASS + gofmt clean. New `TestStripContentValuesRecursive` covers both nested shapes and the surviving path fields.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)