### PR TITLE
fix(tool): checkout executes the trimmed ref; sensitive match anchors to segments (#1687 cases 2+3)

### DIFF
--- a/internal/tool/git_add.go
+++ b/internal/tool/git_add.go
@@ -126,13 +126,17 @@ func checkSensitiveFiles(files []string) string {
 	for _, f := range files {
 		lf := strings.ToLower(f)
 		for _, pattern := range sensitiveFilePatterns {
-			// #835: the old 'HasSuffix || Contains' reduced to a bare substring
-			// match — 'app.environment.go' hit '.env' every stage. Anchor
-			// short patterns to path boundaries.
+			// #835/#1687 case 3: anchor to path SEGMENTS - the '/'+pattern
+			// substring hit 'foo/.envrc' for '/.env'. Split and compare
+			// segments exactly.
 			hit := strings.HasSuffix(lf, pattern)
 			if !hit && strings.Contains(pattern, ".") {
-				hit = strings.Contains(lf, pattern+"/") || strings.Contains(lf, "/"+pattern) ||
-					strings.HasSuffix(lf, "/"+pattern)
+				for _, seg := range strings.Split(lf, "/") {
+					if seg == pattern {
+						hit = true
+						break
+					}
+				}
 			}
 			if hit {
 				flagged = append(flagged, f)

--- a/internal/tool/git_checkout.go
+++ b/internal/tool/git_checkout.go
@@ -100,7 +100,7 @@ func (t GitCheckout) Execute(ctx context.Context, input json.RawMessage) (Result
 	}
 
 	// Execute checkout via VCS abstraction.
-	out, err := vcsImpl.Checkout(ctx, dir, args.Branch, args.Create, args.StartPoint)
+	out, err := vcsImpl.Checkout(ctx, dir, strings.TrimSpace(args.Branch), args.Create, strings.TrimSpace(args.StartPoint)) // #1687 case 2: validate trims a COPY - execute the trimmed value, else " main " passes validation but git rejects it
 	if err != nil {
 		if errors.Is(err, vcs.ErrCheckoutNotSupported) {
 			return Result{IsError: true, Content: fmt.Sprintf("%s does not support branch checkout", vcsImpl.DisplayName())}, nil


### PR DESCRIPTION
Case 2: validateBranchName trims a COPY, so `' main '` passed validation while git rejected the raw value - the trimmed value executes now (start_point likewise).

Case 3: the #835 boundary anchor used `'/'+pattern` substring matching - `/.env` hit `foo/.envrc`. Path segments are compared exactly.

Case 1 (git_add `files=["."]` bypassing the sensitive-file warning via porcelain post-scan) is a larger change - left noted for follow-up.

Isolated worktree: tool build + Sensitive/GitCheckout families PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)