### PR TITLE
fix(checkpoint): agent self-reverts record source=agent (#1708 case 1)

### DIFF
--- a/internal/agent/agent_tool.go
+++ b/internal/agent/agent_tool.go
@@ -1620,7 +1620,7 @@ func (a *Agent) executeUndoEditInner(ctx context.Context, tc provider.ToolCallDe
 				Content: "checkpoint_id is required for action=revert. Use action=list to see available checkpoint IDs.",
 			}
 		}
-		cp, revertedFiles, err := cpMgr.RevertWithFiles(args.CheckpointID)
+		cp, revertedFiles, err := cpMgr.RevertWithFilesSource(args.CheckpointID, "agent") // #1708: agent self-revert must not narrate as user rejection (#1449-A)
 		if err != nil {
 			return tool.Result{
 				IsError: true,

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -202,16 +202,27 @@ func (m *Manager) Undo(source string) (*Checkpoint, error) {
 // semantics (per-file baseline write-back); Revert now follows the same
 // pattern.
 func (m *Manager) Revert(id string) (*Checkpoint, error) {
-	cp, _, err := m.RevertWithFiles(id)
+	cp, _, err := m.RevertWithFilesSource(id, "user") // panel/CLI entries are user intent
 	return cp, err
 }
 
 // RevertWithFiles is Revert plus the full list of files that were written
-// back (#1879 case 1). Revert rewrites EVERY file touched at idx or later
+// back (#1879 case 1); the correction is recorded as USER-sourced. Agent
+// self-reverts must use RevertWithFilesSource(id, "agent") (#1449-A: an
+// agent rollback narrated as a user rejection is a misattribution).
+func (m *Manager) RevertWithFiles(id string) (*Checkpoint, []string, error) {
+	return m.RevertWithFilesSource(id, "user")
+}
+
+func (m *Manager) RevertWithFilesSource(id, source string) (*Checkpoint, []string, error) {
+	return m.revertWithFiles(id, source)
+}
+
+// revertWithFiles rewrites EVERY file touched at idx or later
 // but historically returned only the target checkpoint - callers cleaning
 // up per-file state (e.g. the agent's expired-read ledger) cleaned a single
 // file and stale state resurfaced on the co-existing reverted files.
-func (m *Manager) RevertWithFiles(id string) (*Checkpoint, []string, error) {
+func (m *Manager) revertWithFiles(id, source string) (*Checkpoint, []string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -305,7 +316,7 @@ func (m *Manager) RevertWithFiles(id string) (*Checkpoint, []string, error) {
 		ToolCall: cp.ToolCall,
 		RunID:    cp.RunID,
 		Time:     time.Now(),
-		Source:   "user", // /undo-run is a user slash command (#1449-A)
+		Source:   source, // #1708: caller-declared (#1449-A) - was hardcoded "user"
 	})
 
 	return &cp, files, nil


### PR DESCRIPTION
Revert's correction hardcoded `Source="user"` - the agent's undo_edit action=revert path (RevertWithFiles) inherited it, and the correction-feedback detector narrated the agent's OWN rollback as a user rejection, the exact misattribution #1449-A forbids (it fixed the Undo branch only - the fifth same-family missed-sync: #868/#1332/#1506/#1510/#1517).

New `RevertWithFilesSource(id, "agent")` for the agent path; panel/CLI entries keep "user" via the compatible wrappers (inspector_panel untouched).

Note: the agent package has a pre-existing failure on clean main (`TestAttentionFragmentSingleShotHonest1855` - fails identically with and without this change, unrelated domain); this PR's targeted verification: checkpoint package full PASS + agent Checkpoint/Revert families PASS.

Isolated worktree (fresh origin/main): builds + gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)