### PR TITLE
fix(provider): idle-read watchdog cuts streams wedged by dropped proxies

### DIFF
--- a/internal/provider/http_transport.go
+++ b/internal/provider/http_transport.go
@@ -18,7 +18,7 @@ const (
 	providerMaxIdleConnsPerHost   = 5
 )
 
-func newProviderHTTPTransport() *http.Transport {
+func newProviderHTTPTransport() http.RoundTripper {
 	base := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   providerDialTimeout,
@@ -44,5 +44,15 @@ func newProviderHTTPTransport() *http.Transport {
 	// Restrict ALPN to HTTP/1.1 only — prevents the server from upgrading
 	// to HTTP/2 even if it advertises it.
 	t.TLSClientConfig.NextProtos = []string{"http/1.1"}
+
+	// Outermost guard: cut off response bodies that stay silent past the
+	// idle-read window (dropped proxy tunnel hang). See
+	// idle_timeout_transport.go. Returns http.RoundTripper so callers cannot
+	// accidentally reach past the guard; none of them currently type-assert
+	// back to *http.Transport.
+	timeout := streamIdleReadTimeoutFromEnv()
+	if timeout > 0 {
+		return &idleTimeoutTransport{base: t, timeout: timeout}
+	}
 	return t
 }

--- a/internal/provider/idle_timeout_transport.go
+++ b/internal/provider/idle_timeout_transport.go
@@ -1,0 +1,114 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+// streamIdleReadTimeout bounds how long a response body may stay silent
+// (no bytes read) before the underlying request context is cancelled and the
+// blocked Read returns. Without it, a dropped proxy connection (proxy accepts
+// the TCP peer, response headers already flushed, then the tunnel dies
+// without FIN/RST) leaves the SSE read loop blocked forever: net/http has no
+// idle/read deadline for body bytes, http.Client.Timeout is deliberately 0
+// for streaming LLM responses, and the agent-layer stall detector is advisory
+// only (it warns, never cancels).
+//
+// 10 minutes is deliberately generous: during long reasoning pauses providers
+// send SSE heartbeats (Anthropic ping events, OpenAI keep-alive comments),
+// but some proxies strip them, so the threshold must tolerate a genuinely
+// quiet - yet alive - stream. A dead tunnel produces no bytes ever, so it is
+// still cut off eventually instead of hanging forever.
+const defaultStreamIdleReadTimeout = 10 * time.Minute
+
+// streamIdleReadTimeoutFromEnv allows overriding the idle-read window via
+// GGCODE_STREAM_IDLE_TIMEOUT (seconds). "0" disables the guard entirely.
+func streamIdleReadTimeoutFromEnv() time.Duration {
+	v := os.Getenv("GGCODE_STREAM_IDLE_TIMEOUT")
+	if v == "" {
+		return defaultStreamIdleReadTimeout
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs < 0 {
+		return defaultStreamIdleReadTimeout
+	}
+	if secs == 0 {
+		return 0 // disabled
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// idleTimeoutTransport wraps a RoundTripper and cancels the request context
+// once the response body stays unreadably silent for the configured window.
+// Cancelling the context is the only portable way to unblock a body Read:
+// it tears down the underlying connection for both HTTP/1.1 and HTTP/2, and
+// does not require reaching the net.Conn (unreachable through the SDK's
+// response body wrappers).
+type idleTimeoutTransport struct {
+	base    http.RoundTripper
+	timeout time.Duration
+}
+
+func (t *idleTimeoutTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.timeout <= 0 {
+		return t.base.RoundTrip(req)
+	}
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+
+	// Start the watchdog BEFORE the request is written, not after headers
+	// arrive: a dropped proxy can also wedge the request-write phase (peer
+	// dead with a full send buffer / zero window — writes never complete,
+	// CLOSE-WAIT with unread recv-Q data, dirty reused idle conn), a phase
+	// where ResponseHeaderTimeout has not started counting yet. One idle
+	// window uniformly covers write + headers + body.
+	timer := time.AfterFunc(t.timeout, cancel)
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		timer.Stop()
+		cancel()
+		return nil, err
+	}
+
+	resp.Body = &idleTimeoutBody{
+		rc:      resp.Body,
+		cancel:  cancel,
+		timer:   timer,
+		timeout: t.timeout,
+	}
+	return resp, nil
+}
+
+// idleTimeoutBody resets the idle deadline on every successful read and
+// stops the watchdog on Close. Read errors (including the watchdog's
+// context.Canceled) are passed through unchanged.
+type idleTimeoutBody struct {
+	rc interface {
+		Read(p []byte) (int, error)
+		Close() error
+	}
+	cancel  context.CancelFunc
+	timer   *time.Timer
+	timeout time.Duration
+}
+
+func (b *idleTimeoutBody) Read(p []byte) (int, error) {
+	n, err := b.rc.Read(p)
+	if err == nil && n > 0 {
+		b.timer.Reset(b.timeout)
+	}
+	if err != nil {
+		b.timer.Stop()
+	}
+	return n, err
+}
+
+func (b *idleTimeoutBody) Close() error {
+	b.timer.Stop()
+	b.cancel()
+	return b.rc.Close()
+}

--- a/internal/provider/idle_timeout_transport_test.go
+++ b/internal/provider/idle_timeout_transport_test.go
@@ -1,0 +1,231 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// blockingBody simulates a dropped proxy tunnel: reads block forever and
+// never return bytes (the connection died without FIN/RST).
+type blockingBody struct {
+	closed chan struct{}
+}
+
+func newBlockingBody() *blockingBody { return &blockingBody{closed: make(chan struct{})} }
+
+func (b *blockingBody) Read(p []byte) (int, error) {
+	<-b.closed // block forever until closed
+	return 0, io.EOF
+}
+
+func (b *blockingBody) Close() error {
+	select {
+	case <-b.closed:
+	default:
+		close(b.closed)
+	}
+	return nil
+}
+
+// stubRoundTripper returns a canned response whose body is injected.
+type stubRoundTripper struct {
+	status    int
+	body      io.ReadCloser
+	gotCtx    context.Context
+	closeSeen bool
+}
+
+func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.gotCtx = req.Context()
+	return &http.Response{
+		StatusCode: s.status,
+		Header:     make(http.Header),
+		Body:       s.body,
+		Request:    req,
+	}, nil
+}
+
+func TestIdleTimeoutTransportCutsSilentBody(t *testing.T) {
+	// The body mimics real net/http semantics: a Read blocked on a dead
+	// connection returns once the request context is cancelled (transport
+	// tears down the conn). This is the guarantee idleTimeoutTransport
+	// relies on to unblock the SSE read loop.
+	stub := &ctxBodyTransport{}
+	tr := &idleTimeoutTransport{base: stub, timeout: 80 * time.Millisecond}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "http://example.test/v1", nil)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, rerr := resp.Body.Read(make([]byte, 16))
+		errCh <- rerr
+	}()
+
+	select {
+	case rerr := <-errCh:
+		if rerr == nil {
+			t.Fatal("expected error from blocked Read after idle timeout, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Read still blocked after idle deadline - watchdog did not cancel")
+	}
+
+	select {
+	case <-stub.gotCtx.Done():
+	default:
+		t.Fatal("request context was not cancelled by the watchdog")
+	}
+}
+
+// ctxBodyTransport returns a response whose body blocks until the request
+// context dies - the net/http behavior for a wedged stream connection.
+type ctxBodyTransport struct{ gotCtx context.Context }
+
+func (s *ctxBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.gotCtx = req.Context()
+	return &http.Response{
+		StatusCode: 200,
+		Header:     make(http.Header),
+		Body:       ctxBody{ctx: req.Context()},
+		Request:    req,
+	}, nil
+}
+
+type ctxBody struct{ ctx context.Context }
+
+func (b ctxBody) Read(p []byte) (int, error) {
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (b ctxBody) Close() error { return nil }
+
+func TestIdleTimeoutBodyResetsOnData(t *testing.T) {
+	// Feed data slowly: each chunk arrives well within the idle window, so
+	// the watchdog keeps resetting and the stream completes normally.
+	slow := io.NopCloser(io.MultiReader(
+		bytes.NewReader([]byte("data: chunk1\n\n")),
+		&delayedReader{d: 150 * time.Millisecond, r: bytes.NewReader([]byte("data: chunk2\n\n"))},
+	))
+	stub := &stubRoundTripper{status: 200, body: slow}
+	tr := &idleTimeoutTransport{base: stub, timeout: 300 * time.Millisecond}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "http://example.test/v1", nil)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+
+	all, rerr := io.ReadAll(resp.Body)
+	if rerr != nil {
+		t.Fatalf("ReadAll: %v (idle watchdog fired despite live data)", rerr)
+	}
+	if !bytes.Contains(all, []byte("chunk2")) {
+		t.Fatalf("missing second chunk: %q", all)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestIdleTimeoutTransportCutsBlockedRoundTrip(t *testing.T) {
+	// Simulates the request-write wedge from the proxy-hang postmortem:
+	// RoundTrip never returns (write to a dead peer / waiting for response
+	// headers on a CLOSE-WAIT conn). net/http aborts such a request once
+	// its context is cancelled, which is what the stub models.
+	stub := &ctxBlockedRoundTripper{}
+	tr := &idleTimeoutTransport{base: stub, timeout: 80 * time.Millisecond}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "http://example.test/v1", nil)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := tr.RoundTrip(req)
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error from blocked RoundTrip after idle timeout, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RoundTrip still blocked - watchdog did not cover the write/headers phase")
+	}
+}
+
+// ctxBlockedRoundTripper blocks inside RoundTrip until the request context
+// is cancelled, mirroring net/http's abort-on-ctx-done behavior for wedged
+// request writes.
+type ctxBlockedRoundTripper struct{}
+
+func (s *ctxBlockedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+func TestIdleTimeoutTransportDisabled(t *testing.T) {
+	// timeout <= 0 must bypass the wrapper entirely.
+	stub := &stubRoundTripper{status: 200, body: newBlockingBody()}
+	tr := &idleTimeoutTransport{base: stub, timeout: 0}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "http://example.test/v1", nil)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	if _, isWrapped := resp.Body.(*idleTimeoutBody); isWrapped {
+		t.Fatal("body should not be wrapped when timeout is disabled")
+	}
+}
+
+// delayedReader pauses before delegating the first Read, simulating an SSE
+// keep-alive gap shorter than the idle window.
+type delayedReader struct {
+	d      time.Duration
+	r      io.Reader
+	waited bool
+}
+
+func (d *delayedReader) Read(p []byte) (int, error) {
+	if !d.waited {
+		time.Sleep(d.d)
+		d.waited = true
+	}
+	return d.r.Read(p)
+}
+
+func TestStreamIdleReadTimeoutFromEnv(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("GGCODE_STREAM_IDLE_TIMEOUT", "")
+		if got := streamIdleReadTimeoutFromEnv(); got != defaultStreamIdleReadTimeout {
+			t.Fatalf("default: got %v", got)
+		}
+	})
+	t.Run("override", func(t *testing.T) {
+		t.Setenv("GGCODE_STREAM_IDLE_TIMEOUT", "42")
+		if got := streamIdleReadTimeoutFromEnv(); got != 42*time.Second {
+			t.Fatalf("override: got %v", got)
+		}
+	})
+	t.Run("disabled", func(t *testing.T) {
+		t.Setenv("GGCODE_STREAM_IDLE_TIMEOUT", "0")
+		if got := streamIdleReadTimeoutFromEnv(); got != 0 {
+			t.Fatalf("disabled: got %v", got)
+		}
+	})
+	t.Run("garbage falls back to default", func(t *testing.T) {
+		t.Setenv("GGCODE_STREAM_IDLE_TIMEOUT", "not-a-number")
+		if got := streamIdleReadTimeoutFromEnv(); got != defaultStreamIdleReadTimeout {
+			t.Fatalf("garbage: got %v", got)
+		}
+	})
+}

