### PR TITLE
fix(agent): files-present git_reset ignores mode - tier Low, not HIGH-IMPACT (#1621 side note)

### DIFF
--- a/internal/agent/irrev_gate.go
+++ b/internal/agent/irrev_gate.go
@@ -161,11 +161,19 @@ func irrevClassifyTool(toolName, args string) int {
 		// with no warning). Accept both shapes: the tool's mode field and a
 		// shell literal via run_command.
 		var resetArgs struct {
-			Mode string `json:"mode"`
+			Mode  string   `json:"mode"`
+			Files []string `json:"files"`
 		}
 		modeHard := false
 		if err := json.Unmarshal([]byte(args), &resetArgs); err == nil && strings.EqualFold(strings.TrimSpace(resetArgs.Mode), "hard") {
 			modeHard = true
+		}
+		// #1621 side note: when files are specified the tool ignores mode
+		// entirely and always performs a per-file mixed unstage (its schema
+		// says so) - a leftover "mode":"hard" alongside files is NOT a
+		// hard reset and must not fire the HIGH-IMPACT advisory.
+		if len(resetArgs.Files) > 0 {
+			return irrevTierLow
 		}
 		if modeHard || strings.Contains(strings.ToLower(args), "--hard") {
 			return irrevTierHigh

--- a/internal/agent/irrev_gate_test.go
+++ b/internal/agent/irrev_gate_test.go
@@ -261,3 +261,14 @@ func TestIrrevGateRecordOutcomeRevokesFailedGrounding(t *testing.T) {
 		t.Fatal("outcome for a different tool must not revoke")
 	}
 }
+
+// #1621 side note: files-present resets ignore mode (per-file mixed
+// unstage) - a stale "mode":"hard" next to files is not a hard reset.
+func TestIrrevClassifyTool1621ModeIgnoredWithFiles(t *testing.T) {
+	if got := irrevClassifyTool("git_reset", `{"mode":"hard","files":["a.go"]}`); got != irrevTierLow {
+		t.Fatalf("mode+files must tier Low (mixed unstage), got %d", got)
+	}
+	if got := irrevClassifyTool("git_reset", `{"mode":"hard"}`); got != irrevTierHigh {
+		t.Fatalf("mode hard without files must stay High, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1621. Cases A (git_stash drop → High) and B (git_tag delete → Medium) landed in-flight with pins — confirmed. This closes the side note: git_reset with files present ignores mode (per-file mixed unstage per its schema), but the tier check only looked at mode — passing both fired the HIGH-IMPACT advisory on a reversible unstage. files-present short-circuits to Low; bare mode:hard stays High.

## Verification evidence (review)
Isolated worktree: agent suite **26.5s PASS** (-count=1); pin `TestIrrevClassifyTool1621ModeIgnoredWithFiles` (mode+files → Low, mode:hard alone → High).

Closes #1621

Generated with [ggcode](https://github.com/topcheer/ggcode)