### PR TITLE
ci(windows): add windows-process workflow for OpenProcess liveness verification (#1911 follow-up)

### DIFF
--- a/.github/workflows/windows-process.yml
+++ b/.github/workflows/windows-process.yml
@@ -1,0 +1,42 @@
+name: windows-process
+
+# Windows process-liveness verification (#1723 case 1 / PR #1911).
+#
+# IsProcessAlive on Windows goes through OpenProcess + a non-blocking
+# WaitForSingleObject, and the ERROR_INVALID_PARAMETER (87) verdict
+# (nonexistent pid = dead) only behaves as documented on a real Windows
+# kernel: 87 must report dead, ACCESS_DENIED (5) must stay alive, and a
+# signaled handle must mean exited. No LAN member has a Windows machine,
+# so this runner IS the real-machine test (same standing policy as
+# windows-proxy, #761). TestIsProcessAlive_NonExistent is the regression
+# sentinel: it turns red on Windows exactly when the 87 branch regresses.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "internal/util/process*.go"
+      - ".github/workflows/windows-process.yml"
+  pull_request:
+    paths:
+      - "internal/util/process*.go"
+      - ".github/workflows/windows-process.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  process:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    env:
+      GOFLAGS: "-p=1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Process liveness tests
+        shell: pwsh
+        run: go test -tags goolm -count=1 -v -run "IsProcessAlive" ./internal/util/


### PR DESCRIPTION
Follow-up to #1911 per the standing windows-real-machine policy.

**Why:** CI is ubuntu-only; the Windows branch of `IsProcessAlive` (OpenProcess + non-blocking `WaitForSingleObject`, incl. the new ERROR_INVALID_PARAMETER=dead verdict) never executes in CI. `windows-proxy` covers only the proxy stack. `TestIsProcessAlive_NonExistent` asserts false and turns red on a real Windows kernel exactly when the 87 branch regresses (stated in #1911).

**What:** new `windows-process` workflow mirroring `windows-proxy` (#761) conventions: windows-latest, path-triggered on `internal/util/process*.go` + the workflow file itself, plus workflow_dispatch. Test step: `go test -tags goolm -count=1 -v -run "IsProcessAlive" ./internal/util/` — filter covers all 5 tests (`TestIsProcessAlive_CurrentProcess/NonExistent/InvalidPID`, `TestIsProcessAliveProc_CurrentProcess/Nil`, name cross-checked per prior filter-miss lessons).

**Validation (isolated clone at f21ef8f):**
- YAML parses clean
- `GOOS=windows GOARCH=amd64 go build -tags goolm ./internal/util/` exit 0
- Filter ↔ test-name cross-check: 5/5 match

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)