### PR TITLE
fix(tui): translate the 4 Chinese leftovers in the German catalog; CJK scan for all non-CJK catalogs (#1725)

### DIFF
--- a/internal/tui/i18n_de.go
+++ b/internal/tui/i18n_de.go
@@ -515,13 +515,13 @@ func deCatalog(key string) string {
 	case "panel.model.refresh.builtin_loaded":
 		return "Eingebaute Modelle geladen."
 	case "panel.model.vendor_not_found":
-		return "厂商未找到"
+		return "Anbieter nicht gefunden"
 	case "panel.model.endpoint_not_found":
-		return "端点未找到"
+		return "Endpunkt nicht gefunden"
 	case "panel.model.save_failed":
-		return "保存失败：%s"
+		return "Speichern fehlgeschlagen: %s"
 	case "panel.model.endpoint_save_failed":
-		return "端点配置保存失败：%s"
+		return "Speichern der Endpunktkonfiguration fehlgeschlagen: %s"
 
 	// --- Commands ---
 	case "command.unknown":

--- a/internal/tui/i18n_test.go
+++ b/internal/tui/i18n_test.go
@@ -1,0 +1,44 @@
+package tui
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// #1725: machine-translation leftovers put Chinese strings in the German
+// catalog ("厂商未找到" shown to de users). Guard the whole family: every
+// non-zh catalog file must carry no CJK runes inside its return literals.
+func TestNonZhCatalogsContainNoCJK1725(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Skip("cannot read package dir:", err)
+	}
+	cjk := regexp.MustCompile(`[\x{4e00}-\x{9fff}\x{3000}-\x{303f}\x{ff00}-\x{ffef}]`)
+	ret := regexp.MustCompile(`return\s+"[^"]*"`)
+	bad := 0
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "i18n_") || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.Contains(name, "zh") || strings.Contains(name, "_ja") || strings.Contains(name, "_ko") {
+			// zh-CN/zh-TW/Japanese/Korean are CJK languages by design.
+			continue
+		}
+		data, err := os.ReadFile(name)
+		if err != nil {
+			continue
+		}
+		for _, m := range ret.FindAllStringSubmatch(string(data), -1) {
+			if cjk.MatchString(m[0]) {
+				t.Errorf("%s: CJK in return literal: %s", name, m[0])
+				bad++
+			}
+		}
+	}
+	if bad == 0 && testing.Short() {
+		t.Log("no CJK literals found in non-zh catalogs")
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1725 (case 1; case 2 noted).

- **Case 1 (Med-High, #1521 leftover family)**: deCatalog returned Chinese for the 4 model-panel error keys — German users saw "厂商未找到" on every save failure. Now German, matching the existing refresh.save_failed wording. New pin `TestNonZhCatalogsContainNoCJK1725` scans every non-CJK catalog's return literals for CJK runes — the family-level guard the issue requested.
- **Case 2 (Low-Med)**: module-catalog shadowing — maintenance trap only, no user-visible error (effective texts all correct) — noted in the issue, not fixed.

## Verification evidence (review)
Isolated worktree: tui suite **10.7s PASS** (-count=1); the scan pin passes clean post-fix and demonstrated live catches during development (it flagged all four leftovers before the edit, and correctly excluded ja/ko CJK catalogs).

Closes #1725

Generated with [ggcode](https://github.com/topcheer/ggcode)
