### PR TITLE
fix(tui,toolreplay): per-submission retry budget; json.Number tape keys; missing-todos not clear (#1713 c1-2, #1711 c1-2)

### DIFF
--- a/internal/toolreplay/tape.go
+++ b/internal/toolreplay/tape.go
@@ -26,6 +26,7 @@
 package toolreplay
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -119,8 +120,15 @@ func canonicalizeJSON(input json.RawMessage) []byte {
 	if len(input) == 0 {
 		return []byte("null")
 	}
+	// #1711 case 1: UseNumber keeps integers as json.Number - the default
+	// float64 decoding collapses 2^53-boundary integers (file sizes,
+	// nanosecond timestamps) to the SAME float, identical canonical bytes,
+	// identical tape key - and the non-strict FIFO lookup then returns the
+	// WRONG entry with no warning.
 	var v interface{}
-	if err := json.Unmarshal(input, &v); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(input))
+	dec.UseNumber()
+	if err := dec.Decode(&v); err != nil {
 		// Not valid JSON — hash the raw bytes as-is.
 		return input
 	}

--- a/internal/tui/activity_groups.go
+++ b/internal/tui/activity_groups.go
@@ -286,6 +286,13 @@ func parseTodoSnapshot(rawArgs string) ([]todoStateItem, bool) {
 	if err := json.Unmarshal([]byte(rawArgs), &args); err != nil {
 		return nil, false
 	}
+	// #1711 case 2: a MISSING todos key ({} or a typo'd field) is not a
+	// clear-all - Unmarshal succeeds with nil Todos and the whole sidebar
+	// was wiped. Distinguish from an explicit empty array, which #885
+	// keeps as a legitimate clear.
+	if args.Todos == nil && !strings.Contains(rawArgs, "\"todos\"") {
+		return nil, false
+	}
 	// #885: an explicitly EMPTY todos array is a valid "clear all" snapshot
 	// — returning false here short-circuited applyTodoWrite before the
 	// sidebar auto-hide, so clearing todos left an empty sidebar visible.

--- a/internal/tui/blindspot_retry.go
+++ b/internal/tui/blindspot_retry.go
@@ -85,6 +85,13 @@ func (m *Model) handleBlindSpotRetryMsg(msg blindSpotRetryMsg) tea.Cmd {
 	if m.loading {
 		return nil
 	}
+	// #1713 case 2: the timer only checked loading - an Esc cancel or a
+	// DIFFERENT submission B finishing inside the window made the stale
+	// text auto-resend against the user's intent. Only the still-current
+	// submission may retry (handleRetryCommand's identity check pattern).
+	if msg.Text == "" || msg.Text != m.lastUserSubmission {
+		return nil
+	}
 	return m.submitText(msg.Text, true)
 }
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -599,6 +599,11 @@ func (m *Model) startNormalTextRun(text string, displayText string, displayInCha
 	// and /edit permanently on their "empty" branches. Restored per issue
 	// #541 (original position: startAutoRunCheck in 2fb70704).
 	m.lastUserSubmission = text
+	// #1713 case 1: the retry budget is per-SUBMISSION (the field comment
+	// says "current submission") but nothing reset it here - submission B
+	// inherited A's burnt budget or landed straight in the exhausted
+	// branch with a stale count.
+	m.resetBlindSpotRetry()
 
 	return m.continueDisplayedNormalTextRun(text)
 }


### PR DESCRIPTION
#1713 case 1 (Med): the blind-spot retry budget was session-scoped - submission B inherited A's burnt budget or landed straight in the exhausted branch with a stale count. Reset on every new submission.

#1713 case 2 (Low-Med): the retry timer only checked loading - an Esc cancel or a different submission finishing inside the window auto-resent the stale text. Only the still-current submission may retry (`msg.Text == m.lastUserSubmission`, handleRetryCommand's identity pattern).

#1711 case 1 (Med): canonicalizeJSON's default float64 decoding collapsed 2^53-boundary integers (file sizes, ns timestamps) to identical canonical bytes → identical tape key → the non-strict FIFO lookup silently returned the WRONG entry. `UseNumber` keeps integers exact.

#1711 case 2 (Med): a missing todos key (`{}` or typo'd field) parsed as a clear-all and wiped the whole task sidebar. Only an explicit array counts now (#885's empty-array clear preserved).

Isolated worktree (fresh origin/main): toolreplay + tui packages PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)