### PR TITLE
test(agent): pin the #1646 right-tracker compaction reset (verifDebt + overcorrection)

### DIFF
--- a/internal/agent/guidance_compact_reset_test.go
+++ b/internal/agent/guidance_compact_reset_test.go
@@ -135,3 +135,21 @@ func TestResetGuidanceCounters1651Extension(t *testing.T) {
 		t.Fatal("quota bools must reset")
 	}
 }
+
+// #1646: the compaction reset must reopen the RIGHT debt detector -
+// verifDebt (maxWarn=2, the SAUP model the #1605 commit message named)
+// and overcorrection_cascade (maxWarn=2), not a byte-identical duplicate
+// of the verifyDebt (max=1) block above.
+func TestResetGuidanceCounters1646RightTracker(t *testing.T) {
+	a := &Agent{
+		verifDebt:      &verificationDebtState{warningsIssued: 2},
+		overcorrection: &overcorrectionState{warnCount: 2},
+	}
+	a.resetGuidanceCounters()
+	if a.verifDebt.warningsIssued != 0 {
+		t.Fatal("verifDebt.warningsIssued must reset (the #1605-A no-op fixed)")
+	}
+	if a.overcorrection.warnCount != 0 {
+		t.Fatal("overcorrection warnCount must reset (#1646-2)")
+	}
+}


### PR DESCRIPTION
## Summary
97373a22 (in-flight) fixed the tracker but shipped without a test. This pins both quotas the #1605-A no-op missed: `verifDebt.warningsIssued` and `overcorrection.warnCount` must reopen after `resetGuidanceCounters`.

## Verification evidence (review)
Isolated worktree at main: agent suite **21.4s PASS** (-count=1), pin PASS.

Closes #1646

Generated with [ggcode](https://github.com/topcheer/ggcode)