### PR TITLE
fix(agent): detector reset semantics - foresight per-turn, attention quota per-turn, editOscillation compaction entry (#1843)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1260,6 +1260,12 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 	// hmMaxWarns=1 burned in run 1 kept the detector silent for every
 	// later run of the Agent's lifetime.
 	a.heterogeneousModel.reset()
+	// #1843 case 1: foresightCalib.reset() was never called outside
+	// compaction - "at most 2 per run" (file-header promise) was in fact
+	// per-LIFETIME: mismatches and warnCount accumulated across every
+	// user turn, so after two early warnings the detector stayed silent
+	// for the rest of the session.
+	a.foresightCalib.reset()
 	a.expiredRead.reset()
 	// Convergence lock must reset per run so post-verification edit drift
 	// counters don't leak across runs (issue #341).

--- a/internal/agent/attention_fragment.go
+++ b/internal/agent/attention_fragment.go
@@ -228,8 +228,14 @@ func (s *attentionFragmentState) analyze() string {
 }
 
 // reset clears state for a new user turn.
+// #1843 case 2: warnCount previously persisted across the Agent's
+// LIFETIME (the only reset call site is the per-user-turn block), so
+// afMaxWarnings=1 meant ONE warning for the whole session - the comment
+// claimed "per run" but nothing re-opened the quota. warnCount now
+// resets per user turn, matching the caller's semantics; totalCalls
+// stays monotonic (the refire-gap arithmetic depends on it).
 func (s *attentionFragmentState) reset() {
 	s.recentDirs = s.recentDirs[:0]
 	s.switchCount = 0
-	// Don't reset warnCount or firedAt - those persist across the run.
+	s.warnCount = 0
 }

--- a/internal/agent/foresight_calibrate.go
+++ b/internal/agent/foresight_calibrate.go
@@ -305,10 +305,14 @@ func (s *foresightCalibrateState) checkCalibration(toolName string, resultConten
 	return ""
 }
 
-// reset clears state for a new user turn.
+// reset clears state for a new user turn (#1843: previously dead code
+// outside compaction - warnCount/mismatches accumulated across the whole
+// session, turning "at most 2 per run" into a lifetime quota).
 func (s *foresightCalibrateState) reset() {
 	if s == nil {
 		return
 	}
 	s.predictions = nil
+	s.mismatches = 0
+	s.warnCount = 0
 }

--- a/internal/agent/guidance_compact_reset.go
+++ b/internal/agent/guidance_compact_reset.go
@@ -133,6 +133,12 @@ func (a *Agent) resetGuidanceCounters() {
 	if a.criteriaDrift != nil {
 		a.criteriaDrift.warnCount = 0
 	}
+	// #1843 case 3: editOscillation was missing from this list too -
+	// max=1 burned pre-compaction left the detector silent (and the
+	// model never saw the warning text) for the rest of the run.
+	if a.editOscillation != nil {
+		a.editOscillation.fired = 0
+	}
 	if a.subgoalTrack != nil {
 		a.subgoalTrack.fired = false
 	}

--- a/internal/agent/reset_semantics_1843_test.go
+++ b/internal/agent/reset_semantics_1843_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import "testing"
+
+// #1843 case 1: foresightCalib quota must be per-RUN (user turn), not
+// per-Agent-lifetime - reset() re-opens the mismatch/warn quotas.
+func TestForesightResetReopensQuota1843(t *testing.T) {
+	s := newForesightCalibrateState()
+	s.mismatches = 5
+	s.warnCount = 2 // both lifetime warnings burned
+	s.reset()
+	if s.mismatches != 0 || s.warnCount != 0 {
+		t.Fatalf("reset must clear mismatches/warnCount, got %d/%d", s.mismatches, s.warnCount)
+	}
+}
+
+// #1843 case 2: attention fragment warnCount resets per user turn -
+// afMaxWarnings=1 was one warning per Agent LIFETIME before.
+func TestAttentionFragmentWarnQuotaPerTurn1843(t *testing.T) {
+	s := newAttentionFragmentState()
+	s.warnCount = 1
+	s.reset()
+	if s.warnCount != 0 {
+		t.Fatalf("warnCount must reset per user turn, got %d", s.warnCount)
+	}
+}
+
+// #1843 case 3: compaction must re-open the editOscillation quota
+// (max=1 burned pre-compaction left it silent for the whole run).
+func TestEditOscillationCompactionReopen1843(t *testing.T) {
+	var a Agent
+	a.editOscillation = newOscillationState()
+	a.editOscillation.fired = 1
+	a.resetGuidanceCounters()
+	if a.editOscillation.fired != 0 {
+		t.Fatalf("compaction must reopen editOscillation quota, fired=%d", a.editOscillation.fired)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1843 (all three cases — the #677/#1651 reset-semantics family).

1. **Case 1 (High, dead code)**: foresightCalib.reset() was never called outside compaction — "at most 2 per run" was a per-LIFETIME quota (mismatches/warnCount never cleared). Now wired into the per-turn reset block; reset also clears mismatches/warnCount.
2. **Case 2 (Med-High)**: attentionFragment.warnCount "persisted across the run" but its only reset call site is per-user-turn — with max=1, ONE warning per Agent lifetime. warnCount now resets per user turn (totalCalls stays monotonic for the gap arithmetic).
3. **Case 3 (Med)**: editOscillation missing from the compaction quota list (#1572-C sibling) — fired re-opened by resetGuidanceCounters().

## Verification evidence (review)
Isolated worktree: agent suite **26.2s PASS**. Three pins cover each case (quota reopened by reset / per-turn warn quota / compaction reopen).

Note: branch is based on the local main snapshot; hunks are disjoint from recently merged remote fixes (#1855's attention_fragment cleanup), so the merge is clean.

Closes #1843

Generated with [ggcode](https://github.com/topcheer/ggcode)
