### PR TITLE
fix(im,tui): inner-flush regression reaches fixed path (probe-proven); /im output-mode persists (#1736)

### DIFF
--- a/internal/im/message_split_1736_test.go
+++ b/internal/im/message_split_1736_test.go
@@ -1,0 +1,38 @@
+package im
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1736 case 1: the #1553-C regression test's data had NO newline, so
+// preferredByteSplit always returned the maximal prefix and the INNER
+// flush (the fixed path) was never reached - its assertions passed
+// identically on the pre-fix code. This case FORCES the inner flush:
+// an early newline makes the preferred split short (start lags far
+// behind i), then near-budget CJK fill makes the re-accumulated span
+// exceed maxBytes inside the re-sync loop.
+func TestSplitMessageBytesInnerFlushReachable1736(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("a\n") // early newline -> preferred split returns 1
+	for i := 0; i < 30; i++ {
+		sb.WriteString("中文段落") // 12B runes; re-sync span crosses maxBytes inside the inner loop
+	}
+	const maxBytes = 50
+	chunks := splitMessageBytes(sb.String(), maxBytes, true)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	for idx, c := range chunks {
+		if got := len(c); got > maxBytes {
+			t.Fatalf("chunk %d = %d bytes > max %d", idx, got, maxBytes)
+		}
+	}
+	var total int
+	for _, c := range chunks {
+		total += len([]rune(c))
+	}
+	if total != len([]rune(sb.String())) {
+		t.Fatalf("rune loss: %d vs %d", total, len([]rune(sb.String())))
+	}
+}

--- a/internal/tui/im_panel.go
+++ b/internal/tui/im_panel.go
@@ -352,6 +352,26 @@ func (m *Model) setIMOutputMode(mode string) tea.Cmd {
 		if m.imEmitter != nil {
 			m.imEmitter.SetOutputMode(mode)
 		}
+		// #1736 case 2: disable/enable in this panel persist via
+		// configMutationMsg and the agent path persists the same key
+		// (im.output_mode) via saveAndPatch - the runtime-only set here
+		// lost the user's choice on restart. Persist like the siblings.
+		if m.config != nil {
+			return configMutationMsg{
+				apply: func(m *Model) error {
+					m.config.IM.OutputMode = mode
+					return m.config.Save()
+				},
+				next: func(m *Model) tea.Cmd {
+					return func() tea.Msg {
+						return imPanelResultMsg{message: m.t("panel.im.output_mode.set", mode)}
+					}
+				},
+				fail: func(err error) tea.Msg {
+					return imPanelResultMsg{err: fmt.Errorf("persist output mode failed: %w", err)}
+				},
+			}
+		}
 		return imPanelResultMsg{message: m.t("panel.im.output_mode.set", mode)}
 	}
 }


### PR DESCRIPTION
## Summary
Closes #1736.

1. **Case 1 (Med-Low, test effectiveness)**: #1553-C regression test never reached the fixed inner-flush path (no-newline data → preferredByteSplit always maximal → inner condition permanently false; assertions pass on pre-fix code). New case forces it: early newline + near-budget CJK fill. Reachability proven via temporary instrumentation probe (new case: 1 entry; original #1553 data: 0), probe removed before commit.
2. **Case 2 (Low)**: /im panel setIMOutputMode was runtime-only while sibling actions (disable/enable) and the agent path persist the same key — choice lost on restart. Now persists via configMutationMsg.

## Verification evidence (review)
Isolated worktree: im **64.3s** / tui **9.7s** suites PASS. Probe methodology addresses the issue's own lesson: "有测试≠有效测试" — the new test is proven to execute the fixed path.

Closes #1736

Generated with [ggcode](https://github.com/topcheer/ggcode)
