### PR TITLE
fix(agent): strict verify mirror splits on the pipe separator too (#1564 case C)

### DIFF
--- a/internal/agent/fix_cascade.go
+++ b/internal/agent/fix_cascade.go
@@ -61,16 +61,22 @@ var strictVerifyCommands = map[string]bool{
 // but never synced here - `GOFLAGS="-p=1" go test ./...` (this repo's own
 // documented OOM-avoidance form) and `cd /app && go test` were invisible,
 // starving the cascade counter. Each segment is env-stripped and matched.
+// #1564-C: the third separator is mirrored too - `cat tests.txt | pytest -`
+// fed the whole pipeline to the prefix match and never counted; the loose
+// splitCompoundCommand already splits on && / ; / | (same quote-context
+// tradeoff accepted there).
 func isStrictVerifyCommand(cmd string) bool {
 	for _, seg := range strings.Split(cmd, "&&") {
 		for _, semi := range strings.Split(seg, ";") {
-			c := strings.ToLower(strings.TrimSpace(stripEnvAssignments(semi)))
-			if c == "" {
-				continue
-			}
-			for prefix := range strictVerifyCommands {
-				if strings.HasPrefix(c, prefix+" ") || c == prefix {
-					return true
+			for _, pipe := range strings.Split(semi, "|") {
+				c := strings.ToLower(strings.TrimSpace(stripEnvAssignments(pipe)))
+				if c == "" {
+					continue
+				}
+				for prefix := range strictVerifyCommands {
+					if strings.HasPrefix(c, prefix+" ") || c == prefix {
+						return true
+					}
 				}
 			}
 		}

--- a/internal/agent/fix_cascade_test.go
+++ b/internal/agent/fix_cascade_test.go
@@ -147,3 +147,17 @@ func cascadeIndexOf(s, substr string) int {
 	}
 	return -1
 }
+
+// #1564-C: pipe-tailed verify segments must count - the strict mirror
+// lacked the third separator the loose splitCompoundCommand has.
+func TestIsStrictVerifyCommand1564CPipeSegment(t *testing.T) {
+	if !isStrictVerifyCommand("cat tests.txt | pytest -") {
+		t.Fatal("pipe-tailed verify segment must match")
+	}
+	if !isStrictVerifyCommand("go build ./... && cat r.txt | go test ./pkg/ -run X") {
+		t.Fatal("verify after && and | must match")
+	}
+	if isStrictVerifyCommand("cat notes.txt | grep foo") {
+		t.Fatal("non-verify pipeline must not match")
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1564. Cases A (promotion normalization) and B (comparator unification) landed in-flight — confirmed in place (`fixAmnesiaSameFile`: depth-anchored suffix, shared by promotion/exclusion/early-exit). This PR closes case C:

**isStrictVerifyCommand** split only on `&&` and `;` while the loose `splitCompoundCommand` it mirrors splits on `&&` / `;` / `|` — `cat tests.txt | pytest -` fed the whole pipeline to the prefix match and never entered the cascade counter. Third separator added (same quote-context tradeoff the loose version documents).

## Verification evidence (review)
Isolated worktree: `go test -tags goolm -count=1 ./internal/agent/` → **ok 32.7s**; pin `TestIsStrictVerifyCommand1564CPipeSegment` (pipe-tailed verify matches, `&&`+`|` chain matches, non-verify pipeline does not).

Closes #1564

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)
