### PR TITLE
fix(tool,commands,agent): search_files pathspec parity; rune-count bounds; truncation marker; locked RMW; lsp_rename pin (#1702)

### DIFF
--- a/internal/agent/transient_retry_test.go
+++ b/internal/agent/transient_retry_test.go
@@ -66,7 +66,8 @@ func TestIsRetryableTool(t *testing.T) {
 		}
 	}
 
-	nonRetryable := []string{"edit_file", "write_file", "git_commit", "run_command", "git_add", "git_stash"}
+	nonRetryable := []string{"edit_file", "write_file", "git_commit", "run_command", "git_add", "git_stash",
+		"lsp_rename" /* #1702-4: #1514 moved lsp_rename INTO the retryable set with no test pinning it */}
 	for _, name := range nonRetryable {
 		if isRetryableTool(name) {
 			t.Errorf("isRetryableTool(%q) = true, want false", name)

--- a/internal/commands/disabled_state.go
+++ b/internal/commands/disabled_state.go
@@ -29,10 +29,12 @@ func loadDisabledSet() map[string]bool {
 	}
 	disabledMu.RUnlock()
 
-	disabledMu.Lock()
-	defer disabledMu.Unlock()
+	return loadDisabledSetLocked()
+}
 
-	// Double-check after acquiring write lock
+// loadDisabledSetLocked populates the disabled-set cache from disk.
+// Caller MUST hold disabledMu for writing.
+func loadDisabledSetLocked() map[string]bool {
 	if disabledCacheOK {
 		return disabledCache
 	}
@@ -106,7 +108,16 @@ func ApplyDisabledState(cmds map[string]*Command) {
 
 // PersistEnabledState saves the enabled/disabled state for a single skill.
 func PersistEnabledState(name string, enabled bool) {
-	cached := loadDisabledSet()
+	// #1702 case 5: the read-copy-write ran OUTSIDE any lock spanning the
+	// whole RMW - two concurrent calls both copied the same cache, each
+	// dropped the other's change (lost update), and the interleaved disk
+	// writes made the file nondeterministic. Serialize the full RMW.
+	disabledMu.Lock()
+	defer disabledMu.Unlock()
+	cached := disabledCache
+	if !disabledCacheOK {
+		cached = loadDisabledSetLocked()
+	}
 	// Copy the cached map before mutating to avoid concurrent map access
 	// with readers that hold the same map pointer from the cache.
 	disabled := make(map[string]bool, len(cached)+1)
@@ -120,10 +131,9 @@ func PersistEnabledState(name string, enabled bool) {
 	}
 	_ = saveDisabledSet(disabled)
 
-	// Update cache
-	disabledMu.Lock()
+	// Update cache (lock already held)
 	disabledCache = disabled
-	disabledMu.Unlock()
+	disabledCacheOK = true
 }
 
 // InvalidateDisabledCache clears the in-memory cache so next load reads from disk.

--- a/internal/tool/schema_validation.go
+++ b/internal/tool/schema_validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // ValidateSchemaConstraints checks tool arguments against the JSON Schema beyond
@@ -126,11 +127,16 @@ func validateField(fieldName string, fieldSchema, val json.RawMessage) string {
 		if numType.Type == "string" {
 			var s string
 			if err := json.Unmarshal(val, &s); err == nil {
-				if spec.MinLength != nil && len(s) < *spec.MinLength {
-					return fmt.Sprintf("parameter %q must be at least %d characters, got %d", fieldName, *spec.MinLength, len(s))
+				// #1702 case 3: count RUNES, not bytes - 4 CJK chars are
+				// 12 bytes and sailed past minLength=10 while the error
+				// message said "characters". utf8.RuneCountInString is the
+				// metric the message (and JSON Schema) promise.
+				rlen := utf8.RuneCountInString(s)
+				if spec.MinLength != nil && rlen < *spec.MinLength {
+					return fmt.Sprintf("parameter %q must be at least %d characters, got %d", fieldName, *spec.MinLength, rlen)
 				}
-				if spec.MaxLength != nil && len(s) > *spec.MaxLength {
-					return fmt.Sprintf("parameter %q must be at most %d characters, got %d", fieldName, *spec.MaxLength, len(s))
+				if spec.MaxLength != nil && rlen > *spec.MaxLength {
+					return fmt.Sprintf("parameter %q must be at most %d characters, got %d", fieldName, *spec.MaxLength, rlen)
 				}
 			}
 		}

--- a/internal/tool/search_files.go
+++ b/internal/tool/search_files.go
@@ -131,6 +131,25 @@ func (t SearchFiles) gitGrepSearch(ctx context.Context, args struct {
 		if len(out) == 0 {
 			return nil, 0, false // pattern rejected or git failure: use fallback
 		}
+		// #1702 case 2: git died non-1 (signal/SIGPIPE 141) with partial
+		// stdout. The old code parsed the partial output as COMPLETE -
+		// totalMatches silently underestimated with no truncation marker.
+		// Keep the partial results but tag the output.
+		lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+		results := make([]string, 0, args.MaxResults)
+		total := 0
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			total++
+			if len(results) < args.MaxResults {
+				results = append(results, line)
+			}
+		}
+		results = append(results, fmt.Sprintf("[truncated: git grep exited non-zero (%v) with partial output; %d matches shown may undercount]", err, total))
+		return results, total, true
 	}
 
 	lines := strings.Split(string(out), "\n")
@@ -182,11 +201,23 @@ func (t SearchFiles) parallelSearch(ctx context.Context, args struct {
 			}
 		}
 
-		// Apply include glob filter
+		// Apply include glob filter.
+		// #1702 case 1: the git fast path passes IncludePattern to git
+		// grep as a PATHSPEC (arbitrary-depth: "src/*.go" matches
+		// src/deep/nested/file.go via fnmatch semantics) while the old
+		// fallback matched the BASENAME only - the same argument silently
+		// returned zero results (with a misleading "check the pattern"
+		// hint) depending on git availability. Match basename OR the
+		// repo-relative slash path so the fallback accepts a superset of
+		// the pathspec forms (documented include_pattern semantics).
 		if args.IncludePattern != "" {
 			matched, err := filepath.Match(args.IncludePattern, d.Name())
 			if err != nil || !matched {
-				return nil
+				// Pathspec-style: like git, `*` also crosses path
+				// separators when matching the repo-relative path.
+				if !globMatchCrossSlash(args.IncludePattern, filepath.ToSlash(relPath)) {
+					return nil
+				}
 			}
 		}
 
@@ -313,4 +344,48 @@ func formatResults(results []string, totalMatches int) Result {
 		sb.WriteByte('\n')
 	}
 	return Result{Content: sb.String()}
+}
+
+// globMatchCrossSlash matches a glob where `*` and `?` cross path
+// separators (git pathspec / fnmatch semantics), unlike filepath.Match.
+// Malformed patterns (e.g. unterminated character class) simply do not
+// match. #1702 case 1.
+func globMatchCrossSlash(pattern, name string) bool {
+	var sb strings.Builder
+	sb.WriteString("^")
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		switch c {
+		case '*':
+			sb.WriteString(".*")
+		case '?':
+			sb.WriteString(".")
+		case '[':
+			j := i + 1
+			if j < len(pattern) && (pattern[j] == '!' || pattern[j] == '^') {
+				j++
+			}
+			if j < len(pattern) && pattern[j] == ']' {
+				j++
+			}
+			for j < len(pattern) && pattern[j] != ']' {
+				j++
+			}
+			if j >= len(pattern) {
+				return false // unterminated class
+			}
+			seg := pattern[i : j+1]
+			seg = strings.Replace(seg, "[!", "[^", 1)
+			sb.WriteString(seg)
+			i = j
+		default:
+			sb.WriteString(regexp.QuoteMeta(string(c)))
+		}
+	}
+	sb.WriteString("$")
+	re, err := regexp.Compile(sb.String())
+	if err != nil {
+		return false
+	}
+	return re.MatchString(name)
 }

--- a/internal/tool/search_files_test.go
+++ b/internal/tool/search_files_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -145,4 +146,31 @@ func TestSearchFilesMaxResults(t *testing.T) {
 	}
 	// Should return limited results
 	t.Logf("result: %s", result.Content)
+}
+
+// TestSearchFilesIncludePatternDeepPath1702: the git fast path treats
+// include_pattern as a pathspec (src/*.go matches src/deep/f.go); the
+// fallback used basename-only matching, so the SAME argument silently
+// returned zero results when git was unavailable. The fallback now
+// accepts the repo-relative path too. Run in a directory that is NOT a
+// git repo to force the fallback path.
+func TestSearchFilesIncludePatternDeepPath1702(t *testing.T) {
+	dir := t.TempDir()
+	deep := filepath.Join(dir, "src", "nested")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deep, "f.go"), []byte("needleXYZ\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: t.TempDir is outside any git repo work tree.
+	s := SearchFiles{}
+	input, _ := json.Marshal(map[string]interface{}{"pattern": "needleXYZ", "directory": dir, "include_pattern": "src/*.go", "max_results": 10})
+	r, err := s.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(r.Content, "no matches") || !strings.Contains(r.Content, "f.go") {
+		t.Fatalf("fallback path must match deep pathspec forms, got: %s", r.Content)
+	}
 }


### PR DESCRIPTION
## Summary
Closes #1702 (all five Low cases fixed).

1. **Case 1**: include_pattern was a pathspec on the git path but basename-only on the no-git fallback — same argument, silently different results. Fallback now matches repo-relative paths with pathspec semantics (globMatchCrossSlash).
2. **Case 2**: non-1 git exit (SIGPIPE) with partial stdout parsed as complete — now tagged `[truncated: ...]`.
3. **Case 3**: MinLength/MaxLength counted bytes, message says characters — now RuneCountInString.
4. **Case 4**: lsp_rename non-retryable status (#1514) pinned in TestIsRetryableTool.
5. **Case 5**: PersistEnabledState RMW serialized under disabledMu (lost-update + interleaved-write window closed).

## Verification evidence (review)
Isolated worktree: tool 33.7s / commands 0.3s / agent 23.1s suites PASS. Pin TestSearchFilesIncludePatternDeepPath1702 forces the no-git fallback (t.TempDir outside any repo) and asserts `src/*.go` matches `src/nested/f.go` — it failed live against the basename-only code and passes with pathspec parity. Note: gofmt flags internal/tool/ghostty*.go — pre-existing at HEAD (931913ff), untouched.

Closes #1702

Generated with [ggcode](https://github.com/topcheer/ggcode)
