### PR TITLE
fix(tool): TodoWrite implements Cloner (#1707 case 1)

### DIFF
--- a/internal/tool/todo_write.go
+++ b/internal/tool/todo_write.go
@@ -64,6 +64,17 @@ func (t *TodoWrite) SetSessionID(id string) {
 	t.sessionID = id
 }
 
+// Clone satisfies the Cloner contract (#1707 case 1): Registry.Clone shares
+// non-Cloner instances across teammates, so a teammate's SetSessionID(tmID)
+// flipped the SHARED instance's sessionID - the leader's todo persistence
+// file became the teammate's, and the teammate's ClearTodos deleted the
+// file the leader was using. Each clone owns its sessionID.
+func (t *TodoWrite) Clone() Tool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return &TodoWrite{sessionID: t.sessionID}
+}
+
 // ClearTodos removes the todo file for the current session (if any).
 // This is called on agent stop to prevent permanent todo residue.
 func (t *TodoWrite) ClearTodos() {

--- a/internal/tool/todo_write_test.go
+++ b/internal/tool/todo_write_test.go
@@ -20,3 +20,18 @@ func TestTodoWriteDescriptionEncouragesMeaningfulMilestones(t *testing.T) {
 		}
 	}
 }
+
+// TestTodoWriteCloneIsolation pins #1707 case 1: cloning (what Registry.Clone
+// does per teammate) must yield an INDEPENDENT instance - mutating the
+// clone's session must not flip the original's todo file.
+func TestTodoWriteCloneIsolation(t *testing.T) {
+	orig := NewTodoWrite("leader-session")
+	clone, ok := orig.Clone().(*TodoWrite)
+	if !ok {
+		t.Fatal("Clone must return *TodoWrite")
+	}
+	clone.SetSessionID("tm-1")
+	if orig.currentPath() != TodoFilePath("leader-session") {
+		t.Fatalf("original must still point at the leader file, got %q", orig.currentPath())
+	}
+}


### PR DESCRIPTION
Registry.Clone shares non-Cloner instances across teammates - a teammate's `SetSessionID(tmID)` flipped the SHARED TodoWrite's sessionID, so the leader's todo persistence file became the teammate's (last spawn wins) and the teammate's `ClearTodos` **deleted the file the leader was actively using**. The 'each teammate gets independent tool instances' comment was a lie for TodoWrite.

Each clone now owns its sessionID; pinned by `TestTodoWriteCloneIsolation` (mutating the clone leaves the original's path untouched).

(Case 2 - the teammate_spawn tools allowlist being dropped by both hosts - and the Low items stay for follow-up.)

Isolated worktree (fresh origin/main): TodoWrite family PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)