### PR TITLE
fix(tool,desktop): TS scaffold CI configs; scan_todos honest errors; bounded blame; SendHiddenText gen capture (#1701)

### DIFF
--- a/desktop/wailskit/chat.go
+++ b/desktop/wailskit/chat.go
@@ -3552,8 +3552,18 @@ func (b *ChatBridge) SendHiddenText(text string) error {
 	b.mu.Lock()
 	b.runSes = b.currentSes
 	b.mu.Unlock()
-	b.setRunPersistSnapshot()
-	runGen = b.currentRunGeneration()
+	// #1701 case 3: setRunPersistSnapshot bumps runGeneration itself; the
+	// re-read above raced another run's bump between the two lock windows
+	// and could capture THAT generation, defeating emitIfCurrent - the
+	// same inversion #1511 removed from the text main path. Hold the lock
+	// across bump-and-capture so runGen is exactly the generation this
+	// run created (#1181 guard pattern).
+	b.mu.Lock()
+	b.runGeneration++
+	b.activeRunGen = b.runGeneration
+	b.persistSession = b.runSes
+	runGen = b.runGeneration
+	b.mu.Unlock()
 	err := b.agent.RunStream(ctx, text, func(ev provider.StreamEvent) {
 		b.emitIfCurrent(runGen, ev)
 	})

--- a/internal/tool/scaffold_templates.go
+++ b/internal/tool/scaffold_templates.go
@@ -119,6 +119,7 @@ func tsTemplate(name, rootDir string, ci, docker bool) []scaffoldFile {
   },
   "license": "MIT",
   "devDependencies": {
+    "@eslint/js": "^9.11.0",
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.13",
     "@types/node": "^20.14.0",
@@ -156,6 +157,42 @@ func tsTemplate(name, rootDir string, ci, docker bool) []scaffoldFile {
 		Path: "src/index.ts",
 		Content: fmt.Sprintf(`console.log("Hello from %s!");
 `, name),
+	})
+
+	// #1701 case 1: eslint 9 requires a flat config and jest needs a TS
+	// transform for .test.ts - the CI workflow (npm run lint && npm test)
+	// failed on every freshly generated repo (#1335 added the deps but
+	// no configs).
+	files = append(files, scaffoldFile{
+		Path: "eslint.config.js",
+		Content: `const js = require("@eslint/js");
+
+module.exports = [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "commonjs",
+      globals: { console: "readonly", process: "readonly" },
+    },
+    rules: {},
+  },
+  {
+    ignores: ["dist/**", "coverage/**"],
+  },
+];
+`,
+	})
+
+	files = append(files, scaffoldFile{
+		Path: "jest.config.js",
+		Content: `/** @type {import('jest').Config} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+};
+`,
 	})
 
 	files = append(files, scaffoldFile{

--- a/internal/tool/scan_todos.go
+++ b/internal/tool/scan_todos.go
@@ -181,12 +181,23 @@ func (t ScanTodosTool) Execute(ctx context.Context, input json.RawMessage) (Resu
 	// Parse category filter
 	var categoryFilter map[string]bool
 	if args.Categories != "" {
+		valid := make(map[string]bool, len(todoMarkerOrder))
+		for _, m := range todoMarkerOrder {
+			valid[m] = true
+		}
 		categoryFilter = make(map[string]bool)
 		for _, c := range strings.Split(args.Categories, ",") {
 			c = strings.ToUpper(strings.TrimSpace(c))
-			if c != "" {
-				categoryFilter[c] = true
+			if c == "" {
+				continue
 			}
+			// #1701 case 4: an unknown category used to be silently
+			// accepted and filtered EVERYTHING out - the tool reported
+			// "Codebase is clean." for a typo like "FOO".
+			if !valid[c] {
+				return Result{IsError: true, Content: fmt.Sprintf("unknown category %q; valid: TODO, FIXME, HACK, XXX, BUG, NOTE, WORKAROUND", c)}, nil
+			}
+			categoryFilter[c] = true
 		}
 	}
 
@@ -228,6 +239,27 @@ func (t ScanTodosTool) Execute(ctx context.Context, input json.RawMessage) (Resu
 	return Result{Content: content}, nil
 }
 
+// limitedBuf caps captured stdout at 8MB (#1701 case 6: blame porcelain
+// is verbose; pathological files must not balloon agent memory).
+type limitedBuf struct {
+	b []byte
+}
+
+func (w *limitedBuf) Write(p []byte) (int, error) {
+	const max = 8 << 20
+	if len(w.b) < max {
+		room := max - len(w.b)
+		if room > len(p) {
+			room = len(p)
+		}
+		w.b = append(w.b, p[:room]...)
+	}
+	// Always report full consumption so the command never sees EPIPE.
+	return len(p), nil
+}
+
+func (w *limitedBuf) bytes() []byte { return w.b }
+
 // scanDirectoryForTodos walks the directory tree and collects all markers.
 func scanDirectoryForTodos(rootDir string, categoryFilter map[string]bool) ([]TodoMarker, int, error) {
 	var markers []TodoMarker
@@ -235,7 +267,15 @@ func scanDirectoryForTodos(rootDir string, categoryFilter map[string]bool) ([]To
 
 	err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil // skip unreadable paths
+			// #1701 case 2: an unreadable/nonexistent ROOT used to be
+			// swallowed here and the tool reported "Codebase is clean."
+			// with filesScanned == 0 - the same misleading-success class
+			// #1510 fixed for code-health. Only NON-root paths are
+			// skipped.
+			if path == rootDir {
+				return err
+			}
+			return nil
 		}
 		if d.IsDir() {
 			name := d.Name()
@@ -372,12 +412,20 @@ func enrichWithBlame(rootDir string, markers []TodoMarker, staleDays int) {
 
 	for relPath, indices := range fileMarkers {
 		// Run git blame for this file
-		cmd := exec.Command("git", "blame", "--line-porcelain", "--date=iso", relPath)
+		// #1701 case 6: bound the call - plain Command with unbounded
+		// Output could hang or balloon on pathological files. 30s per
+		// file, 8MB stdout cap (blame porcelain is verbose).
+		blameCtx, cancelBlame := context.WithTimeout(context.Background(), 30*time.Second)
+		cmd := exec.CommandContext(blameCtx, "git", "blame", "--line-porcelain", "--date=iso", relPath)
 		cmd.Dir = rootDir
-		output, err := cmd.Output()
+		var lb limitedBuf
+		cmd.Stdout = &lb
+		err := cmd.Run()
+		cancelBlame()
 		if err != nil {
 			continue
 		}
+		output := lb.bytes()
 		// Parse git blame output
 		blameInfo := parseGitBlame(output)
 

--- a/internal/tool/scan_todos_1701_test.go
+++ b/internal/tool/scan_todos_1701_test.go
@@ -1,0 +1,33 @@
+package tool
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// #1701 case 2: an unreadable/nonexistent root must ERROR, not report
+// "Codebase is clean." - the #1510 misleading-success class.
+func TestScanTodosBadRootErrors1701(t *testing.T) {
+	var tool ScanTodosTool
+	res, err := tool.Execute(context.Background(), []byte(`{"path": "/nonexistent-path-xyz-1701"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("bad root must be an error, got: %s", res.Content)
+	}
+}
+
+// #1701 case 4: unknown categories must ERROR (a typo used to filter
+// everything and report clean).
+func TestScanTodosUnknownCategoryErrors1701(t *testing.T) {
+	var tool2 ScanTodosTool
+	res, err := tool2.Execute(context.Background(), []byte(`{"path": ".", "categories": "FOO"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Content, "unknown category") {
+		t.Fatalf("unknown category must error, got: %s", res.Content)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1701 (cases 1,2,3,4,6; case 5/7 documented-only per issue; mdx sub-item already refuted).

1. **Case 1 (Med)**: TS scaffold CI red on fresh repos (eslint ^9 without flat config; jest without TS transform) — templates now emit eslint.config.js + jest.config.js (+@eslint/js dep).
2. **Case 2 (Med, #1510 sibling)**: scan_todos bad root reported "Codebase is clean." — root WalkDir errors propagate now.
3. **Case 3 (Low-Med, #1511 residue)**: SendHiddenText re-read runGen after setRunPersistSnapshot's internal bump (two lock windows) — bump-and-capture now one critical section.
4. **Case 4 (Low)**: unknown categories silently filtered everything ("FOO" → clean) — explicit error with valid list.
5. **Case 6 (Low)**: git blame unbounded — 30s per-file timeout + 8MB capped writer.

## Verification evidence (review)
Isolated worktree: tool suite **39.6s PASS**; wailskit compiles clean under goolm (its plain-build libolm failure is a pre-existing environment dependency, not touched). Pins: bad-root errors, unknown-category errors.

Closes #1701

Generated with [ggcode](https://github.com/topcheer/ggcode)
