### PR TITLE
fix(tui): cmdpane tail -n 0 + close/write lock pairing; /pin list rune clip (#1715 c1/2/4, #1716 c1)

### DIFF
--- a/internal/tui/cmdpane/manager.go
+++ b/internal/tui/cmdpane/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -174,6 +175,11 @@ func (m *Manager) EnsurePane(ctx context.Context) error {
 	if m.selfPane == "" {
 		out, err := m.runTmux(ctx, "display-message", "-p", "#{pane_id}")
 		if err != nil || strings.TrimSpace(out) == "" {
+			// #1715 case 4: %w on a nil err renders "%!w(<nil>)" when the
+			// command succeeded but printed nothing.
+			if err == nil {
+				err = errors.New("empty pane id")
+			}
 			return fmt.Errorf("cmdpane: failed to determine current tmux pane: %w", err)
 		}
 		m.selfPane = strings.TrimSpace(out)
@@ -194,7 +200,7 @@ func (m *Manager) EnsurePane(ctx context.Context) error {
 	if m.selfPane != "" {
 		splitArgs = append(splitArgs, "-t", m.selfPane)
 	}
-	splitArgs = append(splitArgs, "tail", "-f", m.logPath)
+	splitArgs = append(splitArgs, "tail", "-f", "-n", "0", m.logPath) // #1715 case 1: bare -f replays the last 10 lines - the "old content is never shown" comments were wrong across sessions
 
 	paneID, err := m.runTmux(ctx, splitArgs...)
 	if err != nil {
@@ -313,8 +319,14 @@ func (m *Manager) Close() {
 		m.killPane(ctx)
 	}
 	if m.logFile != nil {
+		// #1715 case 2: lockedWriter.Write holds writeMu across its nil
+		// check and the write - Close used to close the file BETWEEN them
+		// (write error silently dropped, or nil-file ErrInvalid under
+		// -race). Lock order m.mu -> writeMu matches the writer.
+		m.writeMu.Lock()
 		_ = m.logFile.Close()
 		m.logFile = nil
+		m.writeMu.Unlock()
 	}
 	if m.logPath != "" {
 		_ = os.Remove(m.logPath)

--- a/internal/tui/commands_slash_admin.go
+++ b/internal/tui/commands_slash_admin.go
@@ -1299,7 +1299,7 @@ func (m *Model) handlePinCommand(parts []string) tea.Cmd {
 		for i, item := range items {
 			preview := item.Text
 			if len(preview) > 80 {
-				preview = preview[:80] + "..."
+				preview = string([]rune(preview)[:80]) + "..." // #1716: rune-safe clip (skills_panel.go pattern) - byte slice cut CJK mid-sequence
 			}
 			sb.WriteString(fmt.Sprintf("  %d. [%s] %s\n", i+1, item.ID, preview))
 		}


### PR DESCRIPTION
#1715 case 1 (Med): bare `tail -f` replays the last 10 lines - workspace-keyed log path + residual sub-5MB logs + crash-without-Close leaked the previous session's tail into the new pane. The three 'old content is never shown' comments described `-n 0` semantics all along.

#1715 case 2 (Med-Low): Close closed logFile between lockedWriter's nil check and its write (no shared lock) - dropped write errors or nil-file ErrInvalid under -race. Close takes `writeMu` now (lock order m.mu → writeMu, matching the writer).

#1715 case 4 (Low): `%w` on nil err rendered `%!w(<nil>)` when tmux succeeded but printed nothing.

#1716 case 1 (Low): /pin list preview byte-clipped at 80 - CJK cut mid-UTF-8. Rune-safe clip per skills_panel.go's pattern.

Isolated worktree (fresh origin/main): tui package full PASS (10.9s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)