### PR TITLE
fix(provider): simple probe classifies like the tier probe - only auth aborts (#1788)

### DIFF
--- a/internal/provider/context_probe.go
+++ b/internal/provider/context_probe.go
@@ -583,20 +583,30 @@ func trySimpleProbe(ctx context.Context, p Provider) int {
 			return w
 		}
 
-		// Non-context error (auth, network, etc.) — stop probing entirely
+		// #1788: this used to abort the ENTIRE probe on any non-context
+		// error (only context/token-limit/too-long/exceeds continued to
+		// tiered probing). A transient 429 or network blip at probe start
+		// therefore returned -1, the caller fell back to estimation, and
+		// under the #1198 persistent cache a momentary rate limit could
+		// harden into a low window. Align with the tier classifier below:
+		// only AUTH aborts; rate-limit/network/5xx/timeout/unknown are
+		// inconclusive and fall through to tiered probing.
 		errMsg := strings.ToLower(err.Error())
 		isContextError := strings.Contains(errMsg, "context") ||
 			strings.Contains(errMsg, "token limit") ||
 			strings.Contains(errMsg, "too long") ||
 			strings.Contains(errMsg, "exceeds")
 
-		if !isContextError {
-			debug.Log("probe", "simple probe non-context error (auth/network?): %v", err)
+		if isContextError {
+			// Context error but couldn't parse the limit — tiered probing
+			debug.Log("probe", "simple probe hit context limit but couldn't parse exact value")
+			return 0
+		}
+		if containsAny(errMsg, authKeywords) || containsAnyAnchored(errMsg, authStatusPatterns) {
+			debug.Log("probe", "simple probe auth error (aborting all probing): %v", err)
 			return -1
 		}
-
-		// Context error but couldn't parse the limit — continue to tiered probing
-		debug.Log("probe", "simple probe hit context limit but couldn't parse exact value")
+		debug.Log("probe", "simple probe inconclusive error (rate-limit/network/5xx/timeout/unknown — deferring to tiers): %v", err)
 		return 0
 	}
 

--- a/internal/provider/context_probe_1788_test.go
+++ b/internal/provider/context_probe_1788_test.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// fakeProber1788 lets trySimpleProbe see a chosen error without network.
+type fakeProber1788 struct {
+	*mockProvider
+	err error
+}
+
+func (f *fakeProber1788) probeChat(_ context.Context, _ []Message) error { return f.err }
+
+// #1788: the simple probe used to return -1 (abort the ENTIRE probe,
+// caller falls back to estimation, #1198 persists it) for ANY
+// non-context error - a transient 429 at probe start could harden into
+// a low cached window. Only AUTH may abort; everything else defers to
+// tiered probing (returns 0).
+func TestSimpleProbeClassification1788(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"auth abort", fmt.Errorf("401 unauthorized: invalid api key"), -1},
+		{"rate limit defers", fmt.Errorf("429 Too Many Requests"), 0},
+		{"network defers", fmt.Errorf("connection refused"), 0},
+		{"timeout defers", fmt.Errorf("client timeout exceeded"), 0},
+		{"5xx defers", fmt.Errorf("server error 503 Service Unavailable"), 0},
+		{"unknown defers", fmt.Errorf("something odd"), 0},
+		{"context defers", fmt.Errorf("request too long for context"), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := trySimpleProbe(context.Background(), &fakeProber1788{mockProvider: &mockProvider{}, err: tc.err})
+			if got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1788.

- **Case 1 (Med)**: trySimpleProbe aborted the entire probe (-1 → caller estimation → #1198 persistent cache) for ANY non-context error — a transient 429/network blip at probe start could harden into a low cached window. Now aligned with the tier classifier: only auth aborts; rate-limit/network/5xx/timeout/unknown defer to tiered probing.

## Verification evidence (review)
Isolated worktree: provider suite **3.1s PASS**. Pin drives all seven error classes through a fake prober (mockProvider embed + probeChat override) — auth aborts, six inconclusive classes defer. This also covers the previously untested classification boundary the issue flagged.

Closes #1788

Generated with [ggcode](https://github.com/topcheer/ggcode)
