### PR TITLE
fix(agent): self-correction gate exposure-neutral wording; session-timeout warnings reach the LLM; drop dead withSessionTimeout (#1492 B/C/F)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1698,8 +1698,13 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 		}
 		a.guidanceBudget.reset() // reset per-turn guidance injection budget
 		// Check session wall-clock timeout: emit user-visible notifications or stop.
-		// Timeout messages are infrastructure notifications for the user only;
-		// they are NOT injected into LLM context to avoid distracting the model.
+		// #1492-C: the 80%/95% warnings must ALSO reach the LLM context -
+		// #611's commit message promised exactly that, but the only consumer
+		// emitted a user-visible event, so the model never knew the budget
+		// was running out and the 100% hard stop cut runs mid-edit/mid-verify
+		// - the very truncation this guardrail exists to prevent. The 100%
+		// stop message stays user-only (the loop ends; injecting a directive
+		// would only confuse the next session turn, #367/#611).
 		if msg := a.sessionTimeout.check(); msg != "" {
 			onEvent(provider.StreamEvent{
 				Type: provider.StreamEventSystem,
@@ -1710,6 +1715,13 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 				sessionTimedOut = true
 				break
 			}
+			a.contextManager.Add(provider.Message{
+				Role: "user",
+				Content: []provider.ContentBlock{{
+					Type: "text",
+					Text: msg,
+				}},
+			})
 		}
 		// Adopt a completed background pre-compact only at an LLM turn
 		// boundary. If it is still running, do not wait; this ChatStream uses

--- a/internal/agent/self_correction_gate.go
+++ b/internal/agent/self_correction_gate.go
@@ -166,10 +166,16 @@ func (s *selfCorrectionGateState) recordRound(newErrors, persistentErrors, resol
 
 // selfCorrectionUnstableGuidance generates the stability warning message.
 // The message uses a "step back" framing (the paper's "verify-first" prompt
-// intervention that reduces EIR from 2% to ~0%).
+// intervention that reduces EIR from ~2% to ~0%).
+// #1492-B: the fingerprint diff cannot distinguish errors a fix INTRODUCED
+// from errors the compiler EXPOSED (Go reports the first error per package
+// and tests fail fast, so fixing A legitimately surfaces B). The old text
+// asserted causation ("Fixes introduce more errors than they resolve") and
+// steered straight to rollback - pushing a converging fix chain (whose
+// rollback point still contains A) backwards. Observation wording only.
 func selfCorrectionUnstableGuidance(rounds, newErrors, resolvedErrors int, ratio float64) string {
 	return fmt.Sprintf(
-		"[self-correction-unstable] %d cycles: %d new errors vs %d resolved (ratio %.1f < %.1f). Fixes introduce more errors than they resolve.",
+		"[self-correction-unstable] %d cycles: %d newly-visible errors vs %d resolved (ratio %.1f < %.1f). Error counts keep growing across fix rounds - some may be newly introduced by recent fixes, others merely exposed now that earlier errors stopped masking them. Step back and re-verify the plan before writing another fix.",
 		rounds, newErrors, resolvedErrors, ratio, scGateStabilityRatio,
 	)
 }

--- a/internal/agent/self_correction_gate_test.go
+++ b/internal/agent/self_correction_gate_test.go
@@ -36,8 +36,12 @@ func TestSelfCorrectionGate_FiresWhenNetNegative(t *testing.T) {
 	if !strings.Contains(msg, "self-correction-unstable") {
 		t.Errorf("warning should contain stability marker, got: %s", msg)
 	}
-	if !strings.Contains(msg, "more errors") {
-		t.Errorf("warning should mention net-negative, got: %s", msg)
+	// #1492-B: observation wording - no causal "fixes introduce" claim.
+	if !strings.Contains(msg, "newly-visible errors") {
+		t.Errorf("warning should use exposure-neutral wording, got: %s", msg)
+	}
+	if strings.Contains(msg, "Fixes introduce more errors") {
+		t.Errorf("warning must not assert causation, got: %s", msg)
 	}
 }
 

--- a/internal/agent/session_timeout.go
+++ b/internal/agent/session_timeout.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -164,15 +163,4 @@ func effectiveTimeout(configured time.Duration, isAutopilot bool) time.Duration 
 // EffectiveSessionTimeout is the exported wrapper for agentruntime wiring.
 func EffectiveSessionTimeout(configured time.Duration, isAutopilot bool) time.Duration {
 	return effectiveTimeout(configured, isAutopilot)
-}
-
-// withSessionTimeout derives a child context that is cancelled when the session
-// wall-clock timeout expires. This provides a hard backstop even if the agent
-// is blocked in an LLM call or a long-running tool execution.
-func (a *Agent) withSessionTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	if a.sessionTimeout == nil || a.sessionTimeout.timeout <= 0 {
-		return ctx, func() {}
-	}
-	timeoutCtx, cancel := context.WithTimeout(ctx, a.sessionTimeout.timeout)
-	return timeoutCtx, cancel
 }

--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -148,10 +148,13 @@ func (a *Agent) asyncVerify(ctx context.Context, runStats *RunStats) {
 		); gateGuidance != "" {
 			errorSummary += "\n\n" + gateGuidance
 
-			// When the self-correction gate fires, provide actionable revert
-			// targets from the last-known-good checkpoint.
+			// When the self-correction gate fires, surface the
+			// last-known-good checkpoint as ONE option, not a directive -
+			// #1492-B: newly-visible errors may be exposure, not
+			// regression, and the checkpoint may still contain the
+			// original error.
 			if checkpointGuidance := a.lastGoodCheckpointGuidance(); checkpointGuidance != "" {
-				errorSummary += "\n\n" + checkpointGuidance
+				errorSummary += "\n\nIf (and only if) inspection shows these errors were CAUSED by recent fixes, the last-known-good checkpoint is available as a fallback:\n" + checkpointGuidance
 			}
 		}
 	}
@@ -727,10 +730,13 @@ func (a *Agent) syncVerifyAndGate(ctx context.Context, runStats *RunStats, retry
 		); gateGuidance != "" {
 			errorSummary += "\n\n" + gateGuidance
 
-			// When the self-correction gate fires, provide actionable revert
-			// targets from the last-known-good checkpoint.
+			// When the self-correction gate fires, surface the
+			// last-known-good checkpoint as ONE option, not a directive -
+			// #1492-B: newly-visible errors may be exposure, not
+			// regression, and the checkpoint may still contain the
+			// original error.
 			if checkpointGuidance := a.lastGoodCheckpointGuidance(); checkpointGuidance != "" {
-				errorSummary += "\n\n" + checkpointGuidance
+				errorSummary += "\n\nIf (and only if) inspection shows these errors were CAUSED by recent fixes, the last-known-good checkpoint is available as a fallback:\n" + checkpointGuidance
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Closes #1492 (remaining cases B/C/F; A/D/E landed in #1916).

- **Case B (Med)**: gate message asserted causation from a fingerprint diff that cannot distinguish introduced vs compiler-exposed errors; rollback guidance was unconditional. Now observation-worded, checkpoint framed as conditional fallback (both verify.go sites).
- **Case C (Med)**: 80%/95% session-timeout warnings now also reach the LLM context (as #611 promised but never wired); the 100% stop message stays user-only.
- **Case F (Low)**: dead `withSessionTimeout` removed. (Wiring it was tried and reverted: ctx cancellation breaks the graceful `ErrSessionTimeout` stop that #611's tests pin - documented in the commit.)

## Verification evidence (review)
Isolated worktree: agent suite **24.9s PASS** (-count=1) including the Issue611 pair; updated gate pin asserts exposure-neutral wording and rejects the causal phrasing.

Closes #1492

Generated with [ggcode](https://github.com/topcheer/ggcode)
