### PR TITLE
fix(agent,config): claim-verify exemptions tightened; Copilot base_url/empty-token guards (#1695)

### DIFF
--- a/internal/agent/tool_claim_verify.go
+++ b/internal/agent/tool_claim_verify.go
@@ -92,6 +92,29 @@ var claimVerifyContentTools = map[string]bool{
 // the intended true positive — warning when a nominally-successful search
 // actually found nothing — without treating user content that merely
 // contains status-like wording as a failure signal.
+// segHasDownstreamRetriever reports whether a command segment contains a
+// content-retrieval command after the wrapper (#1695 case 1).
+func segHasDownstreamRetriever(seg string) bool {
+	f := strings.Fields(seg)
+	for i := 0; i < len(f); i++ {
+		switch f[i] {
+		case "grep", "rg", "cat", "head", "tail":
+			return true
+		case "-exec":
+			// find -exec grep ... \; / xargs-style suffix counts if a
+			// retriever appears anywhere after -exec.
+			for j := i + 1; j < len(f); j++ {
+				switch f[j] {
+				case "grep", "rg", "cat", "head", "tail":
+					return true
+				}
+			}
+			return false
+		}
+	}
+	return false
+}
+
 // claimVerifyMetaStatusPrefixes are the zero-result status prefixes various
 // content tools render. The old single "no matches found." (with period)
 // matched only grep's wording; search_files ("No matches found for pattern"),
@@ -171,12 +194,41 @@ func isContentRetrievalCommand(cmd string) bool {
 		// search was condemned as a test failure (semantic reversal) on this
 		// repo's most common workflow.
 		if name == "git" && len(fields) > 1 {
-			switch fields[1] {
-			case "grep", "log", "show", "blame":
-				continue // content-bearing git subcommand
+			// #1695 case 2: skip leading GLOBAL options (-C /path, --no-
+			// pager, --git-dir=...) so the common `git -C /path grep`
+			// idiom reaches the subcommand instead of falling back to the
+			// status-pattern scan (fields[1] == "-C" never matched).
+			sub := 1
+			for sub < len(fields) && strings.HasPrefix(fields[sub], "-") {
+				// Value-taking global options (-C <path>, --git-dir=<v> is
+				// self-contained but -C /path is not) consume the NEXT
+				// field - without this the path was mistaken for the
+				// subcommand and `git -C /repo grep` never exempted.
+				if fields[sub] == "-C" || fields[sub] == "--git-dir" ||
+					fields[sub] == "--work-tree" || fields[sub] == "--namespace" {
+					sub += 2
+				} else {
+					sub++
+				}
+			}
+			if sub < len(fields) {
+				switch fields[sub] {
+				case "grep", "log", "show", "blame":
+					continue // content-bearing git subcommand
+				}
 			}
 		} else if name == "xargs" || name == "find" {
-			continue // wrappers: downstream grep/find -exec carries content
+			// #1695 case 1: NOT unconditional - `xargs rm -rf` and
+			// `find . -delete` are pure mutators whose output carries no
+			// retrieved content; exempting them skipped the ENTIRE status
+			// scan and soft failures (permission warnings, partial batch
+			// errors) went unnoticed. Exempt only when the command line
+			// also contains a downstream content retriever (grep/rg/cat/
+			// find -exec ... grep), which is the case the wrapper
+			// exemption exists for (#1506).
+			if segHasDownstreamRetriever(seg) {
+				continue
+			}
 		}
 		// Strip env-var assignments (FOO=bar cmd) and path prefixes.
 		for strings.Contains(name, "=") && len(fields) > 1 {
@@ -230,9 +282,42 @@ func (c *claimVerifyState) check(toolName, content string, isError bool, cmd str
 	// counts as a signal. Match lines / file content that merely CONTAIN the
 	// phrase are payload, not status (fixes issue #739 false positives).
 	if isContent {
-		trimmedLower := strings.ToLower(strings.TrimSpace(content))
+		// #1695 case 3: meta-status prefixes are generic ("no matches") -
+		// a MATCHED payload whose first line reads "no matches are
+		// allowed..." would trip the advisory. The tool's own meta-status
+		// line is the ENTIRE first line, so require the prefix to consume
+		// it exactly (prefix + end, or prefix + space + qualifier).
+		firstLine := strings.ToLower(strings.TrimSpace(content))
+		if idx := strings.IndexByte(firstLine, '\n'); idx >= 0 {
+			firstLine = strings.TrimSpace(firstLine[:idx])
+		}
+		// Longest-prefix-first: "no matches" would otherwise shadow
+		// "no matches found" for the qualifier check below.
+		for i := range claimVerifyMetaStatusPrefixes {
+			for j := i + 1; j < len(claimVerifyMetaStatusPrefixes); j++ {
+				if len(claimVerifyMetaStatusPrefixes[j]) > len(claimVerifyMetaStatusPrefixes[i]) {
+					claimVerifyMetaStatusPrefixes[i], claimVerifyMetaStatusPrefixes[j] =
+						claimVerifyMetaStatusPrefixes[j], claimVerifyMetaStatusPrefixes[i]
+				}
+			}
+		}
 		for _, prefix := range claimVerifyMetaStatusPrefixes {
-			if strings.HasPrefix(trimmedLower, prefix) {
+			if len(firstLine) < len(prefix) || !strings.HasPrefix(firstLine, prefix) {
+				continue
+			}
+			rest := firstLine[len(prefix):]
+			if rest == "" || strings.HasPrefix(rest, ":") || strings.HasPrefix(rest, ".") {
+				c.injections++
+				debug.Log("claim_verify", "zero-result meta-status detected: tool=%s", toolName)
+				return "[Verify] Search returned no matches. Do not claim results were found. Re-read the tool output carefully before proceeding."
+			}
+			// Short GENERIC prefixes ("no matches", "nothing found") stop
+			// here: any continuation ("are allowed in strict mode") is a
+			// matched payload sentence, not a meta qualifier. Longer
+			// specific prefixes ("no matches found") accept qualifiers
+			// ("for pattern: foo" - search_files wording).
+			if prefix == "no matches found" || prefix == "no results found" ||
+				prefix == "no files matched" {
 				c.injections++
 				debug.Log("claim_verify", "zero-result meta-status detected: tool=%s", toolName)
 				return "[Verify] Search returned no matches. Do not claim results were found. Re-read the tool output carefully before proceeding."

--- a/internal/agent/tool_claim_verify_1695_test.go
+++ b/internal/agent/tool_claim_verify_1695_test.go
@@ -1,0 +1,58 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1695 case 1: pure mutators behind xargs/find must NOT be exempt from
+// the status scan - only segments with a downstream content retriever are.
+func TestClaimVerifyXargsFindExemptionNeedsRetriever1695(t *testing.T) {
+	// xargs rm -rf: NOT exempt -> scanned (soft failures visible).
+	if isContentRetrievalCommand("xargs rm -rf /tmp/x") {
+		t.Fatal("xargs rm -rf must not be exempt (pure mutator)")
+	}
+	// xargs grep: exempt (wrapper around content retrieval).
+	if !isContentRetrievalCommand("xargs grep -l foo") {
+		t.Fatal("xargs grep must stay exempt")
+	}
+	// find -delete: NOT exempt.
+	if isContentRetrievalCommand("find . -delete") {
+		t.Fatal("find -delete must not be exempt (pure mutator)")
+	}
+	// find -exec grep: exempt.
+	if !isContentRetrievalCommand("find . -exec grep -l foo {} +") {
+		t.Fatal("find -exec grep must stay exempt")
+	}
+}
+
+// #1695 case 2: `git -C /path grep` reaches the content-subcommand
+// exemption despite the leading global option.
+func TestClaimVerifyGitDashCExemption1695(t *testing.T) {
+	if !isContentRetrievalCommand("git -C /repo grep -n \"fail:\"") {
+		t.Fatal("git -C /path grep must be exempt like bare git grep")
+	}
+	if isContentRetrievalCommand("git -C /repo push origin main") {
+		t.Fatal("git -C push is not content-bearing")
+	}
+}
+
+// #1695 case 3: a matched payload whose first LINE begins with the generic
+// prefix ("no matches are allowed...") must not trip the zero-result
+// advisory; a true meta-status line still must.
+func TestClaimVerifyMetaPrefixFirstLine1695(t *testing.T) {
+	c := newClaimVerifyState()
+	if msg := c.check("grep", "no matches are allowed in strict mode\nsrc line 1", false, "grep x y"); msg != "" {
+		t.Fatalf("payload first line must not trip advisory: %q", msg)
+	}
+	c2 := newClaimVerifyState()
+	if msg := c2.check("grep", "no matches found", false, "grep x y"); msg == "" {
+		t.Fatal("true meta-status line must trigger advisory")
+	}
+	c3 := newClaimVerifyState()
+	if msg := c3.check("grep", "no matches found for pattern: foo", false, "grep x y"); msg == "" {
+		t.Fatal("qualified meta-status line must trigger advisory")
+	}
+}
+
+var _ = strings.TrimSpace

--- a/internal/config/config_vendor.go
+++ b/internal/config/config_vendor.go
@@ -70,7 +70,10 @@ func (c *Config) ResolveEndpointSelection(vendor, endpoint, model string) (*Reso
 			enterpriseURL = strings.TrimSpace(info.EnterpriseURL)
 			if endpoint == "enterprise" && enterpriseURL != "" {
 				baseURL = auth.CopilotAPIBaseURL(enterpriseURL)
-			} else if endpoint == "github.com" {
+			} else if endpoint == "github.com" && baseURL == "" {
+				// #1695 case 5: an explicitly configured base_url (custom
+				// proxy) was silently overwritten with the official API
+				// host. Only default when unset.
 				baseURL = auth.CopilotAPIBaseURL("")
 			}
 		}
@@ -86,8 +89,9 @@ func (c *Config) ResolveEndpointSelection(vendor, endpoint, model string) (*Reso
 				// context.Background() and RefreshClaudeToken uses
 				// http.DefaultClient (no timeout) - a TCP black hole froze
 				// every endpoint resolution for minutes to hours. Bound the
-				// refresh so resolution degrades to the expired token
-				// instead of hanging. (Single-flight and cross-process store
+				// refresh so a TCP black hole cannot hang every endpoint
+				// resolution; a FAILED refresh then fails LOUDLY (#1300
+				// below) to trigger re-auth. (Single-flight / cross-process
 				// safety remain open - see issue.)
 				refreshCtx, cancelRefresh := context.WithTimeout(context.Background(), 30*time.Second)
 				refreshed, refreshErr := auth.RefreshClaudeToken(refreshCtx, info.RefreshToken)
@@ -120,6 +124,13 @@ func (c *Config) ResolveEndpointSelection(vendor, endpoint, model string) (*Reso
 				}
 			} else {
 				apiKey = strings.TrimSpace(info.AccessToken)
+				// #1695 case 5: an unexpired token with an EMPTY access
+				// token used to resolve successfully and surface as a bare
+				// 401 later - reject at resolution time instead.
+				if apiKey == "" {
+					debug.Log("config", "claude oauth: unexpired token has empty access token (re-authentication required)")
+					return nil, fmt.Errorf("claude oauth: stored token has no access token; run /login to re-authenticate")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Closes #1695 (cases 1-5; iOS-darwin cases 5-9 sub-items remain with #1694 family as noted in the issue).

1. **Case 1 (Med)**: unconditional xargs/find exemption skipped the status scan for pure mutators (`xargs rm -rf`, `find . -delete`) — soft failures invisible. Exemption now requires a downstream retriever.
2. **Case 2 (Low)**: `git -C /path grep` missed the exemption (fields[1]=="-C") — global-option walk added, values consumed.
3. **Case 3 (Low)**: generic short prefixes tripped on matched payload first lines ("no matches are allowed…") — longest-first matching, short generics whole-line-only; also fixes a slice panic (first line shorter than prefix).
4. **Case 4 (Low)**: #1505 comment/behavior mismatch corrected (fails loudly per #1300).
5. **Case 5 (Low x2)**: github.com endpoint no longer clobbers an explicit base_url; empty access token on unexpired stored token rejected at resolution time.

## Verification evidence (review)
Isolated worktree: agent **21.6s** / config **10.6s** suites PASS. Three new pins; the slice panic was caught by the suite (TestRunStream…/TestFutileCycle…) and fixed before commit.

Closes #1695

Generated with [ggcode](https://github.com/topcheer/ggcode)
