### PR TITLE
fix(agent): cap-proof spiral snapshots; green resets both (#1726)

### DIFF
--- a/internal/agent/correction_spiral.go
+++ b/internal/agent/correction_spiral.go
@@ -61,6 +61,10 @@ type correctionSpiralState struct {
 
 	// totalCorrections counts how many edit→error pairs we've seen.
 	totalCorrections int
+	// lastWarnedTotal pairs with lastWarnedSeqLen (#1726 case 1): len is
+	// capped at 12, so a snapshot AT the cap could never be exceeded - the
+	// monotonic counter is the second measure that keeps growing.
+	lastWarnedTotal int
 
 	// warningCount limits warnings per run.
 	warningCount int
@@ -127,6 +131,12 @@ func (s *correctionSpiralState) recordVerifyResult(_ string, output string, isEr
 			// every problem WAS fixed. The error sequence clears too.
 			s.pendingEdit = false
 			s.errorSequence = s.errorSequence[:0]
+			// #1726 case 2: green clears the evidence but kept the warning
+			// snapshots - a fresh true spiral needed to exceed the OLD
+			// thresholds to fire, contradicting #1449-B's stated green-slate
+			// intent. Reset both.
+			s.lastWarnedSeqLen = 0
+			s.lastWarnedTotal = 0
 		}
 		return
 	}
@@ -142,7 +152,6 @@ func (s *correctionSpiralState) recordVerifyResult(_ string, output string, isEr
 	if len(s.errorSequence) > 12 {
 		s.errorSequence = s.errorSequence[len(s.errorSequence)-12:]
 	}
-
 	s.pendingEdit = false
 }
 
@@ -167,7 +176,12 @@ func (s *correctionSpiralState) maybeWarn(iteration int) string {
 	// errorSequence; the iteration-distance gate alone re-fired the
 	// CRITICAL on the exact same data while the agent was legitimately
 	// investigating or waiting for clarification.
-	if s.warningCount > 0 && len(s.errorSequence) <= s.lastWarnedSeqLen {
+	// #1726 case 1: len alone deadlocks at the cap - a first warning firing
+	// exactly at len==12 snapshots 12 and every later append is capped back
+	// to 12, so 12<=12 forever suppressed the CRITICAL. New evidence = EITHER
+	// measure grew past its snapshot: uncapped sequences grow len, capped
+	// ones keep growing the monotonic counter. Frozen sequences freeze both.
+	if s.warningCount > 0 && len(s.errorSequence) <= s.lastWarnedSeqLen && s.totalCorrections <= s.lastWarnedTotal {
 		return ""
 	}
 
@@ -205,6 +219,7 @@ func (s *correctionSpiralState) maybeWarn(iteration int) string {
 	s.warningCount++
 	s.lastWarnedAt = iteration
 	s.lastWarnedSeqLen = len(s.errorSequence) // #1538: evidence snapshot for the new-entry gate
+	s.lastWarnedTotal = s.totalCorrections    // #1726: cap-proof second measure
 
 	// Build severity trajectory description
 	labels := make([]string, len(seq))

--- a/internal/agent/correction_spiral_test.go
+++ b/internal/agent/correction_spiral_test.go
@@ -265,3 +265,42 @@ func TestCorrectionSpiralNoNewEvidenceNoRewarn(t *testing.T) {
 		t.Fatal("warning must re-fire after new failure evidence")
 	}
 }
+
+// TestCorrectionSpiralCapSnapshotNotDeadlocked pins #1726 case 1: a first
+// warning firing exactly at len==12 (the cap) must not deadlock the second
+// - every later append caps back to 12, but the monotonic counter keeps
+// growing and counts as new evidence.
+func TestCorrectionSpiralCapSnapshotNotDeadlocked(t *testing.T) {
+	s := newCorrectionSpiralState()
+	// 12 entries with the escalation shape: front < back.
+	s.errorSequence = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	if got := s.maybeWarn(5); got == "" {
+		t.Fatal("first warning must fire at len==12")
+	}
+	// Frozen at the cap: no re-warn.
+	if got := s.maybeWarn(20); got != "" {
+		t.Fatal("frozen sequence must not re-warn")
+	}
+	// New correction: len stays 12 (capped) but the counter grows.
+	s.pendingEdit = true
+	s.recordVerifyResult("go test", "exit status 1", true, 0) // appends+caps+increments the counter
+	if got := s.maybeWarn(20); got == "" {
+		t.Fatal("second warning must fire - counter growth is new evidence (#1726 case 1)")
+	}
+}
+
+// TestCorrectionSpiralGreenResetsSnapshot pins #1726 case 2: a green result
+// clears the evidence AND the warning snapshot - a fresh spiral must not
+// inherit the old threshold.
+func TestCorrectionSpiralGreenResetsSnapshot(t *testing.T) {
+	s := newCorrectionSpiralState()
+	s.errorSequence = []int{1, 2, 3, 4}
+	if got := s.maybeWarn(5); got == "" {
+		t.Fatal("first warning must fire")
+	}
+	s.pendingEdit = true
+	s.recordVerifyResult("go test", "ok", false, 0) // green boundary
+	if s.lastWarnedSeqLen != 0 || s.lastWarnedTotal != 0 {
+		t.Fatalf("green must reset both snapshots, got len=%d total=%d", s.lastWarnedSeqLen, s.lastWarnedTotal)
+	}
+}


### PR DESCRIPTION
## Case 1 (Med-Low)
A first warning firing exactly at len==12 (the cap) snapshotted 12; every later append caps back to 12, so `12<=12` **forever suppressed the CRITICAL** on a genuinely deepening spiral. New evidence now means EITHER measure grew past its snapshot: uncapped sequences grow `len`, capped ones keep growing the monotonic `totalCorrections`; frozen sequences freeze both. (The pure-counter variant broke direct-sequence tests - the dual snapshot is the faithful semantics.)

## Case 2 (Low)
Green cleared the evidence but kept the snapshots - a fresh true spiral had to exceed the OLD thresholds, contradicting #1449-B's green-slate intent. Both reset.

## Verification
Isolated worktree: agent package full PASS (21.4s), gofmt clean. New pins: cap-snapshot deadlock (fires via counter growth through the REAL record path) and green dual reset.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)