### PR TITLE
fix(tui): approval/diff-confirm options re-derive from the current language on every arrival (#1741)

### DIFF
--- a/internal/tui/im_approval_test.go
+++ b/internal/tui/im_approval_test.go
@@ -237,3 +237,52 @@ func TestApprovalNotifiedIMField(t *testing.T) {
 		t.Error("should be settable")
 	}
 }
+
+// #1741: every ApprovalMsg/DiffConfirmMsg arrival must re-derive option
+// labels from the model's CURRENT language, not LangEnglish wrappers.
+func TestApprovalOptionsFollowLanguage1741(t *testing.T) {
+	var m Model
+	m.language = LangZhCN
+	m, _ = m.handleApprovalMsg(ApprovalMsg{ToolName: "run_command"})
+	if len(m.approvalOptions) == 0 {
+		t.Fatal("expected approval options to be set")
+	}
+	// The Chinese catalog must not be the English one: the first label
+	// differs between defaultApprovalOptionsFor(LangEnglish) and (LangZhCN).
+	en := defaultApprovalOptionsFor(LangEnglish)
+	zh := defaultApprovalOptionsFor(LangZhCN)
+	if len(en) == len(zh) && en[0].label == zh[0].label {
+		t.Skip("catalogs identical for first label - nothing to distinguish")
+	}
+	sawZh := false
+	for _, opt := range m.approvalOptions {
+		if opt.label == zh[0].label {
+			sawZh = true
+			break
+		}
+	}
+	if !sawZh {
+		t.Fatalf("approval options must carry Chinese labels, got: %v", m.approvalOptions)
+	}
+	// Diff-confirm path.
+	m.language = LangZhCN
+	m, _ = m.handleDiffConfirmMsg(DiffConfirmMsg{FilePath: "x.go", DiffText: "+ 1"})
+	if len(m.diffOptions) == 0 {
+		t.Fatal("expected diff options to be set")
+	}
+	enD := diffConfirmOptionsFor(LangEnglish)
+	zhD := diffConfirmOptionsFor(LangZhCN)
+	if len(enD) == len(zhD) && enD[0].label == zhD[0].label {
+		t.Skip("diff catalogs identical for first label")
+	}
+	sawZhD := false
+	for _, opt := range m.diffOptions {
+		if opt.label == zhD[0].label {
+			sawZhD = true
+			break
+		}
+	}
+	if !sawZhD {
+		t.Fatalf("diff options must carry Chinese labels, got: %v", m.diffOptions)
+	}
+}

--- a/internal/tui/update_approval.go
+++ b/internal/tui/update_approval.go
@@ -44,7 +44,11 @@ func (m Model) handleApprovalMsg(msg ApprovalMsg) (Model, tea.Cmd) {
 	}
 	// Agent is requesting approval
 	m.pendingApproval = &msg
-	m.approvalOptions = defaultApprovalOptions()
+	// #1741: defaultApprovalOptions() hardcodes LangEnglish wrappers -
+	// every arrival overwrote the language set at startup, so a zh user
+	// saw English approval labels on EVERY approval until they re-switched
+	// languages. Derive from the model's current language instead.
+	m.approvalOptions = defaultApprovalOptionsFor(m.currentLanguage())
 	m.approvalCursor = 0
 	m.inputBellFired = false
 	// Push to IM if available so user can approve remotely
@@ -73,7 +77,8 @@ func (m Model) handleDiffConfirmMsg(msg DiffConfirmMsg) (Model, tea.Cmd) {
 		return m, m.handleDiffConfirm(true)
 	}
 	m.pendingDiffConfirm = &msg
-	m.diffOptions = diffConfirmOptions()
+	// #1741: same LangEnglish hardcoding as the approval options above.
+	m.diffOptions = diffConfirmOptionsFor(m.currentLanguage())
 	m.diffCursor = 0
 	m.inputBellFired = false
 	// Schedule delayed input bell


### PR DESCRIPTION
## Summary
Closes #1741.

- **Case 1 (Med)**: `handleApprovalMsg`/`handleDiffConfirmMsg` rebuilt option labels via `defaultApprovalOptions()`/`diffConfirmOptions()` — both hardcode `LangEnglish` wrappers. `setLanguage` installs the correct catalog at startup, but every message arrival re-overwrote it: a zh user saw English approval labels on EVERY approval. Both sites now use the `For(m.currentLanguage())` variants.
- The issue's #1559 residue notes (dead recordUndo branch, missing integration test) are cron-2-domain follow-ups, noted in the issue.

## Verification evidence (review)
Isolated worktree: tui suite **10.3s PASS** (-count=1); pin `TestApprovalOptionsFollowLanguage1741` (zh labels present after arrival on both the approval and diff-confirm paths).

Closes #1741

Generated with [ggcode](https://github.com/topcheer/ggcode)
