### PR TITLE
fix(agent): detector cooldown arithmetic - honest single-shot, adjacent-iter cooldown, per-mode thermal clocks (#1855)

### DIFF
--- a/internal/agent/attention_fragment.go
+++ b/internal/agent/attention_fragment.go
@@ -60,8 +60,6 @@ type attentionFragmentState struct {
 	windowSize int
 	// warnCount caps warnings per run.
 	warnCount int
-	// firedAt tracks the call count when last warned, to space out re-warnings.
-	firedAt int
 	// totalCalls counts all recorded calls.
 	totalCalls int
 }
@@ -75,9 +73,15 @@ const (
 	// window before the detector fires (avoids firing on 2-dir alternation).
 	afMinUniqueDirs = 4
 	// afMaxWarnings caps how many times this detector warns per run.
+	// #1855 case 1: a guidance-noise cleanup batch lowered this from 2
+	// to 1 but left afRefireGap and firedAt behind as dead code (the
+	// warnCount>=max return made them unreachable), so the code still
+	// LOOKED multi-shot while the implementation memory documented
+	// "2x/run, 8-call refire gap". Single-shot is the intended behavior
+	// (see TestAttentionFragment_MaxWarnings); the dead refire machinery
+	// is removed to make the semantics honest. A fresh warning is
+	// possible only after reset() (new run / compaction).
 	afMaxWarnings = 1
-	// afRefireGap requires this many new calls before re-warning.
-	afRefireGap = 8
 )
 
 func newAttentionFragmentState() *attentionFragmentState {
@@ -189,10 +193,6 @@ func (s *attentionFragmentState) analyze() string {
 	if len(s.recentDirs) < s.windowSize {
 		return ""
 	}
-	// Space out re-warnings.
-	if s.firedAt > 0 && s.totalCalls-s.firedAt < afRefireGap {
-		return ""
-	}
 
 	// Count switches (consecutive pairs with different dirs).
 	switches := 0
@@ -217,7 +217,6 @@ func (s *attentionFragmentState) analyze() string {
 	}
 
 	s.warnCount++
-	s.firedAt = s.totalCalls
 
 	debug.Log("agent", "attention fragmentation detected: density=%.2f, unique_dirs=%d", switchDensity, len(uniqueDirs))
 

--- a/internal/agent/attention_fragment_test.go
+++ b/internal/agent/attention_fragment_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -224,5 +225,35 @@ func TestAttentionFragment_MultiFileRead(t *testing.T) {
 	msg := s.analyze()
 	if msg == "" {
 		t.Fatal("expected fragmentation warning for multi_file_read across dirs")
+	}
+}
+
+// #1855 case 1: the guidance-noise cleanup set max=1 but left the
+// refire-gap/firedAt machinery behind as unreachable dead code. The
+// machinery is now REMOVED - this pins the honest single-shot semantics
+// (one warning per run; reset() re-arms).
+func TestAttentionFragmentSingleShotHonest1855(t *testing.T) {
+	s := newAttentionFragmentState()
+	for i := 0; i < s.windowSize; i++ {
+		s.recordToolCall("read_file", map[string]interface{}{"path": fmt.Sprintf("/dir%d/f.go", i%4)})
+	}
+	if m := s.analyze(); m == "" {
+		t.Fatal("first warning expected")
+	}
+	if s.warnCount != 1 {
+		t.Fatalf("warnCount = %d, want 1", s.warnCount)
+	}
+	// Sustained fragmentation stays silent (single-shot).
+	for i := 0; i < s.windowSize*3; i++ {
+		s.recordToolCall("read_file", map[string]interface{}{"path": fmt.Sprintf("/more%d/f.go", i%4)})
+	}
+	if m := s.analyze(); m != "" {
+		t.Fatalf("single-shot violated: %s", m)
+	}
+	// reset() clears the window but deliberately keeps warnCount (per-run
+	// persistence - see reset()); re-arm is a NEW state for the next run.
+	s.reset()
+	if s.warnCount != 1 {
+		t.Fatalf("warnCount must persist across window reset, got %d", s.warnCount)
 	}
 }

--- a/internal/agent/tool_result_redundancy.go
+++ b/internal/agent/tool_result_redundancy.go
@@ -148,7 +148,13 @@ func (t *toolResultRedundancyState) recordResult(toolName, content string, itera
 		jaccard := trJaccard(lines, entry.lines)
 		if jaccard >= trOverlapThreshold {
 			// Avoid re-warning on consecutive iterations.
-			if iteration == t.lastWarnedIter && t.warningsFired > 0 {
+			// #1855 case 2: this compared EQUALITY (iteration ==
+			// lastWarnedIter), which only suppressed same-iteration
+			// parallel duplicates - two warnings burned on iters N and
+			// N+1 while sustained redundancy stayed silent after. The
+			// comment's intent ("consecutive iterations" cooldown) needs
+			// adjacency suppression across iterations.
+			if t.warningsFired > 0 && iteration <= t.lastWarnedIter+1 {
 				t.storeEntry(toolName, content, iteration)
 				return ""
 			}

--- a/internal/agent/tool_result_redundancy_test.go
+++ b/internal/agent/tool_result_redundancy_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -240,5 +241,37 @@ func TestTRJaccard(t *testing.T) {
 	j = trJaccard(map[string]bool{}, map[string]bool{"a": true})
 	if math.Abs(j) > 1e-9 {
 		t.Errorf("empty set should have Jaccard 0, got %.2f", j)
+	}
+}
+
+// #1855 case 2: equality-only dedup burned both warnings on iters N and
+// N+1. Adjacent-iteration cooldown keeps the second warning available for
+// genuinely later redundancy.
+func TestRedundancyAdjacentIterCooldown1855(t *testing.T) {
+	tr := newToolResultRedundancyState()
+	// Unique lines: trNormalize dedups into a set, so repeated identical
+	// lines collapse below trMinLines.
+	var sb strings.Builder
+	for i := 0; i < trMinLines+1; i++ {
+		fmt.Fprintf(&sb, "unique output line %02d\n", i)
+	}
+	content := sb.String()
+	// Seed one history entry first (a lone result has nothing to overlap).
+	tr.recordResult("read_file", content, 4)
+	// Iter 5: first warning.
+	if m := tr.recordResult("read_file", content, 5); m == "" {
+		t.Fatal("first warning expected")
+	}
+	// Iter 6 (adjacent): suppressed by the cooldown.
+	if m := tr.recordResult("read_file", content, 6); m != "" {
+		t.Fatal("adjacent-iteration repeat must be suppressed")
+	}
+	// Iter 20 (well past adjacency): second warning fires.
+	if m := tr.recordResult("read_file", content, 20); m == "" {
+		t.Fatal("second warning must fire for later redundancy")
+	}
+	// Iter 40: capped at trMaxWarnings.
+	if m := tr.recordResult("read_file", content, 40); m != "" {
+		t.Fatal("cap must still apply")
 	}
 }

--- a/internal/agent/tool_thermal.go
+++ b/internal/agent/tool_thermal.go
@@ -142,8 +142,11 @@ type thermalState struct {
 	// Total calls recorded
 	total int
 
-	// Iteration of last warning (for cooldown)
-	lastWarnIter int
+	// Iteration of last warning, PER MODE (#1855 case 3: a single field
+	// let an explore-heavy warning cool down a verify-heavy trigger -
+	// opposite inefficiency modes sharing one clock).
+	lastExploreWarnIter int
+	lastVerifyWarnIter  int
 
 	// Whether any warning has been given this run
 	warned bool
@@ -151,7 +154,9 @@ type thermalState struct {
 
 func newThermalState() *thermalState {
 	return &thermalState{
-		lastWarnIter: -thermalWarnCooldown, // allow first warning immediately
+		// negative seeds allow the first warning immediately
+		lastExploreWarnIter: -thermalWarnCooldown,
+		lastVerifyWarnIter:  -thermalWarnCooldown,
 	}
 }
 
@@ -160,7 +165,8 @@ func (t *thermalState) reset() {
 		t.categories[i] = 0
 	}
 	t.total = 0
-	t.lastWarnIter = -thermalWarnCooldown
+	t.lastExploreWarnIter = -thermalWarnCooldown
+	t.lastVerifyWarnIter = -thermalWarnCooldown
 	t.warned = false
 }
 
@@ -201,10 +207,13 @@ func (t *thermalState) maybeWarn(iteration int) string {
 
 	// Mode 1: Explore-heavy (most common inefficiency)
 	if exploreFrac > explorationThreshold && modifyFrac < modificationFloor {
-		if iteration-t.lastWarnIter < thermalWarnCooldown {
+		// #1855 case 3: document condition 4 via the warned field (it was
+		// declared, reset, never set, never read).
+		if t.warned && iteration-t.lastExploreWarnIter < thermalWarnCooldown {
 			return ""
 		}
-		t.lastWarnIter = iteration
+		t.warned = true
+		t.lastExploreWarnIter = iteration
 		debug.Log("thermal-profile", "explore-heavy: explore=%.0f%% modify=%.0f%% total=%d",
 			exploreFrac*100, modifyFrac*100, t.total)
 
@@ -218,10 +227,11 @@ func (t *thermalState) maybeWarn(iteration int) string {
 
 	// Mode 2: Verify-heavy (excessive checking)
 	if verifyFrac > 0.30 && modifyFrac < modificationFloor {
-		if iteration-t.lastWarnIter < thermalWarnCooldown {
+		if t.warned && iteration-t.lastVerifyWarnIter < thermalWarnCooldown {
 			return ""
 		}
-		t.lastWarnIter = iteration
+		t.warned = true
+		t.lastVerifyWarnIter = iteration
 		debug.Log("thermal-profile", "verify-heavy: verify=%.0f%% modify=%.0f%% total=%d",
 			verifyFrac*100, modifyFrac*100, t.total)
 

--- a/internal/agent/tool_thermal_test.go
+++ b/internal/agent/tool_thermal_test.go
@@ -173,3 +173,23 @@ func TestThermalState_HighModifyNoWarning(t *testing.T) {
 		t.Fatalf("expected no warning for edit-heavy usage, got: %s", warn)
 	}
 }
+
+// #1855 case 3: explore and verify modes must keep SEPARATE cooldown
+// clocks - a shared one let an explore warning cool down a verify trigger.
+func TestThermalSeparateModeCooldowns1855(t *testing.T) {
+	ts := newThermalState()
+	// Seed an explore-heavy warning at iter 10.
+	ts.lastExploreWarnIter = 10
+	ts.warned = true
+	// Verify-heavy conditions met at iter 11 (within shared cooldown range).
+	ts.categories[thermalVerify] = 50
+	ts.categories[thermalModify] = 1
+	ts.total = 51
+	msg := ts.maybeWarn(11)
+	if msg == "" {
+		t.Fatal("verify-heavy warning must not be cooled down by an explore warning")
+	}
+	if !strings.Contains(msg, "Verification") {
+		t.Fatalf("expected verify-heavy message, got: %s", msg)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1855 (all three cases; resolution for case 1 differs from the issue's first option - see below).

1. **Case 1 (Med)**: investigation found the existing `TestAttentionFragment_MaxWarnings` pins max=1 as a DELIBERATE guidance-noise cleanup — the cleanup batch just left the refire-gap/firedAt machinery behind as unreachable dead code. Rather than restoring 2 (undoing the noise cleanup), the dead machinery is removed and the single-shot semantics documented in place. Pin: `TestAttentionFragmentSingleShotHonest1855`.
2. **Case 2 (Med)**: redundancy dedup was equality-only — both warnings burned on adjacent iters N/N+1. Now adjacency suppression (`iteration <= lastWarnedIter+1`), keeping the second warning for later redundancy. Pin: `TestRedundancyAdjacentIterCooldown1855`.
3. **Case 3 (Med-Low)**: thermal explore/verify modes shared one cooldown clock; split per-mode, and the never-wired `warned` field now implements documented condition 4. Pin: `TestThermalSeparateModeCooldowns1855`.

## Verification evidence (review)
Isolated worktree: agent suite **22.6s PASS** (-count=1) — includes the pre-existing max-warnings test (unchanged behavior) plus three new pins covering fire/suppress/cap or persist semantics per case.

Closes #1855

Generated with [ggcode](https://github.com/topcheer/ggcode)
