### PR TITLE
fix(tool): git_reset/git_show refuse dash-prefixed args; reset files get -- separator (#1689 cases 1-3)

### DIFF
--- a/internal/tool/git_reset.go
+++ b/internal/tool/git_reset.go
@@ -77,7 +77,10 @@ func (t GitReset) Execute(ctx context.Context, input json.RawMessage) (Result, e
 
 	// File-specific reset: unstage specific files (always mixed mode)
 	if len(args.Files) > 0 {
-		gitArgs := append([]string{"reset"}, args.Files...)
+		// #1689 case 3: without the separator, a repo file literally named
+		// "HEAD" (or any dash-prefixed name) is consumed as a ref/option -
+		// git_show's file argument has had "--" all along.
+		gitArgs := append([]string{"reset", "--"}, args.Files...)
 		cmd := gitCommand(ctx, gitArgs...)
 		cmd.Dir = dir
 		out, err := cmd.CombinedOutput()
@@ -91,6 +94,13 @@ func (t GitReset) Execute(ctx context.Context, input json.RawMessage) (Result, e
 		return Result{Content: trimmed}, nil
 	}
 
+	// #1689 case 1: a dash-prefixed target reaches git as an OPTION -
+	// "--pathspec-from-file=..." can steer a DESTRUCTIVE hard reset's
+	// pathspec from an external file. git_revert guards this (#1325);
+	// reset, the more destructive sibling, never did.
+	if strings.HasPrefix(target, "-") {
+		return Result{IsError: true, Content: fmt.Sprintf("invalid reset target %q: leading dash (refusing option injection)", target)}, nil
+	}
 	gitArgs := []string{"reset", "--" + mode, target}
 
 	cmd := gitCommand(ctx, gitArgs...)

--- a/internal/tool/git_show.go
+++ b/internal/tool/git_show.go
@@ -69,6 +69,14 @@ func (t GitShow) Execute(ctx context.Context, input json.RawMessage) (Result, er
 	} else {
 		gitArgs = append(gitArgs, "--format=fuller", "--patch")
 	}
+	// #1689 case 2: the revision rides BEFORE the "--" separator - an
+	// agent-passed "--output=/tmp/x" turns the read-only show into an
+	// arbitrary-path overwrite (git show supports --output=<file>). The
+	// file argument has the guard; the revision didn't (blame got
+	// validateRefName via #1687 - show joins the family).
+	if strings.HasPrefix(args.Revision, "-") {
+		return Result{IsError: true, Content: fmt.Sprintf("invalid revision %q: leading dash (refusing option injection)", args.Revision)}, nil
+	}
 	gitArgs = append(gitArgs, args.Revision)
 	if args.File != "" {
 		gitArgs = append(gitArgs, "--", args.File)


### PR DESCRIPTION
Case 1 (Med): a dash-prefixed reset target reached git as an OPTION - `--pathspec-from-file=...` can steer a DESTRUCTIVE hard reset's pathspec from an external file. git_revert guards this (#1325); reset, the more destructive sibling, never did.

Case 2 (Med-Low): git show's revision rode BEFORE the `--` separator - `--output=/tmp/x` turns the read-only show into an arbitrary-path overwrite. The file argument had the guard; blame got validateRefName via #1687; show joins the family.

Case 3 (Med-Low): the files branch lacked the `--` separator - a repo file literally named HEAD was consumed as a ref (whole-tree reset semantics). git_show's file argument has had it all along.

Case 4 (suppression colon form) and blame were verified already-fixed in-tree.

Isolated worktree (fresh origin/main): tool package full PASS (117.7s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)