### PR TITLE
fix(config,tui,agent): mainstream default endpoint; freeform cursor keys; mixed-question spaces; echoed-status anchoring (#1712)

### DIFF
--- a/internal/agent/bgorphan_detect.go
+++ b/internal/agent/bgorphan_detect.go
@@ -184,9 +184,23 @@ func (s *bgOrphanState) recordOutputCheck(args json.RawMessage, result string, i
 	if !ok {
 		return
 	}
-	for _, line := range strings.Split(result, "\n") {
-		line = strings.TrimSpace(line)
+	// #1712 case 5: only the job MANAGER's own status block counts. Job
+	// OUTPUT (build logs echoing "Status: completed" from the program
+	// under test) must not retire the tracker. The manager's result
+	// always carries a "Job ID:" header line before the "Status:" line,
+	// so require that anchor - a bare echoed Status line lacks it.
+	jobIDSeen := false
+	for _, rawLine := range strings.Split(result, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if strings.HasPrefix(line, "Job ID:") {
+			jobIDSeen = true
+			continue
+		}
 		if !strings.HasPrefix(line, "Status:") {
+			continue
+		}
+		if !jobIDSeen {
+			// Echoed program output, not the manager's status block.
 			continue
 		}
 		status := strings.TrimSpace(strings.TrimPrefix(line, "Status:"))

--- a/internal/agent/bgorphan_detect_test.go
+++ b/internal/agent/bgorphan_detect_test.go
@@ -307,3 +307,26 @@ func TestBGOrphanQuotedNotFoundOutputKeepsTracking(t *testing.T) {
 		t.Fatal("error-channel not-found must remove the job from tracking")
 	}
 }
+
+// #1712 case 5: a bare "Status: completed" line ECHOED by program output
+// (build logs) must NOT retire a still-running jobs
+
+// #1712 case 5: a bare "Status: completed" line ECHOED by program output
+// (build logs) must NOT retire a still-running job's tracker.
+func TestBgOrphanEchoedStatusDoesNotRetire1712(t *testing.T) {
+	s := newBgOrphanState()
+	s.recordStartCommand(json.RawMessage("{\"command\":\"make test\"}"), "Job ID: job-9\nStatus: running", 1)
+	if len(s.activeJobs) == 0 {
+		t.Fatal("job not tracked after start")
+	}
+	// Echoed build output with no Job ID header.
+	s.recordOutputCheck(json.RawMessage(`{"job_id": "job-9"}`), "=== RUN TestX\nStatus: completed (cached)\n--- PASS", 2)
+	if len(s.activeJobs) != 1 {
+		t.Fatalf("echoed status must not retire tracking, tracked=%d", len(s.activeJobs))
+	}
+	// Real manager block still retires.
+	s.recordOutputCheck(json.RawMessage(`{"job_id": "job-9"}`), "Job ID: job-9\nStatus: completed", 3)
+	if len(s.activeJobs) != 0 {
+		t.Fatal("manager status block must retire tracking")
+	}
+}

--- a/internal/config/onboard.go
+++ b/internal/config/onboard.go
@@ -107,10 +107,31 @@ func VendorPresets() []VendorPreset {
 			epIDs = append(epIDs, epID)
 		}
 		sort.Strings(epIDs)
+		// #1712 case 1: taking the FIRST sorted key made the default
+		// deterministic but wrong for github-copilot ("enterprise" < "github.com"
+		// alphabetically - a placeholder GHE domain got preselected over the
+		// mainstream github.com endpoint). Prefer an endpoint whose first tag
+		// is "official" AND that is NOT tagged "enterprise"/"cn"-style
+		// alternates; fall back to sorted-first for vendors without tags.
+		defaultEp := ""
+		for _, epID := range epIDs {
+			ep := vc.Endpoints[epID]
+			if len(ep.Tags) == 0 || ep.Tags[0] != "official" {
+				continue
+			}
+			if hasEndpointTag(ep, "enterprise") {
+				continue
+			}
+			defaultEp = epID
+			break
+		}
+		if defaultEp == "" {
+			defaultEp = epIDs[0]
+		}
 		for _, epID := range epIDs {
 			ep := vc.Endpoints[epID]
 			if vp.DefaultEndpoint == "" {
-				vp.DefaultEndpoint = epID
+				vp.DefaultEndpoint = defaultEp
 			}
 			vp.Endpoints = append(vp.Endpoints, EndpointPreset{
 				ID:           epID,
@@ -146,4 +167,14 @@ func sortVendors(vs []VendorPreset) {
 	sort.Slice(vs, func(i, j int) bool {
 		return vs[i].DisplayName < vs[j].DisplayName
 	})
+}
+
+// hasEndpointTag reports whether ep carries the given tag (#1712).
+func hasEndpointTag(ep EndpointConfig, tag string) bool {
+	for _, t := range ep.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/onboard_test.go
+++ b/internal/config/onboard_test.go
@@ -335,3 +335,32 @@ func TestVendorPresetsNeedsAPIKey(t *testing.T) {
 		}
 	}
 }
+
+// #1712 case 1: the default endpoint must be the MAINSTREAM official one,
+// not the alphabetically-first key (enterprise < github.com sorted first
+// and preselected a placeholder GHE domain).
+func TestVendorPresetDefaultEndpointOfficial1712(t *testing.T) {
+	presets := VendorPresets()
+	var copilot *VendorPreset
+	for i := range presets {
+		if presets[i].ID == "github-copilot" {
+			copilot = &presets[i]
+		}
+	}
+	if copilot == nil {
+		t.Fatal("github-copilot preset missing")
+	}
+	if copilot.DefaultEndpoint != "github.com" {
+		t.Fatalf("DefaultEndpoint = %q, want github.com (not the enterprise placeholder)", copilot.DefaultEndpoint)
+	}
+	// Deterministic across calls.
+	for i := 0; i < 20; i++ {
+		if again := VendorPresets(); again != nil {
+			for _, vp := range again {
+				if vp.ID == "github-copilot" && vp.DefaultEndpoint != "github.com" {
+					t.Fatalf("DefaultEndpoint unstable: %q", vp.DefaultEndpoint)
+				}
+			}
+		}
+	}
+}

--- a/internal/tui/ask_user.go
+++ b/internal/tui/ask_user.go
@@ -69,11 +69,18 @@ func (m Model) handleQuestionnaireKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	}
 	switch msg.String() {
 	case "tab", "right":
-		qs.moveTab(1, m.currentLanguage())
-		return m, nil
+		// #1712 case 2: in the freeform notes input, left/right must move
+		// the TEXT CURSOR (fix a typo mid-sentence), not switch tabs -
+		// fall through to input.Update below. Only bare Tab switches.
+		if msg.String() == "tab" || !qs.activeQuestionAllowsFreeform() {
+			qs.moveTab(1, m.currentLanguage())
+			return m, nil
+		}
 	case "shift+tab", "left":
-		qs.moveTab(-1, m.currentLanguage())
-		return m, nil
+		if msg.String() == "shift+tab" || !qs.activeQuestionAllowsFreeform() {
+			qs.moveTab(-1, m.currentLanguage())
+			return m, nil
+		}
 	case "enter":
 		if qs.onSubmitTab() {
 			return m, m.handleQuestionnaireResult(toolpkg.AskUserStatusSubmitted)
@@ -96,11 +103,19 @@ func (m Model) handleQuestionnaireKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		}
 		return m, nil
 	case "space":
+		// #1712 case 3: on MIXED questions (choices AND AllowFreeform)
+		// space toggled the choice even mid-typing, so freeform answers
+		// could never contain spaces after the first word. Compromise
+		// that preserves the pinned empty-input behavior (space selects
+		// the highlighted choice): once the user has STARTED typing
+		// (input non-empty), space flows to the text input.
 		if qs.activeQuestionHasChoices() {
-			qs.toggleCurrentChoice()
-			return m, nil
+			if !qs.activeQuestionAllowsFreeform() || qs.input.Value() == "" {
+				qs.toggleCurrentChoice()
+				return m, nil
+			}
 		}
-		// No choices: space goes to freeform text input.
+		// Freeform-only, or mixed with typing in progress.
 	}
 	switch msg.String() {
 	case "k":

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -3207,3 +3207,39 @@ func TestProjectMemoryLoadingQueuesTunnelWebchatAndCron(t *testing.T) {
 		t.Fatal("cron firing must not start a run during project-memory loading")
 	}
 }
+
+// #1712 case 3: once freeform typing has started on a MIXED question,
+// space must reach the text input (was: toggle choice forever).
+func TestAskUserMixedQuestionSpaceFlowsToInputAfterTyping1712(t *testing.T) {
+	m := newTestModel()
+	response := make(chan tool.AskUserResponse, 1)
+	m.pendingQuestionnaire = newQuestionnaireState(tool.AskUserRequest{
+		Questions: []tool.AskUserQuestion{
+			{
+				ID:            "scope",
+				Title:         "Scope",
+				Prompt:        "Pick",
+				Kind:          tool.AskUserKindSingle,
+				AllowFreeform: true,
+				Choices:       []tool.AskUserChoice{{ID: "a", Label: "A"}},
+			},
+		},
+	}, response, LangEnglish)
+	m.pendingQuestionnaire.input.Focus()
+
+	// Simulate freeform typing already in progress (the space-key routing
+	// under test is identical whether the text arrived keystroke-by-
+	// keystroke or programmatically).
+	qs := m.pendingQuestionnaire
+	qs.input.SetValue("two")
+	if !qs.input.Focused() {
+		t.Fatalf("input not focused")
+	}
+	before := qs.input.Value()
+	// Real terminal drivers populate Text for the space rune; a bare
+	// Code-only msg inserts nothing (bubbles default branch uses msg.Text).
+	m2, _ := m.handleQuestionnaireKey(tea.KeyPressMsg{Code: tea.KeySpace, Text: " "})
+	if got := m2.pendingQuestionnaire.input.Value(); got != before+" " {
+		t.Fatalf("space must reach input once typing started, got %q (before=%q)", got, before)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1712 (cases 1/2/3/5 fixed; case 4 noted - UX decision needed).

1. **Case 1 (Med, #1523 regression)**: alphabetically-first endpoint as default preselected the enterprise placeholder over github.com. Default now prefers official-tagged non-enterprise endpoints.
2. **Case 2 (Med)**: left/right always switched tabs in the freeform input - text cursor could not move. Cursor keys now fall through to the input on freeform questions.
3. **Case 3 (Med)**: mixed questions sent every space to the choice toggle. Once typing has started, space flows to the input (empty-input toggle behavior preserved).
5. **Case 5 (Low)**: echoed "Status: completed" lines in job output retired trackers - manager status now anchored to a preceding "Job ID:" header.

## Verification evidence (review)
Isolated worktree: config 11.9s / tui 11.7s / agent 22.8s suites PASS. Three new pins; existing pins (space-selects-choice on empty input, manager-block retirement) still green.

Closes #1712

Generated with [ggcode](https://github.com/topcheer/ggcode)
