### PR TITLE
fix(tool): tool_suggest deterministic tie-breaking (#1708 case 2)

### DIFF
--- a/internal/tool/tool_suggest.go
+++ b/internal/tool/tool_suggest.go
@@ -32,14 +32,18 @@ func SuggestToolName(registry *Registry, name string) string {
 		isPrefix := strings.HasPrefix(cand, name) || strings.HasPrefix(name, cand)
 		if isPrefix && len(name) >= 3 {
 			// Prefix match is a strong signal; treat as distance 1.
-			if 1 < bestDist {
+			// #1708: ties previously kept the FIRST-REGISTERED candidate -
+			// "mul" hit multi_file_read/multi_edit_file/... in whatever
+			// order registration happened to use. Lexical order is stable
+			// and deterministic across builds.
+			if 1 < bestDist || (1 == bestDist && t.Name() < bestName) {
 				bestDist = 1
 				bestName = t.Name()
 			}
 			continue
 		}
 
-		if dist < bestDist {
+		if dist < bestDist || (dist == bestDist && t.Name() < bestName) {
 			bestDist = dist
 			bestName = t.Name()
 		}

--- a/internal/tool/tool_suggest_1708_test.go
+++ b/internal/tool/tool_suggest_1708_test.go
@@ -1,0 +1,38 @@
+package tool
+
+import "testing"
+
+// #1708 case 2: equal-distance suggestions must not depend on tool
+// REGISTRATION order - ties resolve to the lexically smaller name.
+// "greb" is distance-1 from "grep" and (via prefix/lexical rules)
+// ambiguous inputs like "glob2" tie across glob/grep at distance 2;
+// assert stability across repeated calls and reverse registration.
+func TestToolSuggestTieDeterministic1708(t *testing.T) {
+	reg := setupTestRegistry()
+	got := SuggestToolName(reg, "greb")
+	if got != "grep" {
+		t.Fatalf("greb: want grep, got %q", got)
+	}
+	for i := 0; i < 8; i++ {
+		if again := SuggestToolName(reg, "greb"); again != got {
+			t.Fatalf("nondeterministic suggestion: %q vs %q", got, again)
+		}
+	}
+	// Reverse registration order must not change a TIED result:
+	// "glob" vs "grep" both distance 2 from "grXb"-style inputs.
+	reg2 := NewRegistry()
+	_ = reg2.Register(Grep{})
+	_ = reg2.Register(Glob{})
+	_ = reg2.Register(ReadFile{})
+	_ = reg2.Register(EditFile{WorkingDir: "/tmp"})
+	a := SuggestToolName(reg2, "grbb")
+	reg3 := NewRegistry()
+	_ = reg3.Register(EditFile{WorkingDir: "/tmp"})
+	_ = reg3.Register(ReadFile{})
+	_ = reg3.Register(Glob{})
+	_ = reg3.Register(Grep{})
+	b := SuggestToolName(reg3, "grbb")
+	if a != b {
+		t.Fatalf("tie winner depends on registration order: %q vs %q", a, b)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1708 (case 2; case 1 landed on main separately as RevertWithFilesSource — this PR rebased onto it).

- **Case 2 (Low)**: tool_suggest ties previously kept the first-registered candidate (`dist < bestDist` false on ties) — "mul" resolved to whichever multi_* tool registered first. Ties at equal distance (prefix branch and plain branch) now prefer the lexically smaller name: deterministic across builds, sessions, and registration order.

## Verification evidence (review)
Isolated worktree, rebased on latest main: tool suite **34.7s PASS**. Pin TestToolSuggestTieDeterministic1708 asserts reverse registration order yields the same winner (the exact nondeterminism class).

Closes #1708

Generated with [ggcode](https://github.com/topcheer/ggcode)
