### PR TITLE
fix(tool): unmerged-first conflict classifier; git_tag rev guard; glob pattern sandbox (#1690 cases 1-3)

### DIFF
--- a/internal/tool/git_status.go
+++ b/internal/tool/git_status.go
@@ -85,6 +85,14 @@ func (t GitStatus) Execute(ctx context.Context, input json.RawMessage) (Result, 
 				continue
 			}
 			switch {
+			// #1690 case 1: unmerged states FIRST - AA/AU/UA contain "A" and
+			// DD/DU/UD contain "D", so the added/deleted buckets above ate
+			// five of the six unmerged states and the #834 arms were dead
+			// code. Only UU ever reached conflicted: "0 CONFLICTED" false
+			// negatives on merged repos.
+			case l[:2] == "AA" || l[:2] == "DD" || l[:2] == "UU" ||
+				l[:2] == "AU" || l[:2] == "UA" || l[:2] == "DU" || l[:2] == "UD":
+				conflicted++
 			case strings.HasPrefix(l, "?? "):
 				untracked++
 			case strings.Contains(l[:2], "M"):
@@ -96,10 +104,6 @@ func (t GitStatus) Execute(ctx context.Context, input json.RawMessage) (Result, 
 			case strings.Contains(l[:2], "R") || strings.Contains(l[:2], "C"):
 				// #834: renamed/copied entries fell through every bucket.
 				modified++
-			case strings.Contains(l[:2], "U") || l[:2] == "AA" || l[:2] == "DD":
-				// #834: unmerged conflict states (UU/AA/DD/AU/UA) — the most
-				// important class — were silently hidden from the summary.
-				conflicted++
 			}
 		}
 		shown := strings.Join(lines[:maxGitStatusLines], "\n")

--- a/internal/tool/git_tag.go
+++ b/internal/tool/git_tag.go
@@ -104,7 +104,13 @@ func (t GitTag) Execute(ctx context.Context, input json.RawMessage) (Result, err
 			gitArgs = append(gitArgs, args.Name)
 		}
 		if args.Commit != "" {
-			gitArgs = append(gitArgs, args.Commit)
+			// #1690 case 2: a dash-prefixed rev reached git as an OPTION -
+			// "-d" DELETED an existing tag, "-f" force-moved it. The git
+			// flag-family guard (#1325/#1687/#1689), fourth instance.
+			if strings.HasPrefix(args.Commit, "-") {
+				return Result{IsError: true, Content: fmt.Sprintf("invalid commit %q: leading dash (refusing option injection)", args.Commit)}, nil
+			}
+			gitArgs = append(gitArgs, "--", args.Commit)
 		}
 
 		cmd := gitCommand(ctx, gitArgs...)

--- a/internal/tool/glob.go
+++ b/internal/tool/glob.go
@@ -67,6 +67,15 @@ func (t Glob) Execute(ctx context.Context, input json.RawMessage) (Result, error
 
 	// Support ** for recursive matching via filepath.Glob doublestar
 	pattern := filepath.Join(args.Directory, args.Pattern)
+	// #1690 case 3: the pattern itself was never sandbox-checked - "../../*"
+	// joined its way out of the allowed directory and Glob happily walked
+	// it. Clean the joined path and require it to stay inside.
+	if t.SandboxCheck != nil {
+		joined := filepath.Clean(pattern)
+		if !t.SandboxCheck(joined) {
+			return Result{IsError: true, Content: fmt.Sprintf("Error: glob pattern %q escapes the allowed directory", args.Pattern)}, nil
+		}
+	}
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("glob error: %v", err)}, nil


### PR DESCRIPTION
Case 1 (Med): AA/AU/UA contain 'A' and DD/DU/UD contain 'D' - the added/deleted buckets ate five of the six unmerged states, the #834 arms were dead code, and only UU ever reached conflicted (**'0 CONFLICTED' false negatives on merged repos**). Unmerged is now the FIRST case.

Case 2 (Med): a dash-prefixed git_tag rev reached git as an OPTION - `-d` deleted an existing tag, `-f` force-moved it. Flag-family guard (#1325/#1687/#1689), fourth instance; `--` separator added.

Case 3 (Med): the glob pattern itself was never sandbox-checked - `../../*` joined its way out of the allowed directory and Glob walked it. The joined path is cleaned and re-checked.

(Case 4 - grep's multiline Go fallback being a no-op - stays for follow-up.)

Isolated worktree (fresh origin/main): GitStatus/GitTag/Glob families PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)