### PR TITLE
fix(agent): sensitive_json untagged-field blind spot; file_ops guard shapes; LSP serial-chain exemption (#1492 A/D/E)

### DIFF
--- a/internal/agent/self_mod_guard.go
+++ b/internal/agent/self_mod_guard.go
@@ -259,6 +259,25 @@ func extractSelfModPaths(args json.RawMessage, _ string) []string {
 		}
 	}
 
+	// #1492-D: file_ops carries {action, source, destination} objects in
+	// an `operations` array - none of the shapes above matched, so
+	// `file_ops delete .ggcode/hooks/x.sh` or a move INTO .ggcode/ passed
+	// the guard silently even though file_ops is in sourceMutatingTools
+	// (the guard ran but always returned empty).
+	if ops, ok := raw["operations"].([]interface{}); ok {
+		for _, item := range ops {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, key := range []string{"source", "destination"} {
+				if s, ok := m[key].(string); ok {
+					add(s)
+				}
+			}
+		}
+	}
+
 	return paths
 }
 

--- a/internal/agent/self_mod_guard_test.go
+++ b/internal/agent/self_mod_guard_test.go
@@ -257,3 +257,42 @@ func TestSelfMod_GateCoversAllWriteTools(t *testing.T) {
 		}
 	}
 }
+
+// #1492-D: file_ops operations[].source/destination must feed the
+// self-modification guard.
+func TestSelfModGuardFileOpsShapes1492(t *testing.T) {
+	paths := extractSelfModPaths(json.RawMessage(`{"operations":[
+		{"action":"delete","source":".ggcode/hooks/x.sh"},
+		{"action":"move","source":"/tmp/a.sh","destination":".ggcode/hooks/y.sh"},
+		{"action":"mkdir","source":"/tmp/d"}
+	]}`), "")
+	joined := strings.Join(paths, ",")
+	for _, want := range []string{".ggcode/hooks/x.sh", "/tmp/a.sh", ".ggcode/hooks/y.sh"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected %s in extracted paths, got: %v", want, paths)
+		}
+	}
+}
+
+// #1492-E: the mandated LSP serial chain (symbols -> definition ->
+// references) is dependent by construction - three such single-read
+// turns must NOT fire the "independent reads" guidance.
+func TestSerialReadLSPChainExempt1492(t *testing.T) {
+	s := newSerialReadState()
+	for i, tool := range []string{"lsp_symbols", "lsp_definition", "lsp_references"} {
+		s.recordToolCall(tool)
+		if msg := s.endTurn(i + 1); msg != "" {
+			t.Fatalf("LSP serial chain must be exempt, got: %s", msg)
+		}
+	}
+	// Mixed chain: two LSP turns then a plain read_file turn still fires.
+	s2 := newSerialReadState()
+	s2.recordToolCall("lsp_symbols")
+	s2.endTurn(1)
+	s2.recordToolCall("lsp_definition")
+	s2.endTurn(2)
+	s2.recordToolCall("read_file")
+	if msg := s2.endTurn(3); msg == "" {
+		t.Fatal("mixed streak (non-LSP read present) must still fire")
+	}
+}

