### PR TITLE
test(agent): reconcile #1855 pin with #1843 case-2 semantics (main red)

### DIFF
--- a/internal/agent/attention_fragment_test.go
+++ b/internal/agent/attention_fragment_test.go
@@ -250,10 +250,16 @@ func TestAttentionFragmentSingleShotHonest1855(t *testing.T) {
 	if m := s.analyze(); m != "" {
 		t.Fatalf("single-shot violated: %s", m)
 	}
-	// reset() clears the window but deliberately keeps warnCount (per-run
-	// persistence - see reset()); re-arm is a NEW state for the next run.
+	// #1843 case 2 wins over this test's original pin: reset() is called
+	// once per user turn (agent.go), and warnCount=0 there re-opens the
+	// quota - otherwise afMaxWarnings=1 means ONE warning per SESSION,
+	// contradicting the "per run" comment. The two pins conflicted; the
+	// #1843 semantics is the correct one, so this test now asserts it.
 	s.reset()
-	if s.warnCount != 1 {
-		t.Fatalf("warnCount must persist across window reset, got %d", s.warnCount)
+	if s.warnCount != 0 {
+		t.Fatalf("warnCount must re-open per user turn (reset), got %d", s.warnCount)
+	}
+	if m := s.analyze(); m != "" {
+		t.Fatalf("fresh window must not warn before thresholds: %s", m)
 	}
 }


### PR DESCRIPTION
## Root cause
Two fixes landed with directly conflicting pins:
- #1855 case 1: TestAttentionFragmentSingleShotHonest1855 asserted `warnCount` SURVIVES reset() (per-run persistence)
- #1843 case 2: made reset() clear warnCount

Whoever merged last went red - the test has failed deterministically on main since it arrived (not a flake; reruns cannot fix it).

## Why #1843 wins
reset()'s ONLY call site is the per-user-turn block (agent.go:1531). With afMaxWarnings=1, the #1855 pin meant ONE warning per entire session - contradicting the "per run" comment both fixes cite. #1843's per-user-turn re-arm is the correct semantics.

## Change
Test-only: the #1855 test now asserts warnCount re-opens on reset() and a fresh window stays silent before thresholds. Zero production code touched.

Verified in isolated worktree: agent FULL package PASS (21.9s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)