### PR TITLE
fix(tui): tmux menu keys gate on availability; bare setup alias only when sole arg (#1764)

### DIFF
--- a/internal/tui/tmux.go
+++ b/internal/tui/tmux.go
@@ -243,7 +243,10 @@ func parseTmuxEnterArgs(args []string) (sessionName, setupLayout string) {
 	for i := 0; i < len(args); i++ {
 		arg := strings.TrimSpace(args[i])
 		switch {
-		case arg == "--setup" || arg == "setup":
+		// #1764 case 3: bare "setup" is treated as --setup ONLY when it
+		// is the sole argument - "/tmux enter setup" used to be unable to
+		// create a session literally named "setup".
+		case arg == "--setup" || (arg == "setup" && len(args) == 1):
 			setupLayout = "default"
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 				setupLayout = args[i+1]
@@ -597,6 +600,16 @@ func (m *Model) openTmuxMenu() {
 	m.statusActivity = "tmux menu"
 }
 
+// tmuxMenuUnavailableMsg closes the menu with the guided message the
+// /tmux command path already shows (#1764 case 1: menu keys used to
+// bypass the tmuxAvailable gate and surface a raw "no server running").
+func (m Model) tmuxMenuUnavailableMsg() tea.Cmd {
+	m.tmuxMenuOpen = false
+	m.statusActivity = ""
+	m.chatWriteSystem(nextSystemID(), "tmux is not available in this terminal session")
+	return nil
+}
+
 func (m Model) handleTmuxMenuKey(key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "esc", "ctrl+c", "q":
@@ -609,21 +622,39 @@ func (m Model) handleTmuxMenuKey(key string) (tea.Model, tea.Cmd) {
 			return m, m.enterTmuxSession("", "")
 		}
 	case "s":
+		if !m.tmuxAvailable() {
+			return m, m.tmuxMenuUnavailableMsg()
+		}
 		m.tmuxMenuOpen = false
 		m.openTmuxSplit("shell", "", true)
 	case "v":
+		if !m.tmuxAvailable() {
+			return m, m.tmuxMenuUnavailableMsg()
+		}
 		m.tmuxMenuOpen = false
 		m.openTmuxSplit("shell", "", false)
 	case "t":
+		if !m.tmuxAvailable() {
+			return m, m.tmuxMenuUnavailableMsg()
+		}
 		m.tmuxMenuOpen = false
 		m.openTmuxSplit("test", "go test -tags goolm ./...", false)
 	case "b":
+		if !m.tmuxAvailable() {
+			return m, m.tmuxMenuUnavailableMsg()
+		}
 		m.tmuxMenuOpen = false
 		m.openTmuxSplit("build", "go build -tags goolm ./...", false)
 	case "d":
+		if !m.tmuxAvailable() {
+			return m, m.tmuxMenuUnavailableMsg()
+		}
 		m.tmuxMenuOpen = false
 		m.openTmuxSplit("dev", "make dev", true)
 	case "p":
+		if !m.tmuxAvailable() {
+			return m, m.tmuxMenuUnavailableMsg()
+		}
 		m.tmuxMenuOpen = false
 		m.openTmuxPopup("")
 	case "l":

--- a/internal/tui/tmux_1764_test.go
+++ b/internal/tui/tmux_1764_test.go
@@ -1,0 +1,33 @@
+package tui
+
+import "testing"
+
+// #1764 case 3: "/tmux enter setup" must be able to create a session
+// literally named "setup" - bare "setup" is only the --setup alias when
+// it is the sole argument.
+func TestParseTmuxEnterArgsBareSetup1764(t *testing.T) {
+	// sole argument: alias behavior preserved
+	sess, layout := parseTmuxEnterArgs([]string{"setup"})
+	if layout != "default" {
+		t.Fatalf("sole 'setup' should alias --setup, layout=%q", layout)
+	}
+	if sess != "" {
+		t.Fatalf("sole 'setup' should not set session name, got %q", sess)
+	}
+	// two arguments: first is the session NAME
+	sess, layout = parseTmuxEnterArgs([]string{"setup", "extra"})
+	if sess != "setup" {
+		t.Fatalf("'setup extra' should treat setup as session name, got %q", sess)
+	}
+	if layout != "" {
+		t.Fatalf("'setup extra' should not set layout, got %q", layout)
+	}
+	// explicit flag still wins with a following value
+	sess, layout = parseTmuxEnterArgs([]string{"--setup", "tiles"})
+	if layout != "tiles" {
+		t.Fatalf("--setup tiles should set layout=tiles, got %q", layout)
+	}
+	if sess != "" {
+		t.Fatalf("--setup tiles should not set session, got %q", sess)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1764 (cases 1+3; case 2 documented as upstream follow-up).

1. **Case 1 (Low, UX)**: menu action keys (s/v/t/b/d/p) bypassed the tmuxAvailable() gate → raw "no server running" outside tmux. Now gate like the /tmux command path with the same guided message.
2. **Case 3 (Low)**: bare "setup" always aliased --setup → "/tmux enter setup" couldn't create a session named "setup". Alias now applies only as the sole argument.
3. **Case 2**: whitespace collapsing root-caused to the global strings.Fields tokenizer (commands.go) — explicitly NOT fixed locally; flagged for separate follow-up per the issue's own verdict.

## Verification evidence (review)
Isolated worktree: tui suite **10.3s PASS**. Pin: three-way bare-setup parse behavior (alias preserved / session name path / explicit flag).

Closes #1764

Generated with [ggcode](https://github.com/topcheer/ggcode)
