### PR TITLE
fix(tui,lanchat): uncancellable windows no longer poison runCanceled; honest receipts (#1768)

### DIFF
--- a/internal/lanchat/hub.go
+++ b/internal/lanchat/hub.go
@@ -1692,6 +1692,31 @@ func (h *Hub) NotifyAgentComplete(messageID string) {
 	safego.Go("lanchat.sendReceipt", func() { h.sendReceipt(*msg, StatusCompleted, "") })
 }
 
+// NotifyAgentNotCompleted sends a non-completed receipt for a run that
+// ended cancelled or failed (#1768 case 3) - the peer must not be told
+// the task finished. Uses StatusRejected as the terminal non-success
+// receipt the protocol already defines.
+func (h *Hub) NotifyAgentNotCompleted(messageID string) {
+	h.mu.RLock()
+	var msg *Message
+	if m, ok := h.recentAgentMsgs[messageID]; ok {
+		msg = &m
+	} else {
+		for i := range h.messages {
+			if h.messages[i].ID == messageID {
+				msg = &h.messages[i]
+				break
+			}
+		}
+	}
+	h.mu.RUnlock()
+	if msg == nil {
+		debug.Log("lanchat", "NotifyAgentNotCompleted: message %s not found, no receipt sent", messageID)
+		return
+	}
+	safego.Go("lanchat.sendReceipt", func() { h.sendReceipt(*msg, StatusRejected, "") })
+}
+
 // handleUDPEnvelope processes incoming UDP messages (called by UDPTransport).
 func (h *Hub) handleUDPEnvelope(env udpEnvelope, remoteAddr net.Addr) {
 	// Handle ACK

--- a/internal/tui/cancel_1768_test.go
+++ b/internal/tui/cancel_1768_test.go
@@ -1,0 +1,27 @@
+package tui
+
+import "testing"
+
+// #1768 case 1+2: cancelActiveRun during an uncancellable loading
+// window (e.g. /compact: Background ctx, cancelFunc nil) must NOT
+// poison runCanceled - the next normal run would be treated as
+// cancelled (persist/metrics/drain skipped).
+func TestCancelActiveRunNoPoisonWhenUncancellable1768(t *testing.T) {
+	m := newTestModel()
+	m.setLoading(true) // /compact-style loading
+	m.cancelFunc = nil // Background ctx - nothing to cancel
+	m.shellOwnedLoading = false
+
+	m.cancelActiveRun()
+
+	if m.runCanceled {
+		t.Fatal("runCanceled must stay false when there is no cancellable run (cross-run poisoning)")
+	}
+
+	// A cancellable run still poisons normally.
+	m.cancelFunc = func() {}
+	m.cancelActiveRun()
+	if !m.runCanceled {
+		t.Fatal("runCanceled must be set when a cancellable run is active")
+	}
+}

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -2904,6 +2904,7 @@ func TestCtrlCCancelDoesNotRestoreHiddenPendingSubmission(t *testing.T) {
 func TestCancelActiveRunClearsVisibleActivityStateImmediately(t *testing.T) {
 	m := newTestModel()
 	m.loading = true
+	m.cancelFunc = func() {} // #1768: a CANCELLABLE run - visible-state clearing only applies then
 	m.statusActivity = "Thinking..."
 	m.statusToolName = "npm run type-check"
 	m.statusToolArg = "type-check"

--- a/internal/tui/model_coverage_test.go
+++ b/internal/tui/model_coverage_test.go
@@ -461,10 +461,13 @@ func TestCancelActiveRun_NilCancelFunc(t *testing.T) {
 	m := newTestModel()
 	m.loading = true
 	m.cancelFunc = nil
-	// Should not panic
+	// Should not panic.
 	m.cancelActiveRun()
-	if !m.runCanceled {
-		t.Error("expected runCanceled to be true even with nil cancelFunc")
+	// #1768: an uncancellable loading window (/compact, Background ctx)
+	// must NOT poison runCanceled - the next normal run would be treated
+	// as cancelled (persist/metrics/drain skipped).
+	if m.runCanceled {
+		t.Error("runCanceled must stay false when nothing is cancellable (cross-run poisoning)")
 	}
 }
 

--- a/internal/tui/model_pending.go
+++ b/internal/tui/model_pending.go
@@ -110,6 +110,17 @@ func (m *Model) cancelActiveRun() {
 		return
 	}
 	debug.Log("cancel", "cancelActiveRun: START")
+	// #1768 case 1+2: only poison runCanceled when there is something
+	// to cancel. /compact runs on context.Background (cancelFunc nil,
+	// uncancellable by design) with loading=true - Esc-Esc during it
+	// used to set runCanceled with nothing to cancel, and nothing
+	// reset it before the NEXT normal run, which was then treated as
+	// cancelled: session persist, metrics digest, and the pending-queue
+	// drain all skipped.
+	if !m.shellOwnedLoading && m.cancelFunc == nil {
+		debug.Log("cancel", "cancelActiveRun: no active cancellable run (loading is uncancellable e.g. /compact); not poisoning runCanceled")
+		return
+	}
 	m.runCanceled = true
 	cancelledTools := m.chatCancelAllRunningTools()
 	for _, tool := range cancelledTools {

--- a/internal/tui/update_done.go
+++ b/internal/tui/update_done.go
@@ -46,6 +46,20 @@ func (m Model) handleDoneMsg(msg doneMsg) (Model, tea.Cmd) {
 	wasFailed := m.runFailed
 	m.runCanceled = false
 	m.runFailed = false
+
+	// #1768 case 3: the lanchat receipt used to fire BEFORE the
+	// canceled/failed flags were read - failed and cancelled runs still
+	// reported "completed" to the peer. Distinguish now that we know the
+	// outcome (completed receipt for healthy runs; a rejected-status
+	// receipt otherwise so the peer is not told the task finished).
+	if m.lanChatPendingComplete != "" && m.lanChatHub != nil {
+		if wasCanceled || wasFailed {
+			m.lanChatHub.NotifyAgentNotCompleted(m.lanChatPendingComplete)
+		} else {
+			m.lanChatHub.NotifyAgentComplete(m.lanChatPendingComplete)
+		}
+		m.lanChatPendingComplete = ""
+	}
 	m.statusActivity = ""
 	m.statusToolName = ""
 	m.statusToolArg = ""
@@ -91,11 +105,6 @@ func (m Model) handleAgentDoneMsg(msg agentDoneMsg) (Model, tea.Cmd) {
 	if msg.RunID != m.activeAgentRunID {
 		return m, nil
 	}
-	// Send "completed" receipt for lanchat messages that triggered this agent run
-	if m.lanChatPendingComplete != "" && m.lanChatHub != nil {
-		m.lanChatHub.NotifyAgentComplete(m.lanChatPendingComplete)
-		m.lanChatPendingComplete = ""
-	}
 	if m.agent != nil {
 		m.projMemFiles = m.agent.ProjectMemoryFiles()
 	}
@@ -113,6 +122,20 @@ func (m Model) handleAgentDoneMsg(msg agentDoneMsg) (Model, tea.Cmd) {
 	wasFailed := m.runFailed
 	m.runCanceled = false
 	m.runFailed = false
+
+	// #1768 case 3: the lanchat receipt used to fire BEFORE the
+	// canceled/failed flags were read - failed and cancelled runs still
+	// reported "completed" to the peer. Distinguish now that we know the
+	// outcome (completed receipt for healthy runs; a rejected-status
+	// receipt otherwise so the peer is not told the task finished).
+	if m.lanChatPendingComplete != "" && m.lanChatHub != nil {
+		if wasCanceled || wasFailed {
+			m.lanChatHub.NotifyAgentNotCompleted(m.lanChatPendingComplete)
+		} else {
+			m.lanChatHub.NotifyAgentComplete(m.lanChatPendingComplete)
+		}
+		m.lanChatPendingComplete = ""
+	}
 	m.statusActivity = ""
 	m.statusToolName = ""
 	m.statusToolArg = ""


### PR DESCRIPTION
## Summary
Closes #1768 (cases 1+2 shared root; case 3).

1. **Case 1+2 (Med)**: Esc-Esc during an uncancellable loading window (/compact on Background ctx) poisoned `runCanceled` with nothing to cancel; the NEXT normal run was then treated as cancelled — persist/metrics/pending-drain all skipped. `cancelActiveRun` now early-returns (no poisoning) when `!shellOwnedLoading && cancelFunc == nil`.
2. **Case 3 (Low-Med)**: lanchat receipt fired before `wasCanceled/wasFailed` were read — failed/cancelled runs reported "completed". Receipt moved after the outcome read; new `NotifyAgentNotCompleted` (StatusRejected) for non-success runs.

## Verification evidence (review)
Isolated worktree: tui **25.1s** / lanchat **5.8s** suites PASS. Two existing tests encoded the old poisoning semantics — updated to the new contract (original panic-safety intent preserved). Pin: TestCancelActiveRunNoPoisonWhenUncancellable1768.

Closes #1768

Generated with [ggcode](https://github.com/topcheer/ggcode)
