### PR TITLE
fix(agent): logging-intel side notes - remove JS-default strip wrapper and dead counters; pin word-boundary final verdict (#1623)

### DIFF
--- a/internal/agent/logging_intel_check.go
+++ b/internal/agent/logging_intel_check.go
@@ -343,9 +343,11 @@ func containsWordBoundary(s, substr string) bool {
 	}
 }
 
-// stripStringLiterals removes quoted string contents from a Go/JS expression,
-// leaving only identifiers, operators, and punctuation.
-func stripStringLiterals(s string) string { return stripStringLiteralsFor(s, true) }
+// stripStringLiterals is intentionally GONE (#1623 side note 1): the old
+// zero-production-caller wrapper defaulted to JS semantics - a future Go
+// path reaching for it would silently reintroduce the #1581-A false
+// positive. Callers must choose a language explicitly via
+// stripStringLiteralsFor(s, isJS).
 
 // stripStringLiteralsFor is the language-aware core (#1581-A): in JS a
 // backtick string is a TEMPLATE LITERAL and ${...} is live interpolation
@@ -728,12 +730,7 @@ func stripInitFuncs(src string) string {
 	return b.String()
 }
 
-// countSensitiveLogArgs returns the count of sensitive-log-arg patterns.
-func countSensitiveLogArgs(src, ext string) int {
-	return len(findSensitiveLogArgs(src, ext))
-}
-
-// countFatalInLib returns the count of fatal-in-library patterns.
-func countFatalInLib(src, ext, filePath string) int {
-	return len(findFatalInLib(src, ext, filePath))
-}
+// countSensitiveLogArgs / countFatalInLib were zero-call wrappers
+// (#1623 side note 2) and are gone; call findSensitiveLogArgs /
+// findFatalInLib and take len() at the (currently nonexistent) metrics
+// call sites if counting is ever needed.

--- a/internal/agent/logging_intel_check_test.go
+++ b/internal/agent/logging_intel_check_test.go
@@ -280,6 +280,9 @@ func TestHasSensitiveVarRef_AsIdentifier(t *testing.T) {
 }
 
 func TestStripStringLiterals(t *testing.T) {
+	// #1623 side note 1: the JS-default wrapper is gone; state the
+	// language explicitly (these cases are JS-shaped: single quotes,
+	// backticks).
 	tests := []struct {
 		input  string
 		expect string
@@ -291,9 +294,9 @@ func TestStripStringLiterals(t *testing.T) {
 		{"`backtick`", ``},
 	}
 	for _, tt := range tests {
-		got := stripStringLiterals(tt.input)
+		got := stripStringLiteralsFor(tt.input, true)
 		if got != tt.expect {
-			t.Errorf("stripStringLiterals(%q) = %q, want %q", tt.input, got, tt.expect)
+			t.Errorf("stripStringLiteralsFor(%q, true) = %q, want %q", tt.input, got, tt.expect)
 		}
 	}
 }
@@ -609,5 +612,22 @@ func TestContainsWordBoundary(t *testing.T) {
 	}
 	if !containsWordBoundary("token, other", "token") {
 		t.Fatal("token followed by delimiter must match")
+	}
+}
+
+// #1623 main case: stage-2 must honor stage-1s
+
+// #1623 main case: stage-2 must honor stage-1's word-boundary semantics -
+// a message literal containing "token" plus an argument whose ident merely
+// CONTAINS the sensitive word (maxTokenCount) is correct code, not a leak.
+func TestHasSensitiveVarRef_1623WordBoundaryFinalVerdict(t *testing.T) {
+	args := `"token issued for %s", maxTokenCount`
+	matches := []string{"token"}
+	if hasSensitiveVarRef(args, matches, false) {
+		t.Fatal("substring-only match in maxTokenCount must NOT fire - stage 2 must keep word-boundary semantics")
+	}
+	real := `"issued for %s", token`
+	if !hasSensitiveVarRef(real, matches, false) {
+		t.Fatal("a bare sensitive identifier argument must still fire")
 	}
 }


### PR DESCRIPTION
## Summary
Closes #1623. The main case (stage-2 `Contains` discarding stage-1's `\b` protection → CRITICAL false positive on `log.Printf("token issued for %s", maxTokenCount)`) landed in-flight — confirmed in place via `containsWordBoundary`. This PR closes the two side notes and adds the missing end-to-end pin:

- **Side 1**: `stripStringLiterals` (zero production callers, JS-default) removed — the landmine that would silently reintroduce #1581-A on a future Go path. Test caller states the language explicitly.
- **Side 2**: `countSensitiveLogArgs` / `countFatalInLib` zero-call dead wrappers removed.
- **Pin**: `TestHasSensitiveVarRef_1623WordBoundaryFinalVerdict` — substring-only ident must NOT fire, bare sensitive ident must fire (the end-to-end regression the issue noted as missing).

## Verification evidence (review)
Isolated worktree: `go test -tags goolm -count=1 ./internal/agent/` → **ok 21.1s**, pin PASS.

Closes #1623

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)
