### PR TITLE
fix(permission): switch_mode escalation to bypass/autopilot asks (#1705 case 1)

### DIFF
--- a/internal/permission/config_policy.go
+++ b/internal/permission/config_policy.go
@@ -114,6 +114,18 @@ func (p *ConfigPolicy) Check(toolName string, input json.RawMessage) (Decision, 
 	// save_memory: writing project memory is always safe and expected.
 	// lanchat: P2P messaging between ggcode instances — no local filesystem or system impact.
 	if IsAlwaysAllowedTool(toolName) {
+		// #1705 case 1: switch_mode stays reachable in EVERY mode (the
+		// #1210 self-rescue invariant - an agent trapped in plan mode
+		// must always be able to switch OUT), but ESCALATING to
+		// bypass/autopilot now needs consent: one zero-confirmation
+		// call used to grant near-total permissions (self-escalation),
+		// and switching to auto/bypass from plan escaped #551-D's
+		// exit_plan_mode Ask gate through the WIDER unguarded channel.
+		// Downgrade/same-level switches (and escaping plan BACK to the
+		// session's supervised mode) stay auto-allowed.
+		if toolName == "switch_mode" && switchModeEscalates(input) {
+			return Ask, nil
+		}
 		return Allow, nil
 	}
 	// #1283: im is no longer blanket-approved — only its side-effect-free
@@ -379,6 +391,18 @@ func (p *ConfigPolicy) Check(toolName string, input json.RawMessage) (Decision, 
 // side-effect-free adapter management (#1283). Anything that can move data
 // out of the machine (send, send_file) or an unknown/missing action is NOT
 // benign — fail closed toward the normal approval pipeline.
+// switchModeEscalates reports whether a switch_mode call targets a MORE
+// privileged mode (#1705 case 1): bypass/autopilot ask for consent; every
+// other target (including plan escapes) flows Allow.
+func switchModeEscalates(input json.RawMessage) bool {
+	var a struct {
+		Mode string `json:"mode"`
+	}
+	_ = json.Unmarshal(input, &a)
+	m := strings.TrimSpace(a.Mode)
+	return m == "bypass" || m == "autopilot"
+}
+
 func imActionIsBenign(input json.RawMessage) bool {
 	var m struct {
 		Action string `json:"action"`

--- a/internal/permission/zz_issue1210_guard_test.go
+++ b/internal/permission/zz_issue1210_guard_test.go
@@ -25,3 +25,32 @@ func TestIssue1210Guard_SwitchModeAllowedInEveryMode(t *testing.T) {
 		}
 	}
 }
+
+// TestIssue1705_EscalationAsks pins #1705 case 1: switching INTO
+// bypass/autopilot asks for consent in every mode - the zero-confirmation
+// self-escalation is closed - while the #1210 self-rescue invariant (every
+// other target Allow, incl. plan escapes) still holds.
+func TestIssue1705_EscalationAsks(t *testing.T) {
+	for _, mode := range ValidPermissionModes {
+		p := NewConfigPolicyWithMode(nil, nil, mode)
+		for _, target := range []string{"bypass", "autopilot"} {
+			d, err := p.Check("switch_mode", json.RawMessage(`{"mode":"`+target+`"}`))
+			if err != nil {
+				t.Fatalf("%s->%s: %v", mode, target, err)
+			}
+			if d != Ask {
+				t.Fatalf("%s->%s must Ask (escalation consent), got %v", mode, target, d)
+			}
+		}
+		// Downgrade/escape targets keep the self-rescue Allow.
+		for _, target := range []string{"plan", "supervised", "auto"} {
+			d, err := p.Check("switch_mode", json.RawMessage(`{"mode":"`+target+`"}`))
+			if err != nil {
+				t.Fatalf("%s->%s: %v", mode, target, err)
+			}
+			if d != Allow {
+				t.Fatalf("%s->%s must stay Allow (self-rescue), got %v", mode, target, d)
+			}
+		}
+	}
+}


### PR DESCRIPTION
One zero-confirmation `switch_mode` call granted near-total permissions from any mode (**self-escalation**), and switching to auto/bypass from plan escaped #551-D's exit_plan_mode Ask gate through the WIDER unguarded channel.

The always-allowed fast path now asks for consent when the TARGET is bypass/autopilot; every other target - including plan escapes, the #1210 self-rescue invariant - stays Allow. `TestIssue1705_EscalationAsks` pins both sides alongside the untouched #1210 guard (permission package full PASS).

(Case 2+ assignee validation and the Low items stay for follow-up.)

Isolated worktree (fresh origin/main): gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)