--- a/internal/provider/providers_coverage_test.go
+++ b/internal/provider/providers_coverage_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -123,14 +124,29 @@ func TestNewProviderHTTPTransportUsesLLMHeaderTimeout(t *testing.T) {
 	if tr == nil {
 		t.Fatal("expected non-nil transport")
 	}
-	if tr.DialContext == nil {
+	// The transport is wrapped by the idle-timeout stream guard; unwrap to
+	// the base *http.Transport to verify the tuned LLM timeouts survive.
+	var inner *http.Transport
+	switch v := tr.(type) {
+	case *idleTimeoutTransport:
+		base, ok := v.base.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected *http.Transport under idleTimeoutTransport, got %T", v.base)
+		}
+		inner = base
+	case *http.Transport:
+		inner = v
+	default:
+		t.Fatalf("unexpected transport type %T", tr)
+	}
+	if inner.DialContext == nil {
 		t.Fatal("expected DialContext timeout to be configured")
 	}
-	if tr.TLSHandshakeTimeout != 10*time.Second {
-		t.Fatalf("expected TLS handshake timeout 10s, got %v", tr.TLSHandshakeTimeout)
+	if inner.TLSHandshakeTimeout != 10*time.Second {
+		t.Fatalf("expected TLS handshake timeout 10s, got %v", inner.TLSHandshakeTimeout)
 	}
-	if tr.ResponseHeaderTimeout != 120*time.Second {
-		t.Fatalf("expected response header timeout 120s, got %v", tr.ResponseHeaderTimeout)
+	if inner.ResponseHeaderTimeout != 120*time.Second {
+		t.Fatalf("expected response header timeout 120s, got %v", inner.ResponseHeaderTimeout)
 	}
 }
 

--- a/internal/tool/ghostty.go
+++ b/internal/tool/ghostty.go
@@ -118,7 +118,7 @@ func (g *GhosttyTool) Execute(ctx context.Context, input json.RawMessage) (Resul
 
 	// Status doesn't require Ghostty to be running — it reports detection.
 	if action == "status" {
-		return g.executeStatus(ctx, ), nil
+		return g.executeStatus(ctx), nil
 	}
 
 	if !ghosttyAvailable() {
@@ -127,7 +127,7 @@ func (g *GhosttyTool) Execute(ctx context.Context, input json.RawMessage) (Resul
 
 	switch action {
 	case "list":
-		return g.executeList(ctx, ), nil
+		return g.executeList(ctx), nil
 	case "split":
 		return g.executeSplit(ctx, args.TerminalID, args.Direction, args.Size, args.Command, args.WorkingDir), nil
 	case "new_tab":

--- a/internal/tool/ghostty_darwin.go
+++ b/internal/tool/ghostty_darwin.go
@@ -143,7 +143,7 @@ func ghosttyBinaryPath() string {
 
 // ── Action implementations (macOS) ──────────────────────────────────────────
 
-func (g *GhosttyTool) executeStatus(ctx context.Context, ) Result {
+func (g *GhosttyTool) executeStatus(ctx context.Context) Result {
 	if !ghosttyAvailable() {
 		return Result{Content: "ghostty: not detected (TERM_PROGRAM != ghostty)"}
 	}
@@ -173,7 +173,7 @@ func (g *GhosttyTool) executeStatus(ctx context.Context, ) Result {
 	return Result{Content: b.String()}
 }
 
-func (g *GhosttyTool) executeList(ctx context.Context, ) Result {
+func (g *GhosttyTool) executeList(ctx context.Context) Result {
 	script := `
 tell application "Ghostty"
 	set output to ""

--- a/internal/tool/ghostty_other.go
+++ b/internal/tool/ghostty_other.go
@@ -13,14 +13,14 @@ import (
 
 func ghosttyBinaryPath() string { return "" }
 
-func (g *GhosttyTool) executeStatus(ctx context.Context, ) Result {
+func (g *GhosttyTool) executeStatus(ctx context.Context) Result {
 	if !ghosttyAvailable() {
 		return Result{Content: "ghostty: not detected (TERM_PROGRAM != ghostty)"}
 	}
 	return Result{Content: fmt.Sprintf("ghostty: detected but platform %s/%s is not supported (only darwin and linux)", runtime.GOOS, runtime.GOARCH)}
 }
 
-func (g *GhosttyTool) executeList(ctx context.Context, ) Result {
+func (g *GhosttyTool) executeList(ctx context.Context) Result {
 	return unsupportedResult()
 }
 


### PR DESCRIPTION
## Problem (postmortem v1.3.236)

LAN proxy (`192.168.31.16:7890`) dropped mid-stream without FIN/RST reaching ggcode. Goroutine dump: agent goroutine in IO-wait on a dead socket for **33 minutes**, TUI event loop wedged the whole time (`timeout: 0s`).

Why nothing else catches it:
- `http.Client.Timeout` is deliberately 0 for SSE (a total timeout would truncate long answers)
- net/http has **no per-byte idle deadline** for response bodies
- TCP keepalive cannot see past the healthy LAN hop to the proxy (probe gets ACKed by the proxy's own TCP stack)
- `ResponseHeaderTimeout` only covers the header wait
- agent-layer stall detector is advisory-only (warns, never cancels)

## Fix

`idleTimeoutTransport` wraps the provider transport outermost; one idle window (**default 10 min**, env `GGCODE_STREAM_IDLE_TIMEOUT` seconds, `0` disables) guards the **whole request lifecycle**:

1. watchdog starts **before** the request is written — the postmortem shows the wedge can sit in the write phase too (CLOSE-WAIT, unread recv-Q, zero window), which header timeout never covers
2. every successful body Read resets the timer — live-but-quiet streams (long reasoning, proxied heartbeats) are never cut
3. on lapse: cancel request context → transport tears the connection → blocked Read/RoundTrip return → normal error/retry path

Wired once in `newProviderHTTPTransport`; openai / anthropic / gemini / copilot all inherit. Return type widened to `http.RoundTripper`.

## Tests (6, all green in isolated worktree)

- blocked body Read cut in ~80ms (stub models real net/http cancel semantics)
- blocked RoundTrip (write phase) cut
- slow-but-live stream (chunks 150ms apart, window 300ms) completes untouched
- disabled path bypasses wrapping
- env override parsing (default/override/0/garbage)
- transport tuning (dial/TLS/header timeouts) survives the wrap

Includes a drive-by gofmt of 3 ghostty files that the pre-push gate rejects main-wide (formatting only).

## Out of scope (separate PRs)

- TUI eventLoop sync-join on agent batches (postmortem clue 2) — this fix bounds the freeze at the idle window, does not eliminate it
- MCP child stdout pipe backpressure freeze (postmortem clue 3)

Co-Authored-By: ggcode <noreply@ggcode.dev>