### PR TITLE
fix(util): OpenProcess ERROR_INVALID_PARAMETER means dead (#1723 case 1)

### DIFF
--- a/internal/util/process_windows_helper.go
+++ b/internal/util/process_windows_helper.go
@@ -3,6 +3,7 @@
 package util
 
 import (
+	"errors"
 	"os"
 
 	"golang.org/x/sys/windows"
@@ -23,10 +24,17 @@ func isProcessRunningWindows(proc *os.Process) bool {
 
 	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(proc.Pid))
 	if err != nil {
-		// #1535: ACCESS_DENIED means the process exists but belongs to
-		// another user/elevation - treating it as dead made daemon slot
-		// checks delete the PID file and fork a second daemon. Same
-		// principle as the WaitFor fallback below: when in doubt, alive.
+		// #1723 case 1: distinguish the errors. ACCESS_DENIED (5) means the
+		// process exists but belongs to another user/elevation - treating it
+		// as dead made daemon slot checks delete the PID file and fork a
+		// second daemon (#1535). ERROR_INVALID_PARAMETER (87) is what Windows
+		// returns for a NONEXISTENT pid - judging it alive wedged the slot
+		// forever after a daemon panic (CheckExistingDaemon -> alive ->
+		// empty cmdline -> same helper again). Everything else: when in
+		// doubt, alive.
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return false
+		}
 		return true
 	}
 	defer windows.CloseHandle(handle)


### PR DESCRIPTION
#1535 made every OpenProcess error mean 'alive' - right for ACCESS_DENIED (5: exists, foreign elevation) but Windows returns **ERROR_INVALID_PARAMETER (87) for a nonexistent pid**, so a dead daemon's slot stayed wedged forever (CheckExistingDaemon → alive → empty cmdline → same helper again). 87 now means dead; everything else stays alive (when in doubt, alive).

Note: TestIsProcessAlive_NonExistent already asserts false and turns red on Windows exactly when this regresses. Windows real-machine verification via Actions per the standing policy is recommended post-merge.

Isolated worktree: unix+windows GOOS builds OK, util package PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)