--- a/internal/agent/sensitive_json_check.go
+++ b/internal/agent/sensitive_json_check.go
@@ -90,7 +90,23 @@ func extractJSONTagName(tag string) (name string, hasTag bool) {
 // Returns "" if the field is not sensitive or already properly excluded.
 func sensitiveFieldWarning(fset *token.FileSet, filePath, structName string, field *ast.Field) string {
 	if field.Tag == nil {
-		return ""
+		// #1492-A: an exported field with NO json tag is serialized by
+		// encoding/json under its field name - `Password string` leaks just
+		// the same. This is the MOST COMMON leak shape and was skipped
+		// entirely. An untagged field cannot carry "-" without ADDING a
+		// tag, so the remediation differs from the tagged case.
+		fieldName := ""
+		if len(field.Names) > 0 {
+			fieldName = field.Names[0].Name
+		}
+		if fieldName == "" || !isSensitiveFieldName(fieldName) || !field.Names[0].IsExported() {
+			return ""
+		}
+		pos := fset.Position(field.Pos())
+		return fmt.Sprintf(
+			"%s:%d: sensitive field %q in struct %q has NO json tag - encoding/json serializes it under the field name, leaking it in any marshaled output. If this struct crosses a response/log boundary, add `json:\"-\"` (or omit the field); if it MUST serialize (request payloads, token exchanges, persisted config), verify every sink redacts it before relying on it (OWASP A01:2021)",
+			filepath.Base(filePath), pos.Line, fieldName, structName,
+		)
 	}
 	tagName, hasJSONTag := extractJSONTagName(field.Tag.Value)
 	if !hasJSONTag || tagName == "-" {
@@ -114,7 +130,7 @@ func sensitiveFieldWarning(fset *token.FileSet, filePath, structName string, fie
 	}
 	pos := fset.Position(field.Pos())
 	return fmt.Sprintf(
-		"%s:%d: sensitive field %q in struct %q has json tag %q but is not excluded from JSON output -- add `json:\"-\"` to prevent sensitive data exposure in API responses (OWASP A01:2021)",
+		"%s:%d: sensitive field %q in struct %q has json tag %q and IS serialized - if this struct crosses a response/log boundary add `json:\"-\"` to exclude it; if it must serialize (request payload, token exchange, persisted config), verify every consumer/redaction sink handles it before shipping (OWASP A01:2021)",
 		filepath.Base(filePath), pos.Line, displayName, structName, tagName,
 	)
 }

--- a/internal/agent/sensitive_json_check_test.go
+++ b/internal/agent/sensitive_json_check_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -43,9 +44,14 @@ type User struct {
 	Password string
 }
 `
+	// #1492-A: an untagged exported sensitive field IS serialized under its
+	// field name - the old expectation of 0 warnings was the blind spot.
 	warnings := checkSensitiveJSONExposure("test.go", "", src)
-	if len(warnings) != 0 {
-		t.Fatalf("expected 0 warnings for field without json tag, got %d: %v", len(warnings), warnings)
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning for untagged sensitive field, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "NO json tag") {
+		t.Fatalf("expected untagged-field remediation, got: %s", warnings[0])
 	}
 }
 

--- a/internal/agent/serial_read_detect.go
+++ b/internal/agent/serial_read_detect.go
@@ -102,6 +102,17 @@ type serialReadState struct {
 	// mutating tool call. If so, the turn is not a "single read" turn.
 	currentTurnHasMutation bool
 
+	// lspStreak counts consecutive single-read turns whose one call was
+	// an LSP tool (#1492-E): the system prompt MANDATES the serial chain
+	// lsp_symbols -> lsp_definition -> lsp_references - each step feeds
+	// the next - so three such turns are dependent by design, not
+	// "independent reads" the batch guidance could parallelize.
+	lspStreak int
+
+	// currentTurnTool is the tool name of the current turn's first
+	// read-only call (only meaningful when the turn ends as a single read).
+	currentTurnTool string
+
 	// fired tracks whether the detector has already fired this run.
 	fired bool
 }
@@ -145,6 +156,9 @@ func (s *serialReadState) recordToolCall(toolName string) {
 	defer s.mu.Unlock()
 	if serialReadOnlyTools[toolName] {
 		s.currentTurnReadOnly++
+		if s.currentTurnTool == "" {
+			s.currentTurnTool = toolName
+		}
 	} else if serialMutatingTools[toolName] {
 		s.currentTurnHasMutation = true
 	}
@@ -160,16 +174,29 @@ func (s *serialReadState) endTurn(iteration int) string {
 	// A "single read" turn: exactly 1 read-only call, zero mutations.
 	if s.currentTurnReadOnly == 1 && !s.currentTurnHasMutation {
 		s.consecutiveSingleReads++
+		if strings.HasPrefix(s.currentTurnTool, "lsp_") {
+			s.lspStreak++
+		} else {
+			s.lspStreak = 0
+		}
 	} else {
 		s.consecutiveSingleReads = 0
+		s.lspStreak = 0
 	}
 
 	// Reset per-turn counters for the next turn.
 	s.currentTurnReadOnly = 0
 	s.currentTurnHasMutation = false
+	s.currentTurnTool = ""
 
 	// Fire once per run when 3+ consecutive single-read turns are detected.
+	// #1492-E: skip when every streak turn was an LSP call - the mandated
+	// symbols->definition->references chain is dependent by construction.
 	if s.consecutiveSingleReads >= 3 && !s.fired {
+		if s.lspStreak >= s.consecutiveSingleReads {
+			debug.Log("agent", "Serial read: skipping fire - streak is the mandated LSP serial chain (iteration %d)", iteration)
+			return ""
+		}
 		s.fired = true
 		debug.Log("agent", "Serial read serialization detected: %d consecutive single-read turns at iteration %d", s.consecutiveSingleReads, iteration)
 		return strings.TrimSpace(`


### PR DESCRIPTION
## Summary
Addresses #1492 cases A, D, E (B and C noted as remaining in the issue):

- **A (High)**: untagged exported sensitive fields () are serialized by encoding/json under the field name — the most common leak shape, previously skipped entirely. Now detected with its own remediation; the tagged-field message no longer unconditionally orders `json:"-"` (distinguishes response/log boundaries from must-serialize payloads).
- **D (Med-Low)**: `extractSelfModPaths` now handles file_ops `operations[].source/destination` — `file_ops delete .ggcode/hooks/x.sh` previously passed the guard silently despite file_ops being in sourceMutatingTools.
- **E (Low-Med)**: serial_read exempts an all-LSP streak — the system prompt mandates the dependent symbols→definition→references chain; mixed streaks still fire.

## Verification evidence (review)
Isolated worktree: agent suite **22.3s PASS** (-count=1); pins `TestSelfModGuardFileOpsShapes1492`, `TestSerialReadLSPChainExempt1492` (exempt + mixed-still-fires), updated `TestCheckSensitiveJSONExposure_NoJSONTag` (the old test pinned the blind spot itself).

Addresses #1492

Generated with [ggcode](https://github.com/topcheer/ggcode)