### PR TITLE
fix(desktop): Linux notifications ride the shared unix queue - finish #1431-A (#1852)

### DIFF
--- a/desktop/ggcode-desktop-wails/notifications.go
+++ b/desktop/ggcode-desktop-wails/notifications.go
@@ -399,7 +399,12 @@ func (nm *NotificationManager) showOSNotification(title, body string) {
 	case "darwin":
 		nm.notifyMacOS(title, body)
 	case "linux":
-		nm.notifyLinux(title, body)
+		// #1852 case 1: route Linux through the SAME bounded queue as
+		// macOS - the old notifyLinux call spawned one goroutine+process
+		// per notification and never touched unixQueue, so the #1431-A
+		// serialization contract was honored on darwin only. The worker
+		// (deliverUnix) already dispatches notify-send for non-darwin.
+		nm.notifyMacOS(title, body)
 	case "windows":
 		nm.notifyWindows(title, body)
 	}
@@ -503,18 +508,10 @@ func (nm *NotificationManager) deliverUnix(title, body string) {
 	}
 }
 
-func (nm *NotificationManager) notifyLinux(title, body string) {
-	// Try notify-send (libnotify) — available on most Linux desktops.
-	// Run asynchronously (#290): notify-send forks a process on the
-	// stream-event dispatch path; keep it off the caller like the #202
-	// Windows fix. Failures are best-effort and only logged.
-	safego.Go("notify-linux", func() {
-		cmd := exec.Command("notify-send", "--app-name=GGCode", "--icon=dialog-information", title, body)
-		if err := cmd.Run(); err != nil {
-			debug.Log("desktop", "Linux notification failed: %v", err)
-		}
-	})
-}
+// notifyLinux was removed (#1852 case 1): Linux now rides the shared
+// unixQueue (see showOSNotification); deliverUnix runs notify-send on
+// the single worker. The old one-goroutine-per-notification path was
+// the #399 storm shape that #1431-A fixed for darwin only.
 
 func (nm *NotificationManager) notifyWindows(title, body string) {
 	// Kept for interface parity; real delivery goes through enqueueWinToast so

--- a/desktop/ggcode-desktop-wails/notifications_test.go
+++ b/desktop/ggcode-desktop-wails/notifications_test.go
@@ -221,7 +221,9 @@ func TestNotifyUnixQueuedNotForked(t *testing.T) {
 		defer close(done)
 		for i := 0; i < 64; i++ {
 			nm.notifyMacOS("t", "b")
-			nm.notifyLinux("t", "b")
+			// #1852: linux rides the same queue now - exercise the
+			// enqueue primitive directly (notifyLinux was removed).
+			nm.enqueueUnixToast("t", "b")
 		}
 	}()
 	select {


### PR DESCRIPTION
## Summary
Closes #1852 (case 1; cases 2/3 confirmed already landed in-flight by #1866).

- **Case 1 (Med)**: `showOSNotification`'s linux branch still called `notifyLinux` — one goroutine + one notify-send process per notification, never touching unixQueue. #1431-A's serialization was darwin-only in practice. Linux now rides the same bounded enqueue path; the dead `notifyLinux` is removed (the worker `deliverUnix` has dispatched notify-send for non-darwin since #1866).
- **Case 2 (Med)**: verified in place from #1866 — non-blocking enqueue + `rollbackNotify` + per-event `safego.Run` worker isolation. No change needed.
- **Case 3 (Low-Med)**: badge no-op is the known #201 backlog — noted in the issue, not fixed here.

## Verification evidence (review)
Isolated worktree (desktop wails module): suite **1.7s PASS** (goolm tag); storm test updated to exercise the enqueue primitive directly and still proves the bounded hand-off. `go build -tags goolm ./...` green.

Closes #1852

Generated with [ggcode](https://github.com/topcheer/ggcode)
