### PR TITLE
fix(desktop): config file sync poller keeps globalCfg fresh; IM adapter writes serialize (#1847)

### DIFF
--- a/desktop/wailskit/config.go
+++ b/desktop/wailskit/config.go
@@ -31,6 +31,7 @@ func SetConfig(cfg *config.Config) {
 	globalMu.Lock()
 	defer globalMu.Unlock()
 	globalCfg = cfg
+	startConfigFileSync()
 }
 
 // GetGlobalConfig returns the current global config.
@@ -38,6 +39,80 @@ func GetGlobalConfig() *config.Config {
 	globalMu.RLock()
 	defer globalMu.RUnlock()
 	return globalCfg
+}
+
+// configFileState tracks the config file for external changes (#1847).
+var (
+	cfgFileSyncOnce    sync.Once
+	cfgFileLastMod     time.Time
+	cfgFileLastModOnce bool
+)
+
+// startConfigFileSync refreshes globalCfg when the config file changes
+// underneath the desktop process (#1847 case 1/3).
+//
+// The desktop keeps a startup snapshot; a TUI/CLI session (or any other
+// OS process) can patch the file at any time. Saving the stale snapshot
+// deep-merged STALE NON-ZERO values over the newer disk state - silently
+// rolling back the other session's changes (UI display included). The
+// same 2s polling pattern as agentruntime's config hot-reload (project
+// convention: no fsnotify dependency). Our own saves update the tracked
+// mtime first, so self-writes do not trigger a redundant reload; a
+// reload racing a writer is serialized by globalMu.
+func startConfigFileSync() {
+	cfgFileSyncOnce.Do(func() {
+		if st, err := os.Stat(trackedConfigPathLocked()); err == nil {
+			cfgFileLastMod, cfgFileLastModOnce = st.ModTime(), true
+		}
+		go func() {
+			ticker := time.NewTicker(2 * time.Second)
+			defer ticker.Stop()
+			for range ticker.C {
+				globalMu.Lock()
+				syncCfgFileLocked()
+				globalMu.Unlock()
+			}
+		}()
+	})
+}
+
+// trackedConfigPathLocked returns the file globalCfg was loaded from
+// (falls back to the default path). Callers hold globalMu.
+func trackedConfigPathLocked() string {
+	if globalCfg != nil && globalCfg.FilePath != "" {
+		return globalCfg.FilePath
+	}
+	return config.ConfigPath()
+}
+
+// syncCfgFileLocked reloads globalCfg from disk when the file is newer
+// than the last observed mtime. Callers must hold globalMu for writing.
+func syncCfgFileLocked() {
+	path := trackedConfigPathLocked()
+	st, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	if cfgFileLastModOnce && !st.ModTime().After(cfgFileLastMod) {
+		return
+	}
+	cfgFileLastMod, cfgFileLastModOnce = st.ModTime(), true
+	if globalCfg == nil {
+		return
+	}
+	if fresh, lerr := config.Load(path); lerr == nil && fresh != nil {
+		globalCfg = fresh
+		debug.Log("desktop", "config file changed externally; global config refreshed (#1847)")
+	}
+}
+
+// noteConfigFileSaved records the mtime right after OUR OWN save, so the
+// poller does not treat our write as an external change (callers hold
+// globalMu).
+func noteConfigFileSaved() {
+	if st, err := os.Stat(trackedConfigPathLocked()); err == nil {
+		cfgFileLastMod, cfgFileLastModOnce = st.ModTime(), true
+	}
 }
 
 // ResolveConfigFilePath finds the config file for a workspace directory.
@@ -126,12 +201,16 @@ type FullConfig struct {
 // GetFullConfig returns a complete config snapshot.
 func GetFullConfig() (*FullConfig, error) {
 	globalMu.RLock()
-	defer globalMu.RUnlock()
 	cfg := globalCfg
+	globalMu.RUnlock()
 
 	if cfg == nil {
 		return &FullConfig{NeedsSetup: true}, nil
 	}
+	// #1847: display freshness comes from the file-sync poller (2s)
+	// rather than a display-time disk read - GetFullConfig must keep
+	// rendering the in-memory snapshot, which tests and the onboarding
+	// flow rely on as the source of truth for not-yet-saved state.
 
 	// Check if API key is set (without exposing it)
 	// Guard on vendor entry existing; key resolution itself goes through
@@ -350,6 +429,7 @@ func UpdateConfig(values map[string]interface{}) error {
 	if err := cfg.Save(); err != nil {
 		return err
 	}
+	noteConfigFileSaved()
 	// Save() strips instance-sourced keys from the global file write; persist
 	// any such field touched by this update to the instance file too, or the
 	// change would be silently lost on restart (#282).
@@ -667,7 +747,11 @@ func ApplyImpersonation(presetID, version string, customHeaders map[string]strin
 		CustomVersion: version,
 		CustomHeaders: mergedHeaders,
 	}
-	return cfg.Save()
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	noteConfigFileSaved()
+	return nil
 }
 
 // Ensure unused imports are referenced.
@@ -705,7 +789,11 @@ func (b *ChatBridge) SaveHooks(cfg hooks.HookConfig) error {
 	if b.agent != nil {
 		b.agent.SetHookConfig(cfg)
 	}
-	return b.cfg.Save()
+	err := b.cfg.Save()
+	if err == nil {
+		noteConfigFileSaved()
+	}
+	return err
 }
 
 // TestHookMatchResult is the result of testing a hook match pattern.

--- a/desktop/wailskit/config_sync_test.go
+++ b/desktop/wailskit/config_sync_test.go
@@ -1,0 +1,70 @@
+package wailskit
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/topcheer/ggcode/internal/config"
+)
+
+// #1847 case 1/3: an EXTERNAL change to the config file must reach
+// globalCfg via the sync poller, and a subsequent in-process save must
+// not roll it back (stale non-zero snapshot deep-merge).
+func TestConfigFileSyncPollerPicksUpExternalChange1847(t *testing.T) {
+	cfgPath, _ := setupConfigTestEnv(t, "")
+	cfg := GetGlobalConfig()
+	cfg.Vendor = "deskvendor"
+	cfg.Endpoint = "main"
+	cfg.Vendors = map[string]config.VendorConfig{
+		"deskvendor": {Endpoints: map[string]config.EndpointConfig{
+			"main": {BaseURL: "https://example.com", Protocol: "openai"},
+		}},
+	}
+	cfg.DefaultMode = "auto"
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	globalMu.Lock()
+	noteConfigFileSaved()
+	globalMu.Unlock()
+
+	// External session (TUI/CLI) patches the file AFTER our last save.
+	time.Sleep(50 * time.Millisecond)
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	vendorsBlock := "vendors:\n  deskvendor:\n    endpoints:\n      main:\n        base_url: https://example.com\n        protocol: openai\n"
+	patched := strings.Replace(string(raw), "default_mode: auto", "default_mode: plan", 1)
+	if !strings.Contains(patched, "default_mode: plan") {
+		patched += "default_mode: plan\n"
+	}
+	if !strings.Contains(patched, "vendors:") {
+		patched += vendorsBlock
+	}
+	if err := os.WriteFile(cfgPath, []byte(patched), 0644); err != nil {
+		t.Fatalf("external write: %v", err)
+	}
+
+	// Poller window: force a sync cycle.
+	globalMu.Lock()
+	syncCfgFileLocked()
+	globalMu.Unlock()
+
+	if got := GetGlobalConfig().DefaultMode; got != "plan" {
+		t.Fatalf("poller must refresh external change, default_mode=%q", got)
+	}
+	// A delta save from the desktop now preserves the external value.
+	if err := UpdateConfig(map[string]interface{}{"model": "m2"}); err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+	re, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if re.DefaultMode != "plan" {
+		t.Fatalf("desktop save rolled back external change: default_mode=%q", re.DefaultMode)
+	}
+}

--- a/desktop/wailskit/im.go
+++ b/desktop/wailskit/im.go
@@ -179,6 +179,12 @@ func ListIMAdapters(workingDir string, imMgr interface {
 //   - "command": command for stdio transport
 //   - other keys are stored in the adapter's Extra map
 func SaveIMAdapter(name string, values map[string]string) error {
+	// #1847 case 2: serialize against UpdateConfig/ApplyImpersonation
+	// (globalMu) - this path fresh-loads and saves OUTSIDE any lock, so a
+	// concurrent UpdateConfig save could interleave and silently drop this
+	// write (or vice versa).
+	globalMu.Lock()
+	defer globalMu.Unlock()
 	cfg, err := config.Load(config.ConfigPath())
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -314,6 +320,12 @@ func mergeExistingIntoUpdate(update, existing config.IMAdapterConfig) config.IMA
 func RemoveIMAdapter(name string, imMgr interface {
 	UnbindAdapter(adapterName string) error
 }) error {
+	// #1847 case 2: serialize against UpdateConfig/ApplyImpersonation
+	// (globalMu) - this path fresh-loads and saves OUTSIDE any lock, so a
+	// concurrent UpdateConfig save could interleave and silently drop this
+	// write (or vice versa).
+	globalMu.Lock()
+	defer globalMu.Unlock()
 	cfg, err := config.Load(config.ConfigPath())
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
@@ -336,6 +348,12 @@ func RemoveIMAdapter(name string, imMgr interface {
 
 // SetIMAdapterEnabled toggles the enabled state of an IM adapter.
 func SetIMAdapterEnabled(name string, enabled bool) error {
+	// #1847 case 2: serialize against UpdateConfig/ApplyImpersonation
+	// (globalMu) - this path fresh-loads and saves OUTSIDE any lock, so a
+	// concurrent UpdateConfig save could interleave and silently drop this
+	// write (or vice versa).
+	globalMu.Lock()
+	defer globalMu.Unlock()
 	cfg, err := config.Load(config.ConfigPath())
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)


### PR DESCRIPTION
## Summary
Closes #1847 (all three cases).

- **Case 1/3 (High/Med, stale-snapshot rollback)**: desktop saves deep-merged stale startup-snapshot values over changes written by TUI/CLI sessions. Fix: 2s config file-sync poller (project polling convention) refreshes globalCfg on mtime advance; writers self-record mtimes; poller tracks globalCfg.FilePath; GetFullConfig keeps the in-memory-snapshot contract (freshness via poller).
- **Case 2 (Med, TOCTOU)**: SaveIMAdapter / RemoveIMAdapter / SetIMAdapterEnabled loaded+saved outside globalMu — interleaved saves silently dropped fields. All three now hold globalMu.

## Verification evidence (review)
Isolated worktree: wailskit suite **10.9s PASS** — includes pre-existing contract tests (#284 empty-string guard, #282 instance write-back, #584) unchanged and green, plus new pin TestConfigFileSyncPollerPicksUpExternalChange1847 (external patch → poller refresh → delta save preserves external change).

Design note: an earlier fresh-load-in-writer approach was reverted because it broke the in-memory-snapshot contract those tests pin (unsaved onboarding state). The poller preserves all existing contracts.

Closes #1847

Generated with [ggcode](https://github.com/topcheer/ggcode)
