### PR TITLE
fix(tui): pt provider hint advertises the n key (#1732 case 2)

### DIFF
--- a/internal/tui/i18n_pt.go
+++ b/internal/tui/i18n_pt.go
@@ -1160,7 +1160,7 @@ func ptCatalog(key string) string {
 	case "panel.provider.hint.edit":
 		return "Enter salvar • Esc cancelar"
 	case "panel.provider.hint.main":
-		return "Tab/Shift+Tab mudar foco • j/k mover • / focar filtro • Enter ou s aplicar • a chave fornecedor • u chave endpoint • b URL base • m modelo personalizado • e adicionar endpoint • Esc fechar"
+		return "Tab/Shift+Tab mudar foco • j/k mover • / focar filtro • Enter ou s aplicar • a chave fornecedor • u chave endpoint • b URL base • m modelo personalizado • e adicionar endpoint • n novo fornecedor • Esc fechar"
 	case "panel.provider.login.browser_failed":
 		return "Falha ao abrir a página de verificação: %s"
 	case "panel.provider.login.browser_opened":


### PR DESCRIPTION
en/zh hints carry 'n new vendor' (handler implements `case "n"`, provider_panel.go) but pt never got it - the repair-propagation gap of the earlier en/zh fix. Adds '• n novo fornecedor'.

Case 1 (the 66/73 shadowed-keys dead weight in i18n_provider.go, #1725 family extreme form) is a larger dedup+CI-guard refactor shared with i18n_command's #1725 case 2 - deliberately left for a dedicated family PR, noted in the issue comment.

## Verification
Isolated worktree: tui build + full package PASS (13.8s) + gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)