### PR TITLE
test(tool): darwin build tag for the iterm2 1691 companion test (un-greens main)

### DIFF
--- a/internal/tool/iterm2_1691_test.go
+++ b/internal/tool/iterm2_1691_test.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package tool
 
 import (


### PR DESCRIPTION
The companion test exercises `countDroppedControlRunes`, a darwin-only helper - without the tag, linux/windows CI vet fails with 'undefined' (the test file compiles while the darwin source is excluded). Main has been red since 7f01a08b (5 consecutive failures).

Verified: linux+windows GOOS vet clean, darwin test PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)