### PR TITLE
fix(tui): onboarding discovery clamps model cursor to the FILTERED list (#1748)

### DIFF
--- a/internal/tui/onboard.go
+++ b/internal/tui/onboard.go
@@ -350,8 +350,17 @@ func (m *onboardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// #1385 side-fix: a deeper cursor from the pre-discovery list
 				// could point past the new list - clamp so the first render has
 				// a valid highlight.
-				if m.modelCursor >= len(m.models) {
-					m.modelCursor = len(m.models) - 1
+				// #1748: clamp against the FILTERED list - consumers index
+				// m.modelFiltered[m.modelCursor], and a narrowing filter
+				// typed during discovery left the full-list clamp pointing
+				// past the filtered tail: Enter without moving the cursor
+				// panicked out of range (custom-provider path).
+				if n := len(m.modelFiltered); n > 0 {
+					if m.modelCursor >= n {
+						m.modelCursor = n - 1
+					}
+				} else {
+					m.modelCursor = 0
 				}
 				if m.modelCursor < 0 {
 					m.modelCursor = 0

--- a/internal/tui/onboard_clamp_1748_test.go
+++ b/internal/tui/onboard_clamp_1748_test.go
@@ -1,0 +1,30 @@
+package tui
+
+import "testing"
+
+// #1748: discovery arriving while a NARROWING filter is active must clamp
+// the cursor against the FILTERED list - consumers index
+// modelFiltered[cursor]. The old full-list clamp left the cursor past the
+// filtered tail; Enter without moving the cursor panicked out of range.
+func TestOnboardDiscoverClampsCursorToFilteredList1748(t *testing.T) {
+	m := newOnboardModelForTest()
+	m.step = onboardStepModel
+	m.discoverGen = 3
+	// Pre-discovery list deep enough that the stale cursor is large.
+	m.models = []string{"m0", "m1", "m2", "m3", "m4", "m5"}
+	m.modelCursor = 5
+	// Narrowing filter typed DURING discovery: only glm entries survive.
+	m.modelFilter.SetValue("glm")
+	m.applyModelFilter()
+
+	m2, _ := m.Update(discoverResultMsg{
+		models: []string{"a0", "a1", "a2", "a3", "a4", "glm5", "glm5f"},
+		gen:    3,
+	})
+	got := *m2.(*onboardModel)
+	if got.modelCursor >= len(got.modelFiltered) {
+		t.Fatalf("cursor %d must be clamped to filtered list (len %d)", got.modelCursor, len(got.modelFiltered))
+	}
+	// The exact consumer indexing path must not panic.
+	_ = got.models[got.modelFiltered[got.modelCursor]]
+}


### PR DESCRIPTION
## Summary
Closes #1748.

discoverResultMsg clamped the model cursor against the FULL list while both consumers index `modelFiltered[cursor]` — a narrowing filter typed during discovery (modelLoading blocks no keys) + Enter without moving the cursor panicked the custom-provider onboarding path. Clamp now uses the filtered list (0-guarded), matching #1385-B's own stated intent (highlight renders from the filtered table too).

## Verification evidence (review)
Isolated worktree: tui suite **9.5s PASS**. Pin TestOnboardDiscoverClampsCursorToFilteredList1748; verified the pin FAILS against pre-fix code (stash check) — it genuinely locks the fix.

Closes #1748

Generated with [ggcode](https://github.com/topcheer/ggcode)
