### PR TITLE
fix(agent): anchor guard-state path keys to the workspace root; clear the exploration window on fire (#1559 C/D)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1081,6 +1081,15 @@ func (a *Agent) SetWorkingDir(dir string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.workingDir = dir
+	// #1559-C: the read/edit guard states key files by path - anchor
+	// them to the workspace root so relative reads and absolute edits
+	// hit the same map entry.
+	if a.unreadEdit != nil {
+		a.unreadEdit.baseDir = dir
+	}
+	if a.expiredRead != nil {
+		a.expiredRead.baseDir = dir
+	}
 }
 func (a *Agent) WorkingDir() string {
 	a.mu.RLock()

--- a/internal/agent/expired_read_check.go
+++ b/internal/agent/expired_read_check.go
@@ -40,6 +40,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/topcheer/ggcode/internal/debug"
 )
@@ -75,6 +76,16 @@ type expiredReadState struct {
 
 	// seq is a monotonically increasing counter for event ordering.
 	seq int
+
+	// baseDir anchors relative paths to the workspace root (#1559-C);
+	// mirrors unreadEditState.baseDir - see its normalize for rationale.
+	baseDir string
+}
+
+// normalize anchors to the workspace root, mirroring
+// unreadEditState.normalize (#1559-C).
+func (s *expiredReadState) normalize(path string) string {
+	return normalizeCompanionPath(s.baseDir, strings.TrimSpace(path))
 }
 
 func newExpiredReadState() *expiredReadState {
@@ -101,7 +112,7 @@ func (e *expiredReadState) recordRead(path string) {
 	if path == "" {
 		return
 	}
-	n := normalizePath(path)
+	n := e.normalize(path)
 	// Mark that this file has been read at least once (for expiry detection).
 	// Only track if not yet edited -- if already edited, the prior read is
 	// already expired and this re-read will be caught by checkPostEditReread.
@@ -121,7 +132,7 @@ func (e *expiredReadState) recordUndo(path string) {
 	if path == "" {
 		return
 	}
-	n := normalizePath(path)
+	n := e.normalize(path)
 	delete(e.editedFiles, n)
 	delete(e.readBeforeEdit, n)
 }
@@ -132,7 +143,7 @@ func (e *expiredReadState) recordEdit(path string) string {
 	if path == "" {
 		return ""
 	}
-	n := normalizePath(path)
+	n := e.normalize(path)
 
 	// Record this edit with the current sequence number.
 	e.seq++
@@ -171,7 +182,7 @@ func (e *expiredReadState) checkPostEditReread(path string) string {
 	if path == "" {
 		return ""
 	}
-	n := normalizePath(path)
+	n := e.normalize(path)
 
 	// Was this file edited?
 	editSeq, wasEdited := e.editedFiles[n]

--- a/internal/agent/exploration_frag.go
+++ b/internal/agent/exploration_frag.go
@@ -262,6 +262,11 @@ func (s *exploreFragState) recordToolCall(toolName string, args []byte, iteratio
 	}
 
 	s.warnings++
+	// #1559-D: fire-and-keep made the very next exploration call re-fire
+	// with a byte-identical message (window still full), burning both
+	// warnings back-to-back. Mirror attention_fragment: the window empties
+	// on fire, so a re-fire needs a full fresh window of exploration.
+	s.entries = nil
 	debug.Log("agent", "Iteration %d: exploration fragmentation detected (%d calls, %d unique targets)",
 		iteration, len(s.entries), len(uniqueTargets))
 

--- a/internal/agent/exploration_frag_test.go
+++ b/internal/agent/exploration_frag_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -175,4 +176,46 @@ func TestExploreFragSingleBatchNotFragmentation(t *testing.T) {
 func mustFragJSON(t *testing.T, p string) []byte {
 	t.Helper()
 	return []byte(`{"path":"` + p + `"}`)
+}
+
+// #1559-C: relative reads and absolute edits must key the same map entry
+// once the workspace root is wired via SetWorkingDir.
+func TestUnreadEditAnchoredNormalization1559(t *testing.T) {
+	a := &Agent{unreadEdit: newUnreadEditState(), expiredRead: newExpiredReadState()}
+	a.SetWorkingDir("/repo")
+	a.unreadEdit.recordRead("internal/agent/foo.go")
+	if !a.unreadEdit.hasBeenRead("/repo/internal/agent/foo.go") {
+		t.Fatal("relative read must match absolute form after anchoring")
+	}
+	a.expiredRead.recordRead("internal/agent/bar.go")
+	if hint := a.expiredRead.recordEdit("/repo/internal/agent/bar.go"); hint == "" {
+		t.Fatal("absolute edit of a relatively-read file must find the prior read (expiry fires)")
+	}
+}
+
+// #1559-D: firing empties the window - the very next exploration call must
+// not re-fire with the same full-window message.
+func TestExplorationFragWindowClearsOnFire1559(t *testing.T) {
+	s := newExploreFragState()
+	first := ""
+	for i := 0; i < exploreFragWindow+4 && first == ""; i++ {
+		iter := (i / 2) + 1 // spread across iterations (2-distinct gate)
+		first = s.recordToolCall("read_file", mustFragArgs(t, fmt.Sprintf("/x/dir%d/f%d.go", i%5, i)), iter)
+	}
+	if first == "" {
+		t.Fatal("expected fire once thresholds met")
+	}
+	s.warnings = 0 // isolate the window-clearing behavior from the max-2 cap
+	if second := s.recordToolCall("read_file", mustFragArgs(t, "/x/once.go"), 99); second != "" {
+		t.Fatal("window must empty on fire - next call cannot re-fire")
+	}
+}
+
+func mustFragArgs(t *testing.T, p string) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{"path": p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
 }

--- a/internal/agent/unread_edit_guard.go
+++ b/internal/agent/unread_edit_guard.go
@@ -60,6 +60,11 @@ type unreadEditState struct {
 	// Used for stale-read detection: if the file's mtime has changed since
 	// the last read, the agent's edit may be based on stale content.
 	readMtime map[string]time.Time
+
+	// baseDir anchors relative paths to the workspace root (#1559-C):
+	// "a.go" (read) and "/repo/a.go" (edit) must key the same map entry.
+	// Empty until SetWorkingDir wires it - Clean-only until then.
+	baseDir string
 }
 
 func newUnreadEditState() *unreadEditState {
@@ -79,11 +84,23 @@ func (s *unreadEditState) reset() {
 }
 
 // normalizePath converts a file path to a consistent form for comparison.
-// Lowercased and trimmed of trailing slashes — sufficient for dedup.
+// Trimmed and cleaned of trailing slashes - sufficient for dedup when the
+// caller feeds one path form. See unreadEditState.normalize for the
+// workspace-anchored variant the guard states use (#1559-C: the old
+// comment claimed "Lowercased" and no lowercasing ever existed).
 func normalizePath(p string) string {
 	p = strings.TrimSpace(p)
 	p = strings.TrimRight(p, "/")
 	return p
+}
+
+// normalize anchors the path to the workspace root before keying: a
+// relative read ("internal/agent/foo.go") and an absolute edit
+// ("/repo/internal/agent/foo.go") previously landed on two map keys, so
+// recordEdit never found the prior read (missed stale-read reports) and
+// uniqueTargets double-counted. Mirrors normalizeCompanionPath semantics.
+func (s *unreadEditState) normalize(path string) string {
+	return normalizeCompanionPath(s.baseDir, strings.TrimSpace(path))
 }
 
 // recordRead marks a file as read. Called after successful read_file/multi_file_read.
@@ -92,7 +109,7 @@ func (s *unreadEditState) recordRead(path string) {
 	if path == "" {
 		return
 	}
-	n := normalizePath(path)
+	n := s.normalize(path)
 	s.filesRead[n] = true
 	// Re-reading the file refreshes the staleness baseline: any future
 	// external modification after this read must be able to re-warn, so
@@ -115,7 +132,7 @@ func (s *unreadEditState) recordWrite(path string) {
 	if path == "" {
 		return
 	}
-	n := normalizePath(path)
+	n := s.normalize(path)
 	s.readMtime[n] = time.Now()
 	delete(s.warnedFiles, n+"\x00stale")
 }
@@ -126,12 +143,12 @@ func (s *unreadEditState) recordCreated(path string) {
 	if path == "" {
 		return
 	}
-	s.filesCreated[normalizePath(path)] = true
+	s.filesCreated[s.normalize(path)] = true
 }
 
 // hasBeenRead returns true if the file was read or created during this run.
 func (s *unreadEditState) hasBeenRead(path string) bool {
-	n := normalizePath(path)
+	n := s.normalize(path)
 	return s.filesRead[n] || s.filesCreated[n]
 }
 
@@ -142,7 +159,7 @@ func (s *unreadEditState) checkUnreadEdit(path string) string {
 	if path == "" {
 		return ""
 	}
-	n := normalizePath(path)
+	n := s.normalize(path)
 	if s.filesRead[n] || s.filesCreated[n] {
 		return ""
 	}
@@ -163,7 +180,7 @@ func (s *unreadEditState) checkStaleRead(path string) string {
 	if path == "" {
 		return ""
 	}
-	n := normalizePath(path)
+	n := s.normalize(path)
 
 	// Only check files that were read (not created — those are agent-authored).
 	readAt, wasRead := s.readMtime[n]


### PR DESCRIPTION
## Summary
Closes #1559. Cases A (recordUndo rewired to the source in agent_tool.go undo handler — cp.FilePath in hand, triple-unreachable agent.go wiring gone) and B (error gate narrowed: `!result.IsError || mutatingToolNamesFrag[tc.Name]` — failed run_command still resets the window) landed in-flight — confirmed. This closes C and D:

- **C (Med-Low)**: unreadEdit/expiredRead keyed by TrimSpace+TrimRight only — relative read + absolute edit = two map keys → recordEdit never found the prior read (missed expiry), uniqueTargets double-counted. Both states now carry `baseDir` (wired via SetWorkingDir) and normalize via `normalizeCompanionPath` (rel joins root, Clean). False "Lowercased" comment gone; empty baseDir degrades to Clean-only.
- **D (Low)**: exploration_fragmentation kept its full window after firing — next call re-fired a byte-identical message, burning both warnings back-to-back. Window empties on fire (refire needs a full fresh window, matching attention_fragment).

## Verification evidence (review)
Isolated worktree: agent suite **22.6s PASS** (-count=1); pins `TestUnreadEditAnchoredNormalization1559` (cross-form lookup + expiry fires) and `TestExplorationFragWindowClearsOnFire1559`.

Closes #1559

Generated with [ggcode](https://github.com/topcheer/ggcode)