### PR TITLE
fix(agent,tui): YAML list block-scalar edge shapes; extpane DCS/APC/PM stripped (#1721)

### DIFF
--- a/internal/agent/config_syntax_check.go
+++ b/internal/agent/config_syntax_check.go
@@ -273,14 +273,31 @@ func findYAMLDuplicateKeys(content string) []string {
 			// #1534: the list item can ALSO open the scalar keylessly (`- |`,
 			// `- >`, `- |2` - Argo/Flux/k8s shapes). Without this the shell
 			// body's same-prefixed lines were read as duplicate mapping keys.
-			if ci := strings.Index(trimmed, ":"); ci > 0 {
-				if isYAMLBlockScalarHeader(strings.TrimSpace(trimmed[ci+1:])) {
+			// #1721 case 2: first-colon Index hits a colon INSIDE a quoted
+			// key (`- "host:port": |`) - the mapping path skips quoted keys,
+			// this list branch never did. Strip a leading marker and quote
+			// pair before colon-hunting.
+			listBody := strings.TrimSpace(strings.TrimPrefix(trimmed, "-"))
+			if strings.HasPrefix(listBody, `"`) {
+				if end := strings.Index(listBody[1:], `"`); end >= 0 {
+					listBody = strings.TrimSpace(listBody[end+2:])
+				}
+			}
+			if ci := strings.Index(listBody, ":"); ci > 0 {
+				if isYAMLBlockScalarHeader(strings.TrimSpace(listBody[ci+1:])) {
 					inBlockScalar = true
 					blockIndent = indent
 				}
 			} else if isYAMLBlockScalarHeader(strings.TrimSpace(trimmed[1:])) {
 				inBlockScalar = true
 				blockIndent = indent
+			} else if strings.HasPrefix(listBody, "-") {
+				// #1721 case 1: `- - |` (list of lists of block scalars) -
+				// strip the inner marker and re-check the remainder.
+				if isYAMLBlockScalarHeader(strings.TrimSpace(strings.TrimPrefix(listBody, "-"))) {
+					inBlockScalar = true
+					blockIndent = indent
+				}
 			}
 			continue
 		}

--- a/internal/tui/extpane/format.go
+++ b/internal/tui/extpane/format.go
@@ -87,9 +87,11 @@ func stripAnsi(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	const (
-		statePlain  = iota
-		stateEsc    // saw ESC, deciding CSI vs two-byte
-		stateCsi    // inside CSI [... final @-~
+		statePlain = iota
+		stateEsc   // saw ESC, deciding CSI vs two-byte
+		stateCsi   // inside CSI [... final @-~
+		stateDcs   // #1721: DCS/APC/PM passthrough consumer
+		stateDcsEsc
 		stateOsc    // #1414-B: inside OSC ] ... BEL/ST
 		stateOscEsc // OSC saw ESC: ST (\) ends, else stay
 	)
@@ -112,6 +114,13 @@ func stripAnsi(s string) string {
 				// hyperlink URLs) plus BEL leaked verbatim into the
 				// preview pane as invisible control bytes.
 				st = stateOsc
+			} else if c == 'P' || c == '_' || c == '^' {
+				// #1721 case 3: DCS (P), APC (_), PM (^) - the same leak
+				// family #1414-B fixed for OSC, but the note only patched
+				// ']'. A tmux wrap-passthrough ESC P tmux;... leaked its
+				// second byte, the DCS body AND the trailing ST backslash
+				// into the preview. Consume until ST (ESC \).
+				st = stateDcs
 			} else {
 				st = statePlain // two-byte ESC sequence (e.g. \x1bM)
 				b.WriteRune(c)
@@ -119,6 +128,17 @@ func stripAnsi(s string) string {
 		case stateCsi:
 			if c >= 0x40 && c <= 0x7E {
 				st = statePlain
+			}
+		case stateDcs:
+			// #1721 case 3: consume the string body; ST (ESC \) ends it.
+			if c == 0x1b {
+				st = stateDcsEsc
+			}
+		case stateDcsEsc:
+			if c == '\\' {
+				st = statePlain // ST complete - sequence fully consumed
+			} else {
+				st = stateDcs // stray ESC inside the body keeps consuming
 			}
 		case stateOsc:
 			if c == '\x07' { // BEL terminator


### PR DESCRIPTION
Case 1 (Low): `- - |` (list of lists of block scalars) never engaged the block - body misread as duplicate keys (Critical, suppressing the real Unmarshal). Inner marker stripped, remainder re-checked.

Case 2 (Low-Med): `- "host:port": |` - first-colon Index hit the colon INSIDE the quoted key; the mapping path skips quoted keys, the list branch never did. Quote pair stripped before colon-hunting.

Case 3 (Low-Med): #1414-B fixed the OSC leak but only patched `]\' - DCS (P), APC (_), PM (^) fell to the two-byte branch, leaking tmux wrap-passthrough bodies (`ESC P tmux;...`) and the trailing ST backslash into the preview. A stateDcs consumer eats until ST.

Isolated worktree: agent+tui packages full PASS (21.9s/12.4s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)