### PR TITLE
fix(config): protocol default only on creation; key persistence surfaced; cleared keys removed (#1706)

### DIFF
--- a/internal/config/api_keys.go
+++ b/internal/config/api_keys.go
@@ -504,6 +504,61 @@ func writeKeysEnv(newEntries map[string]string) error {
 	return writeKeysEnvTo(newEntries, KeysEnvPath())
 }
 
+// removeKeysEnv deletes the named variables from keys.env (#1706 case 3:
+// clearing a key used to leave the stale plaintext entry behind forever -
+// writeKeysEnv only ever adds/updates, so the secret outlived its config).
+func removeKeysEnv(names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+	path := KeysEnvPath()
+	unlock := lockConfigFile(path)
+	defer unlock()
+
+	del := make(map[string]bool, len(names))
+	for _, n := range names {
+		del[n] = true
+	}
+
+	existing := make(map[string]string)
+	if data, err := os.ReadFile(path); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			name, value, ok := parseEnvAssignment(line)
+			if ok {
+				existing[name] = value
+			}
+		}
+	}
+	changed := false
+	for _, n := range names {
+		if _, ok := existing[n]; ok {
+			delete(existing, n)
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+
+	keys := make([]string, 0, len(existing))
+	for k := range existing {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString("# Managed by ggcode — DO NOT EDIT manually.\n")
+	b.WriteString("# Use ggcode config to change API keys.\n")
+	for _, k := range keys {
+		fmt.Fprintf(&b, "export %s='%s'\n", k, existing[k])
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), secureConfigDirMode); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(b.String()), secureConfigFileMode)
+}
+
 // writeKeysEnvTo merges new entries into the keys.env file at the given path.
 func writeKeysEnvTo(newEntries map[string]string, path string) error {
 	// Acquire cross-process lock to prevent concurrent read-modify-write

--- a/internal/config/api_keys_1706_test.go
+++ b/internal/config/api_keys_1706_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #1706 case 1: a PARTIAL update (base_url only, protocol omitted) must
+// keep the existing protocol - the pre-merge default silently flipped an
+// anthropic endpoint to openai.
+func TestAddEndpointPartialUpdateKeepsProtocol1706(t *testing.T) {
+	c := testConfigWithVendor()
+	if err := c.AddEndpoint("zai", "ep1", "anthropic", "https://a.example", "sk-x"); err != nil {
+		t.Fatal(err)
+	}
+	// Update base_url only.
+	if err := c.AddEndpoint("zai", "ep1", "", "https://b.example", ""); err != nil {
+		t.Fatal(err)
+	}
+	got := c.Vendors["zai"].Endpoints["ep1"]
+	if got.Protocol != "anthropic" {
+		t.Fatalf("protocol silently flipped: got %q, want anthropic", got.Protocol)
+	}
+	if got.BaseURL != "https://b.example" {
+		t.Fatalf("base_url not updated: %q", got.BaseURL)
+	}
+	// NEW endpoint without protocol still defaults to openai.
+	if err := c.AddEndpoint("zai", "ep2", "", "https://c.example", ""); err != nil {
+		t.Fatal(err)
+	}
+	if p := c.Vendors["zai"].Endpoints["ep2"].Protocol; p != "openai" {
+		t.Fatalf("new endpoint default = %q, want openai", p)
+	}
+}
+
+// #1706 case 3: clearing a vendor key removes the keys.env entry.
+func TestSetVendorAPIKeyClearRemovesKeysEnv1706(t *testing.T) {
+	keysPath := filepath.Join(t.TempDir(), "keys.env")
+	keysEnvPathOverride = keysPath
+	defer func() { keysEnvPathOverride = "" }()
+
+	c := testConfigWithVendor()
+	if err := c.SetVendorAPIKey("zai", "sk-secret"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(keysPath)
+	if !strings.Contains(string(data), "sk-secret") {
+		t.Fatal("key should be persisted for the set-up phase")
+	}
+	if err := c.SetVendorAPIKey("zai", ""); err != nil {
+		t.Fatal(err)
+	}
+	data2, _ := os.ReadFile(keysPath)
+	if strings.Contains(string(data2), "sk-secret") {
+		t.Fatal("cleared key must not linger in keys.env")
+	}
+	if c.Vendors["zai"].APIKey != "" {
+		t.Fatal("vendor key must be empty after clear")
+	}
+}

--- a/internal/config/config_keys.go
+++ b/internal/config/config_keys.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/topcheer/ggcode/internal/debug"
+	"os"
+	"strings"
 )
 
 // SetEndpointAPIKey updates the active endpoint or vendor-level API key.
@@ -26,12 +26,18 @@ func (c *Config) SetEndpointAPIKey(vendor, endpoint, apiKey string, vendorScoped
 	// If the value is already an env reference (${VAR}), store as-is.
 	if _, isRef := envReferenceVarName(apiKey); isRef || apiKey == "" {
 		if vendorScoped {
+			if apiKey == "" {
+				clearAPIKeyRefEnv(vc.APIKey) // #1706 case 3
+			}
 			vc.APIKey = apiKey
 			c.Vendors[vendor] = vc
 		} else {
 			ep, ok := vc.Endpoints[endpoint]
 			if !ok {
 				return fmt.Errorf("endpoint %q is not configured for vendor %q", endpoint, vendor)
+			}
+			if apiKey == "" {
+				clearAPIKeyRefEnv(ep.APIKey) // #1706 case 3
 			}
 			ep.APIKey = apiKey
 			vc.Endpoints[endpoint] = ep
@@ -53,9 +59,13 @@ func (c *Config) SetEndpointAPIKey(vendor, endpoint, apiKey string, vendorScoped
 	os.Setenv(envVarName, apiKey)
 
 	// Persist to keys.env so the key survives restarts.
+	// #1706 case 2: a failure here used to be swallowed (debug-only) -
+	// the key lived in process env, vanished on restart, and NeedsOnboard
+	// could re-trigger. SetVendorAPIKey already hard-errors on this exact
+	// condition (#1517); same semantics now (os.Setenv above keeps the
+	// current session working even when the caller logs and continues).
 	if err := writeKeysEnv(map[string]string{envVarName: apiKey}); err != nil {
-		// Non-fatal: the key works for this session via os.Setenv above.
-		debug.Log("config", "failed to persist %s to keys.env: %v", envVarName, err)
+		return fmt.Errorf("persisting API key for %s/%s: %w", vendor, endpoint, err)
 	}
 
 	ref := "${" + envVarName + "}"
@@ -74,6 +84,18 @@ func (c *Config) SetEndpointAPIKey(vendor, endpoint, apiKey string, vendorScoped
 	return nil
 }
 
+// clearAPIKeyRefEnv removes the keys.env entry backing a ${VAR} ref (if
+// any) so a cleared key does not leave stale plaintext behind (#1706
+// case 3).
+func clearAPIKeyRefEnv(ref string) {
+	if name, ok := envReferenceVarName(ref); ok {
+		if err := removeKeysEnv([]string{name}); err != nil {
+			debug.Log("config", "failed to remove %s from keys.env: %v", name, err)
+		}
+		os.Unsetenv(name)
+	}
+}
+
 // SetVendorAPIKey sets the vendor-level API key.
 func (c *Config) SetVendorAPIKey(vendor, apiKey string) error {
 	if c == nil {
@@ -85,6 +107,8 @@ func (c *Config) SetVendorAPIKey(vendor, apiKey string) error {
 	}
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
+		// #1706 case 3: drop the keys.env entry backing the old ref.
+		clearAPIKeyRefEnv(vc.APIKey)
 		vc.APIKey = ""
 	} else if _, isRef := envReferenceVarName(apiKey); isRef {
 		vc.APIKey = apiKey

--- a/internal/config/config_vendor.go
+++ b/internal/config/config_vendor.go
@@ -462,7 +462,17 @@ func (c *Config) AddEndpoint(vendor, endpointName, protocol, baseURL, apiKey str
 	if endpointName == "" {
 		return fmt.Errorf("endpoint name cannot be empty")
 	}
-	if protocol == "" {
+
+	// #1706 case 1: the openai default previously applied HERE, before
+	// the merge check - so ep.Protocol was never empty and the merge
+	// branch's "empty = keep existing" never applied to protocol: a
+	// partial update (base_url only) silently flipped an anthropic
+	// endpoint to openai. The default now applies only to NEW endpoints.
+	isNew := false
+	if _, exists := vc.Endpoints[endpointName]; !exists {
+		isNew = true
+	}
+	if protocol == "" && isNew {
 		protocol = "openai"
 	}
 


### PR DESCRIPTION
## Summary
Closes #1706 (all three cases).

1. **Case 1 (Med-Low)**: openai protocol default applied before the #1517 merge check — partial updates (base_url only) silently flipped anthropic endpoints to openai via four entry points. Default now creation-only.
2. **Case 2 (Low)**: SetEndpointAPIKey swallowed keys.env persistence failures while SetVendorAPIKey hard-errored — unified to hard-error (session still works via os.Setenv).
3. **Case 3 (Low)**: clearing a key never removed the stale keys.env entry — new removeKeysEnv (cross-process lock + sorted rewrite) wired into both clear paths; the ${VAR} backing the old ref is deleted and unset.

## Verification evidence (review)
Isolated worktree: config suite **10.0s PASS**. Pins: partial-update-keeps-protocol (+ new-endpoint default still applies), clear-key round-trip via the same keysEnvPathOverride hook the existing tests use.

Closes #1706

Generated with [ggcode](https://github.com/topcheer/ggcode)
