### PR TITLE
fix(tool): iterm2 ctx threading; AppleScript control-char boundaries; im_tool health-wait honesty (#1691)

### DIFF
--- a/internal/tool/im_tool.go
+++ b/internal/tool/im_tool.go
@@ -368,9 +368,14 @@ func isAdapterHealthy(snap IMSnapshot, adapter string) bool {
 }
 
 // waitForHealthy polls Snapshot until the adapter becomes healthy or timeout.
-func (t IMTool) waitForHealthy(adapter string, timeout time.Duration) bool {
+// #1691 case 3: honors ctx cancellation - a cancelled session used to
+// block for the full 15s window.
+func (t IMTool) waitForHealthy(ctx context.Context, adapter string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return false
+		}
 		snap := t.Manager.Snapshot()
 		if isAdapterHealthy(snap, adapter) {
 			return true
@@ -447,9 +452,26 @@ func (t IMTool) doSend(ctx context.Context, adapter, message string, autoStart b
 		return Result{IsError: true, Content: fmt.Sprintf("failed to activate adapter %q: %v", adapter, activateErr)}, nil
 	}
 
+	// #1691 case 4: when neither enable nor unmute applied (adapter was
+	// merely unhealthy, not muted/disabled), no ACTIVATION happened - the
+	// old path idled the full 15s and reported "was activated" untruth-
+	// fully. Only wait when we actually activated something.
+	activated := isDisabled || isMuted
+	if !activated {
+		// Healthy already? Send now. Otherwise surface the state without
+		// the pointless wait.
+		if t.waitForHealthy(ctx, adapter, 2*time.Second) {
+			return t.sendAndReport(ctx, adapter, binding.ChannelID, message)
+		}
+		return Result{IsError: true, Content: fmt.Sprintf(
+			"adapter %q is unhealthy (not muted/disabled - nothing to auto-activate). Use the IM status tool to inspect it; the message was not sent.",
+			adapter,
+		)}, nil
+	}
+
 	// Wait for adapter to become healthy (max 15 seconds)
 	const healthTimeout = 15 * time.Second
-	if !t.waitForHealthy(adapter, healthTimeout) {
+	if !t.waitForHealthy(ctx, adapter, healthTimeout) {
 		return Result{IsError: true, Content: fmt.Sprintf(
 			"adapter %q was activated but did not become healthy within %s. The message was not sent. "+
 				"Check adapter status for errors.",

--- a/internal/tool/iterm2.go
+++ b/internal/tool/iterm2.go
@@ -140,7 +140,7 @@ func (t *Iterm2Tool) Execute(ctx context.Context, input json.RawMessage) (Result
 
 	// Status doesn't require iTerm2 to be running — it reports detection.
 	if action == "status" {
-		return t.executeStatus(), nil
+		return t.executeStatus(ctx), nil
 	}
 
 	if !iterm2Available() {
@@ -149,43 +149,43 @@ func (t *Iterm2Tool) Execute(ctx context.Context, input json.RawMessage) (Result
 
 	switch action {
 	case "list":
-		return t.executeList(), nil
+		return t.executeList(ctx), nil
 	case "split":
-		return t.executeSplit(args.SessionID, args.Direction, args.Size, args.Command, args.WorkingDir), nil
+		return t.executeSplit(ctx, args.SessionID, args.Direction, args.Size, args.Command, args.WorkingDir), nil
 	case "new_tab":
-		return t.executeNewTab(args.Command, args.WorkingDir), nil
+		return t.executeNewTab(ctx, args.Command, args.WorkingDir), nil
 	case "new_window":
-		return t.executeNewWindow(args.Command, args.WorkingDir), nil
+		return t.executeNewWindow(ctx, args.Command, args.WorkingDir), nil
 	case "focus":
-		return t.executeFocus(args.SessionID), nil
+		return t.executeFocus(ctx, args.SessionID), nil
 	case "close":
-		return t.executeClose(args.SessionID), nil
+		return t.executeClose(ctx, args.SessionID), nil
 	case "select_tab":
-		return t.executeSelectTab(args.TabIndex), nil
+		return t.executeSelectTab(ctx, args.TabIndex), nil
 	case "input":
-		return t.executeInput(args.SessionID, args.Text), nil
+		return t.executeInput(ctx, args.SessionID, args.Text), nil
 	case "send_key":
-		return t.executeSendKey(args.SessionID, args.Key, args.Modifiers), nil
+		return t.executeSendKey(ctx, args.SessionID, args.Key, args.Modifiers), nil
 	case "resize":
-		return t.executeResize(args.SessionID, args.Axis, args.Increment), nil
+		return t.executeResize(ctx, args.SessionID, args.Axis, args.Increment), nil
 	case "get_text":
-		return t.executeGetText(args.SessionID), nil
+		return t.executeGetText(ctx, args.SessionID), nil
 	case "set_title":
-		return t.executeSetTitle(args.SessionID, args.Text), nil
+		return t.executeSetTitle(ctx, args.SessionID, args.Text), nil
 	case "profile":
-		return t.executeProfile(args.SessionID, args.Text), nil
+		return t.executeProfile(ctx, args.SessionID, args.Text), nil
 	case "badge":
-		return t.executeBadge(args.SessionID, args.Text), nil
+		return t.executeBadge(ctx, args.SessionID, args.Text), nil
 	case "broadcast":
-		return t.executeBroadcast(args.Text), nil
+		return t.executeBroadcast(ctx, args.Text), nil
 	case "mark":
-		return t.executeMark(args.Text), nil
+		return t.executeMark(ctx, args.Text), nil
 	case "clear":
-		return t.executeClear(args.SessionID), nil
+		return t.executeClear(ctx, args.SessionID), nil
 	case "action":
-		return t.executeMenuAction(args.Text), nil
+		return t.executeMenuAction(ctx, args.Text), nil
 	case "reload_config":
-		return t.executeReloadConfig(), nil
+		return t.executeReloadConfig(ctx), nil
 	default:
 		return Result{IsError: true, Content: fmt.Sprintf("unsupported iterm2 action %q", args.Action)}, nil
 	}

--- a/internal/tool/iterm2_1691_test.go
+++ b/internal/tool/iterm2_1691_test.go
@@ -1,0 +1,49 @@
+package tool
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #1691 case 2: control characters in input text must be REJECTED with an
+// explicit error, not silently stripped by escapeAS (corrupted delivery).
+func TestIterm2InputControlCharRejected1691(t *testing.T) {
+	var it Iterm2Tool
+	res := it.executeInput(context.Background(), "s1", "ok\x1b[Atext")
+	if !res.IsError {
+		t.Fatal("control char in input must be an explicit error")
+	}
+	if !strings.Contains(res.Content, "U+") {
+		t.Fatalf("error must name the character, got: %s", res.Content)
+	}
+	// Plain text unaffected - checked at the VALIDATOR level only (no
+	// real AppleScript from unit tests).
+	if bad := asUnsupportedControl("plain text \t tab \n nl \r ok"); bad != 0 {
+		t.Fatalf("tab/newline/CR must stay allowed, got U+%04X", bad)
+	}
+}
+
+// #1691 case 2: set_title boundary.
+func TestIterm2TitleControlCharRejected1691(t *testing.T) {
+	var it Iterm2Tool
+	res := it.executeSetTitle(context.Background(), "s1", "bad\x07title")
+	if !res.IsError {
+		t.Fatal("control char in title must be an explicit error")
+	}
+}
+
+// #1691 case 3: waitForHealthy must honor ctx cancellation.
+type imHealthSnapStub struct{ healthy bool }
+
+func TestIMWaitForHealthyCtxCancel1691(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// A stub tool without a Manager: waitForHealthy returns before
+	// touching Snapshot when ctx is already cancelled.
+	var it IMTool
+	if it.waitForHealthy(ctx, "tg", 15*0+time.Millisecond) {
+		t.Fatal("cancelled ctx must abort immediately")
+	}
+}

--- a/internal/tool/iterm2_darwin.go
+++ b/internal/tool/iterm2_darwin.go
@@ -4,10 +4,11 @@ package tool
 
 import (
 	"context"
+
 	"fmt"
+	"github.com/topcheer/ggcode/internal/debug"
 	"io"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -62,7 +63,7 @@ func iterm2SessionLookup(sessionID string) string {
 // iterm2WriteText writes text to a session using iTerm2's native AppleScript.
 // Unlike Warp/Ghostty, iTerm2 has a native "write text" command that types
 // directly into the target session without needing System Events.
-func iterm2WriteText(sessionID, text string) error {
+func iterm2WriteText(ctx context.Context, sessionID, text string) error {
 	spec := iterm2SessionSpecifier(sessionID)
 	lookup := iterm2SessionLookup(sessionID)
 	script := fmt.Sprintf(`
@@ -72,13 +73,13 @@ tell application "iTerm"
 		write text "%s"
 	end tell
 end tell`, lookup, spec, escapeAS(text))
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	return err
 }
 
 // ── Action implementations (macOS) ───────────────────────────────────────────
 
-func (t *Iterm2Tool) executeStatus() Result {
+func (t *Iterm2Tool) executeStatus(ctx context.Context) Result {
 	if !iterm2Available() {
 		return Result{Content: "iterm2: not detected (TERM_PROGRAM != iTerm.app)"}
 	}
@@ -88,38 +89,38 @@ func (t *Iterm2Tool) executeStatus() Result {
 	b.WriteString(fmt.Sprintf("platform: %s/%s\n", runtime.GOOS, runtime.GOARCH))
 
 	// iTerm2 version
-	if v, err := runAppleScript(context.Background(), `tell application "iTerm" to get version`); err == nil {
+	if v, err := runAppleScript(ctx, `tell application "iTerm" to get version`); err == nil {
 		b.WriteString(fmt.Sprintf("version: %s\n", v))
 	}
 
 	// App path
-	if p, err := runAppleScript(context.Background(), `tell application "iTerm" to get path to`); err == nil && p != "" {
+	if p, err := runAppleScript(ctx, `tell application "iTerm" to get path to`); err == nil && p != "" {
 		b.WriteString(fmt.Sprintf("app path: %s\n", p))
 	}
 
 	// Current session info
-	if name, err := runAppleScript(context.Background(), `tell application "iTerm" to get name of current session of current tab of front window`); err == nil {
+	if name, err := runAppleScript(ctx, `tell application "iTerm" to get name of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("current session name: %s\n", name))
 	}
-	if tty, err := runAppleScript(context.Background(), `tell application "iTerm" to get tty of current session of current tab of front window`); err == nil {
+	if tty, err := runAppleScript(ctx, `tell application "iTerm" to get tty of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("current session tty: %s\n", tty))
 	}
-	if cols, err := runAppleScript(context.Background(), `tell application "iTerm" to get columns of current session of current tab of front window`); err == nil {
+	if cols, err := runAppleScript(ctx, `tell application "iTerm" to get columns of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("columns: %s\n", cols))
 	}
-	if rows, err := runAppleScript(context.Background(), `tell application "iTerm" to get rows of current session of current tab of front window`); err == nil {
+	if rows, err := runAppleScript(ctx, `tell application "iTerm" to get rows of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("rows: %s\n", rows))
 	}
 
 	// Session ID (iTerm2 assigns a numeric ID to each session)
-	if sid, err := runAppleScript(context.Background(), `tell application "iTerm" to get id of current session of current tab of front window`); err == nil {
+	if sid, err := runAppleScript(ctx, `tell application "iTerm" to get id of current session of current tab of front window`); err == nil {
 		b.WriteString(fmt.Sprintf("current session ID: %s", sid))
 	}
 
 	return Result{Content: b.String()}
 }
 
-func (t *Iterm2Tool) executeList() Result {
+func (t *Iterm2Tool) executeList(ctx context.Context) Result {
 	script := `
 tell application "iTerm"
 	set output to ""
@@ -166,14 +167,14 @@ tell application "iTerm"
 	return output
 end tell`
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 list failed: %v", err)}
 	}
 	return Result{Content: out}
 }
 
-func (t *Iterm2Tool) executeSplit(sessionID, direction string, size int, command, workingDir string) Result {
+func (t *Iterm2Tool) executeSplit(ctx context.Context, sessionID, direction string, size int, command, workingDir string) Result {
 	dir := strings.ToLower(strings.TrimSpace(direction))
 	if dir == "" {
 		dir = "right"
@@ -241,7 +242,7 @@ tell application "iTerm"
 end tell`, lookup, targetSpec, splitCmd, escapeAS(escapeShellSingleQuote(wd)))
 	}
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 split failed: %v", err)}
 	}
@@ -258,7 +259,7 @@ end tell`, lookup, targetSpec, splitCmd, escapeAS(escapeShellSingleQuote(wd)))
 	return Result{Content: fmt.Sprintf("iterm2 split created: direction=%s, session_id=%s", dir, out)}
 }
 
-func (t *Iterm2Tool) executeNewTab(command, workingDir string) Result {
+func (t *Iterm2Tool) executeNewTab(ctx context.Context, command, workingDir string) Result {
 	wd := strings.TrimSpace(workingDir)
 	if wd == "" {
 		wd = t.workingDir()
@@ -288,7 +289,7 @@ tell application "iTerm"
 end tell`
 	}
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 new_tab failed: %v", err)}
 	}
@@ -296,7 +297,7 @@ end tell`
 	return Result{Content: fmt.Sprintf("iterm2 tab created: session_id=%s", out)}
 }
 
-func (t *Iterm2Tool) executeNewWindow(command, workingDir string) Result {
+func (t *Iterm2Tool) executeNewWindow(ctx context.Context, command, workingDir string) Result {
 	wd := strings.TrimSpace(workingDir)
 	if wd == "" {
 		wd = t.workingDir()
@@ -322,7 +323,7 @@ tell application "iTerm"
 end tell`
 	}
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 new_window failed: %v", err)}
 	}
@@ -330,7 +331,7 @@ end tell`
 	return Result{Content: fmt.Sprintf("iterm2 window created: session_id=%s", out)}
 }
 
-func (t *Iterm2Tool) executeFocus(sessionID string) Result {
+func (t *Iterm2Tool) executeFocus(ctx context.Context, sessionID string) Result {
 	spec := iterm2SessionSpecifier(sessionID)
 	lookup := iterm2SessionLookup(sessionID)
 	script := fmt.Sprintf(`
@@ -340,7 +341,7 @@ tell application "iTerm"
 	return "focused"
 end tell`, lookup, spec)
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 focus failed: %v", err)}
 	}
@@ -352,7 +353,7 @@ end tell`, lookup, spec)
 	return Result{Content: fmt.Sprintf("iterm2 focused: %s", label)}
 }
 
-func (t *Iterm2Tool) executeClose(sessionID string) Result {
+func (t *Iterm2Tool) executeClose(ctx context.Context, sessionID string) Result {
 	spec := iterm2SessionSpecifier(sessionID)
 	lookup := iterm2SessionLookup(sessionID)
 	script := fmt.Sprintf(`
@@ -362,7 +363,7 @@ tell application "iTerm"
 	return "closed"
 end tell`, lookup, spec)
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 close failed: %v", err)}
 	}
@@ -374,7 +375,7 @@ end tell`, lookup, spec)
 	return Result{Content: fmt.Sprintf("iterm2 closed: %s", label)}
 }
 
-func (t *Iterm2Tool) executeSelectTab(tabIndex int) Result {
+func (t *Iterm2Tool) executeSelectTab(ctx context.Context, tabIndex int) Result {
 	if tabIndex < 1 {
 		return Result{IsError: true, Content: "tab_index must be >= 1 (1-based)"}
 	}
@@ -389,7 +390,7 @@ tell application "iTerm"
 	end tell
 end tell`, tabIndex)
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 select_tab failed: %v", err)}
 	}
@@ -397,12 +398,31 @@ end tell`, tabIndex)
 	return Result{Content: fmt.Sprintf("iterm2 selected tab: %d", tabIndex)}
 }
 
-func (t *Iterm2Tool) executeInput(sessionID, text string) Result {
+// asUnsupportedControl returns the first control character that
+// escapeAS would SILENTLY DROP (#1691 case 2): embedding such text via
+// `write text` delivered corrupted content with no error - callers
+// believed the full text was typed. Control chars must go through
+// send_key (TTY-direct), not input text.
+func asUnsupportedControl(s string) rune {
+	for _, r := range s {
+		if r < 0x20 && r != '\t' && r != '\n' && r != '\r' {
+			return r
+		}
+	}
+	return 0
+}
+
+func (t *Iterm2Tool) executeInput(ctx context.Context, sessionID, text string) Result {
 	if strings.TrimSpace(text) == "" {
 		return Result{IsError: true, Content: "text is required for input action"}
 	}
+	// #1691 case 2: reject instead of silently stripping control
+	// characters - the old path delivered corrupted text with success.
+	if bad := asUnsupportedControl(text); bad != 0 {
+		return Result{IsError: true, Content: fmt.Sprintf("input text contains control character U+%04X that cannot be delivered via AppleScript write text; use send_key for control keys", bad)}
+	}
 
-	err := iterm2WriteText(sessionID, text)
+	err := iterm2WriteText(ctx, sessionID, text)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 input failed: %v", err)}
 	}
@@ -418,7 +438,7 @@ func (t *Iterm2Tool) executeInput(sessionID, text string) Result {
 	return Result{Content: fmt.Sprintf("iterm2 input sent to %s: %s", label, preview)}
 }
 
-func (t *Iterm2Tool) executeSendKey(sessionID, key, modifiers string) Result {
+func (t *Iterm2Tool) executeSendKey(ctx context.Context, sessionID, key, modifiers string) Result {
 	if strings.TrimSpace(key) == "" {
 		return Result{IsError: true, Content: "key is required for send_key action"}
 	}
@@ -464,7 +484,7 @@ func (t *Iterm2Tool) executeSendKey(sessionID, key, modifiers string) Result {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 send_key: unknown key %q (supported: enter, escape, tab, space, backspace, arrow keys, home, end, pageup, pagedown, f1-f12, single characters)", key)}
 	}
 
-	if err := t.iterm2WriteToTTY(sessionID, data); err != nil {
+	if err := t.iterm2WriteToTTY(ctx, sessionID, data); err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 send_key failed: %v", err)}
 	}
 
@@ -479,7 +499,7 @@ func (t *Iterm2Tool) executeSendKey(sessionID, key, modifiers string) Result {
 	return Result{Content: fmt.Sprintf("iterm2 key sent to %s: %s", label, keyDesc)}
 }
 
-func (t *Iterm2Tool) executeResize(sessionID, axis string, increment int) Result {
+func (t *Iterm2Tool) executeResize(ctx context.Context, sessionID, axis string, increment int) Result {
 	if increment == 0 {
 		increment = 20
 	}
@@ -498,9 +518,13 @@ func (t *Iterm2Tool) executeResize(sessionID, axis string, increment int) Result
 
 	// Focus target session
 	if sessionID != "" {
-		t.executeFocus(sessionID)
+		t.executeFocus(ctx, sessionID)
 	} else {
-		exec.Command("osascript", "-e", `tell application "iTerm" to activate`).Run()
+		// #1691 case 5: swallow + no ctx were both wrong - route through
+		// the shared helper (ctx-aware, stderr captured).
+		if _, err := runAppleScript(ctx, `tell application "iTerm" to activate`); err != nil {
+			debug.Log("tool", "iterm2 resize activate failed: %v", err)
+		}
 	}
 	time.Sleep(30 * time.Millisecond)
 
@@ -534,7 +558,7 @@ tell application "iTerm"
 end tell`, lookup, spec, increment)
 	}
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 resize failed: %v", err)}
 	}
@@ -553,7 +577,7 @@ func absInt(n int) int {
 	return n
 }
 
-func (t *Iterm2Tool) executeGetText(sessionID string) Result {
+func (t *Iterm2Tool) executeGetText(ctx context.Context, sessionID string) Result {
 	spec := iterm2SessionSpecifier(sessionID)
 	lookup := iterm2SessionLookup(sessionID)
 	script := fmt.Sprintf(`
@@ -572,7 +596,7 @@ tell application "iTerm"
 	end tell
 end tell`, lookup, spec)
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		// Fallback: try using capture() which may not be available in all versions
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 get_text failed: %v", err)}
@@ -581,9 +605,13 @@ end tell`, lookup, spec)
 	return Result{Content: out}
 }
 
-func (t *Iterm2Tool) executeSetTitle(sessionID, title string) Result {
+func (t *Iterm2Tool) executeSetTitle(ctx context.Context, sessionID, title string) Result {
 	if strings.TrimSpace(title) == "" {
 		return Result{IsError: true, Content: "text (title) is required for set_title action"}
+	}
+	// #1691 case 2: same silent-strip boundary as executeInput.
+	if bad := asUnsupportedControl(title); bad != 0 {
+		return Result{IsError: true, Content: fmt.Sprintf("title contains control character U+%04X that cannot be delivered via AppleScript", bad)}
 	}
 
 	spec := iterm2SessionSpecifier(sessionID)
@@ -596,7 +624,7 @@ tell application "iTerm"
 	end tell
 end tell`, lookup, spec, escapeAS(title))
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 set_title failed: %v", err)}
 	}
@@ -604,7 +632,7 @@ end tell`, lookup, spec, escapeAS(title))
 	return Result{Content: fmt.Sprintf("iterm2 session title set: %s", title)}
 }
 
-func (t *Iterm2Tool) executeProfile(sessionID, profileName string) Result {
+func (t *Iterm2Tool) executeProfile(ctx context.Context, sessionID, profileName string) Result {
 	if strings.TrimSpace(profileName) == "" {
 		return Result{IsError: true, Content: "text (profile name) is required for profile action"}
 	}
@@ -613,7 +641,7 @@ func (t *Iterm2Tool) executeProfile(sessionID, profileName string) Result {
 	// Use the proprietary escape sequence ESC]1337;SetProfile=Name BEL
 	// to switch the profile for the target session.
 	esc := fmt.Sprintf("\x1b]1337;SetProfile=%s\x07", profileName)
-	if err := t.iterm2WriteToTTY(sessionID, esc); err != nil {
+	if err := t.iterm2WriteToTTY(ctx, sessionID, esc); err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 profile switch failed: %v", err)}
 	}
 
@@ -623,7 +651,7 @@ func (t *Iterm2Tool) executeProfile(sessionID, profileName string) Result {
 // iterm2WriteToTTY writes a raw string directly to the session's TTY device,
 // bypassing both System Events and the shell. This is used for escape
 // sequences (badge, mark, clear) that must not be interpreted by the shell.
-func (t *Iterm2Tool) iterm2WriteToTTY(sessionID, data string) error {
+func (t *Iterm2Tool) iterm2WriteToTTY(ctx context.Context, sessionID, data string) error {
 	spec := iterm2SessionSpecifier(sessionID)
 	lookup := iterm2SessionLookup(sessionID)
 	ttyScript := fmt.Sprintf(`
@@ -634,7 +662,7 @@ tell application "iTerm"
 	end tell
 end tell`, lookup, spec)
 
-	tty, err := runAppleScript(context.Background(), ttyScript)
+	tty, err := runAppleScript(ctx, ttyScript)
 	if err != nil {
 		return fmt.Errorf("failed to get session tty: %w", err)
 	}
@@ -654,21 +682,21 @@ end tell`, lookup, spec)
 	return nil
 }
 
-func (t *Iterm2Tool) executeBadge(sessionID, badgeText string) Result {
+func (t *Iterm2Tool) executeBadge(ctx context.Context, sessionID, badgeText string) Result {
 	// iTerm2 supports per-session badges via the OSC 1337 escape sequence:
 	// ESC ] 1337 ; SetBadgeFormat = BASE64(text) BEL
 	// We write the escape sequence directly to the session's TTY device
 	// to avoid interference from the shell or TUI raw mode.
 
 	if badgeText == "" {
-		err := t.iterm2WriteToTTY(sessionID, "\033]1337;SetBadgeFormat=\007")
+		err := t.iterm2WriteToTTY(ctx, sessionID, "\033]1337;SetBadgeFormat=\007")
 		if err != nil {
 			return Result{IsError: true, Content: fmt.Sprintf("iterm2 badge clear failed: %v", err)}
 		}
 		return Result{Content: "iterm2 badge cleared"}
 	}
 
-	err := t.iterm2WriteToTTY(sessionID, fmt.Sprintf("\033]1337;SetBadgeFormat=%s\007", badgeText))
+	err := t.iterm2WriteToTTY(ctx, sessionID, fmt.Sprintf("\033]1337;SetBadgeFormat=%s\007", badgeText))
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 badge failed: %v", err)}
 	}
@@ -680,7 +708,7 @@ func (t *Iterm2Tool) executeBadge(sessionID, badgeText string) Result {
 	return Result{Content: fmt.Sprintf("iterm2 badge set: %s", preview)}
 }
 
-func (t *Iterm2Tool) executeBroadcast(subAction string) Result {
+func (t *Iterm2Tool) executeBroadcast(ctx context.Context, subAction string) Result {
 	sub := strings.ToLower(strings.TrimSpace(subAction))
 	if sub == "" {
 		sub = "toggle"
@@ -711,7 +739,7 @@ end tell`
 		return Result{IsError: true, Content: fmt.Sprintf("invalid broadcast sub-action %q (use toggle/on/off)", subAction)}
 	}
 
-	_, err := runAppleScript(context.Background(), script)
+	_, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 broadcast failed: %v", err)}
 	}
@@ -719,7 +747,7 @@ end tell`
 	return Result{Content: fmt.Sprintf("iterm2 broadcast: %s", sub)}
 }
 
-func (t *Iterm2Tool) executeMark(subAction string) Result {
+func (t *Iterm2Tool) executeMark(ctx context.Context, subAction string) Result {
 	sub := strings.ToLower(strings.TrimSpace(subAction))
 	if sub == "" {
 		sub = "set"
@@ -729,7 +757,7 @@ func (t *Iterm2Tool) executeMark(subAction string) Result {
 	case "set":
 		// Use OSC 1337 escape sequence written directly to TTY - no
 		// Accessibility permission needed.
-		err := t.iterm2WriteToTTY("", "\033]1337;SetMark\007")
+		err := t.iterm2WriteToTTY(ctx, "", "\033]1337;SetMark\007")
 		if err != nil {
 			return Result{IsError: true, Content: fmt.Sprintf("iterm2 mark set failed: %v", err)}
 		}
@@ -752,7 +780,7 @@ tell application "System Events"
 	end tell
 end tell`, sub, sub, sub)
 
-		_, err := runAppleScript(context.Background(), script)
+		_, err := runAppleScript(ctx, script)
 		if err != nil {
 			return Result{IsError: true, Content: fmt.Sprintf("iterm2 mark %s failed (needs Accessibility permission for keyboard shortcuts): %v", sub, err)}
 		}
@@ -763,18 +791,18 @@ end tell`, sub, sub, sub)
 	}
 }
 
-func (t *Iterm2Tool) executeClear(sessionID string) Result {
+func (t *Iterm2Tool) executeClear(ctx context.Context, sessionID string) Result {
 	// Clear screen + scrollback via escape sequence written to TTY.
 	// ESC[2J = clear screen, ESC[3J = clear scrollback, ESC[H = cursor home.
 	// No Accessibility permission needed.
-	err := t.iterm2WriteToTTY(sessionID, "\033[2J\033[3J\033[H")
+	err := t.iterm2WriteToTTY(ctx, sessionID, "\033[2J\033[3J\033[H")
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 clear failed: %v", err)}
 	}
 	return Result{Content: "iterm2 buffer cleared"}
 }
 
-func (t *Iterm2Tool) executeMenuAction(menuItem string) Result {
+func (t *Iterm2Tool) executeMenuAction(ctx context.Context, menuItem string) Result {
 	if strings.TrimSpace(menuItem) == "" {
 		return Result{IsError: true, Content: "text (menu item name) is required for action"}
 	}
@@ -784,7 +812,7 @@ func (t *Iterm2Tool) executeMenuAction(menuItem string) Result {
 tell application "iTerm" to activate
 tell application "System Events"
 	tell process "iTerm2"
-		set targetItem to %q
+		set targetItem to "%s"
 		set menuNames to {"File", "Edit", "View", "Sessions", "Tab", "Split Panes", "Window", "Help", "Shell"}
 		repeat with mb in menuNames
 			try
@@ -803,9 +831,9 @@ tell application "System Events"
 		end repeat
 	end tell
 end tell
-return "not found"`, menuItem)
+return "not found"`, escapeAS(menuItem))
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 action %q failed: %v", menuItem, err)}
 	}
@@ -817,7 +845,7 @@ return "not found"`, menuItem)
 	return Result{Content: fmt.Sprintf("iterm2: %s", menuItem)}
 }
 
-func (t *Iterm2Tool) executeReloadConfig() Result {
+func (t *Iterm2Tool) executeReloadConfig(ctx context.Context) Result {
 	// iTerm2 does not have a native AppleScript command to reload preferences.
 	// System Events UI scripting requires Accessibility permissions.
 	// Best effort: try the menu item; if it fails, inform the user.
@@ -839,7 +867,7 @@ tell application "System Events"
 	end tell
 end tell`
 
-	out, err := runAppleScript(context.Background(), script)
+	out, err := runAppleScript(ctx, script)
 	if err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("iterm2 reload_config failed: %v", err)}
 	}


### PR DESCRIPTION
## Summary
Closes #1691 (cases 1-5; badge/left-up doc nits documented-only per issue).

1. **Case 1 (Med)**: iterm2's 19 branches used context.Background() — #1686's shared-helper fix was unreachable from this tool; ctx now threads end-to-end; resize's activate fallback routed through the helper (ctx + stderr, was swallowed).
2. **Case 2 (Med)**: escapeAS silently dropped control chars (corrupted `input`/`set_title` delivered as success) — explicit U+XXXX rejection at both boundaries, tab/newline/CR allowed, send_key (TTY-direct) unaffected.
3. **Case 3 (Low)**: waitForHealthy honors ctx.
4. **Case 4 (Low)**: auto_start no longer idles 15s claiming "was activated" when nothing was activated — 2s probe + honest error.
5. **Case 5 (Low)**: menu lookup %q → escapeAS (no unparseable Go escapes in AppleScript).

## Verification evidence (review)
Isolated worktree: tool suite **38.5s PASS**. Pins: control-char rejection both boundaries, validator-level allowance, ctx-cancelled wait. Note: the first pin draft executed REAL osascript (124s) — caught and rewritten to validator-level before commit; unit tests must not drive the host terminal.

Closes #1691

Generated with [ggcode](https://github.com/topcheer/ggcode)
