### PR TITLE
fix(agent): plan drift needs tool evidence, not text promises; error-strategy candidates unmasked (#1850)

### DIFF
--- a/internal/agent/error_strategy_loop.go
+++ b/internal/agent/error_strategy_loop.go
@@ -30,6 +30,7 @@ package agent
 //   - Threshold: 3+ same-category errors within a sliding window of 15
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -139,21 +140,46 @@ func (s *errStrategyState) checkAndWarn() string {
 	if s.warningCount >= maxErrStrategyWarnings {
 		return ""
 	}
+	// #1850 case 2: evaluate candidates in a DETERMINISTIC order (map
+	// iteration is random - ties picked a nondeterministic winner) and do
+	// not let a sub-threshold dominant category mask a QUALIFIED one:
+	// 4 generic + 3 timeout used to return early on generic (below its
+	// strengthened bar) without ever looking at timeout, silencing a
+	// legitimate strategy warning for the rest of the run.
+	type candidate struct {
+		cat   errCategory
+		count int
+	}
+	var candidates []candidate
+	for c, n := range s.catCounts {
+		candidates = append(candidates, candidate{c, n})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].count != candidates[j].count {
+			return candidates[i].count > candidates[j].count
+		}
+		return candidates[i].cat < candidates[j].cat
+	})
 	var dominantCat errCategory
 	var dominantCount int
-	for c, n := range s.catCounts {
-		if n > dominantCount {
-			dominantCount = n
-			dominantCat = c
+	found := false
+	for _, cand := range candidates {
+		if s.firedFor[cand.cat] {
+			continue
 		}
+		// #340: generic has no semantic identity — require a stronger
+		// threshold for the catch-all bucket.
+		if cand.cat == errCatGeneric && cand.count < 5 {
+			continue
+		}
+		if cand.count < errStrategyThreshold {
+			// Sorted descending: no later candidate can qualify either.
+			break
+		}
+		dominantCat, dominantCount, found = cand.cat, cand.count, true
+		break
 	}
-	if dominantCount < errStrategyThreshold || s.firedFor[dominantCat] {
-		return ""
-	}
-	// #340: generic has no semantic identity — "the same error category is
-	// recurring" is not a valid claim for a catch-all bucket of unrelated
-	// one-off errors. Require a stronger threshold for it.
-	if dominantCat == errCatGeneric && dominantCount < 5 {
+	if !found {
 		return ""
 	}
 	s.firedFor[dominantCat] = true

--- a/internal/agent/error_strategy_loop_test.go
+++ b/internal/agent/error_strategy_loop_test.go
@@ -147,3 +147,17 @@ func errStrContains(s, sub string) bool {
 	}
 	return false
 }
+
+// #1850 case 2: a sub-threshold dominant generic must not mask a
+// QUALIFIED timeout category.
+func TestErrStrategyGenericDoesNotMaskQualifiedTimeout1850(t *testing.T) {
+	s := newErrStrategyState()
+	s.catCounts = map[errCategory]int{errCatGeneric: 4, errCatTimeout: 3}
+	msg := s.checkAndWarn()
+	if msg == "" {
+		t.Fatal("qualified timeout warning must fire despite generic 4")
+	}
+	if !s.firedFor[errCatTimeout] {
+		t.Fatal("timeout should be the fired category")
+	}
+}

--- a/internal/agent/plan_drift.go
+++ b/internal/agent/plan_drift.go
@@ -271,15 +271,22 @@ func isAlpha(s string) bool {
 
 // checkPlanDrift verifies that plan items have corresponding work.
 // Returns a non-empty message if significant drift is detected.
-func (p *planDriftState) checkPlanDrift(runStats *RunStats, assistantText string) string {
+func (p *planDriftState) checkPlanDrift(runStats *RunStats, _ string) string {
 	if !p.captured || p.fired || len(p.items) == 0 {
 		return ""
 	}
 
 	p.fired = true
 
-	// Build a corpus of "work done" from stats + assistant text
-	workCorpus := strings.ToLower(assistantText)
+	// Build a corpus of "work done" from TOOL-FACED EVIDENCE only.
+	// #1850 case 1: the corpus used to start from assistantText - an LLM
+	// that RESTATED the plan in its reply ("next I'll update
+	// config_loader and auth_middleware...") marked unwritten items as
+	// addressed and the reminder went silent exactly when needed.
+	// Restating a plan is not doing it; compare against what the tools
+	// actually touched (the todo_staleness pattern: silencing requires
+	// tool-pattern evidence, not text promises).
+	workCorpus := ""
 
 	// Add edited file paths and names
 	for _, f := range runStats.FilesEdited {
@@ -289,10 +296,10 @@ func (p *planDriftState) checkPlanDrift(runStats *RunStats, assistantText string
 		}
 	}
 
-	// Add tool names used
-	for toolName := range runStats.ToolCalls {
-		workCorpus += " " + strings.ToLower(toolName)
-	}
+	// Tool names are EXCLUDED from the corpus: plan-item keywords
+	// colliding with generic tool names (grep/search/read) counted as
+	// "work done" without any action. Per-tool call targets below carry
+	// the real evidence.
 
 	// Add commands run
 	for _, cmd := range runStats.CommandsRun {

--- a/internal/agent/plan_drift_test.go
+++ b/internal/agent/plan_drift_test.go
@@ -231,3 +231,25 @@ func containsStrPD(s, substr string) bool {
 	}
 	return false
 }
+
+// #1850 case 1: restating the plan in the reply text must NOT count as
+// addressing plan items - only tool-faced evidence does.
+func TestPlanDriftRestatedPlanDoesNotMute1850(t *testing.T) {
+	s := newPlanDriftState()
+	s.captured = true
+	s.items = []planItem{{Text: "update auth middleware", Keywords: []string{"auth", "middleware"}}}
+	stats := &RunStats{}
+	// Assistant text literally restates the plan; NO files edited.
+	msg := s.checkPlanDrift(stats, "Next I will update the auth middleware.")
+	if msg == "" {
+		t.Fatal("restated-but-not-done plan must stay flagged")
+	}
+	// Tool-faced evidence does mute.
+	stats2 := &RunStats{FilesEdited: []string{"internal/auth/middleware.go"}}
+	s2 := newPlanDriftState()
+	s2.captured = true
+	s2.items = s.items
+	if m := s2.checkPlanDrift(stats2, ""); m != "" {
+		t.Fatalf("edited-file evidence should address item, got: %s", m)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1850 (both cases).

1. **Case 1 (Med, false-negative)**: plan drift's "work done" corpus started from assistantText — restating the plan in the reply muted the reminder for unwritten items. Corpus is now tool-faced evidence only (FilesEdited + CommandsRun); tool names removed (keyword collisions with grep/search/read counted as work).
2. **Case 2 (Med-Low, conditional)**: dominant-only evaluation let a sub-threshold generic (4, below its #340 bar) mask a qualified timeout (3) forever. Candidates now scanned deterministically, skipping fired/sub-bar categories instead of aborting.

## Verification evidence (review)
Isolated worktree: agent suite **22.5s PASS**. Pins: TestPlanDriftRestatedPlanDoesNotMute1850 (restated plan stays flagged; edited-file evidence still mutes) and TestErrStrategyGenericDoesNotMaskQualifiedTimeout1850.

Closes #1850

Generated with [ggcode](https://github.com/topcheer/ggcode)
