### PR TITLE
fix(chat,tool): error path line cap; exit_plan_mode plan-mode guard (#1697 cases 1+3)

### DIFF
--- a/internal/chat/tools.go
+++ b/internal/chat/tools.go
@@ -199,6 +199,12 @@ func (t *BaseToolItem) RenderBody(width int) string {
 		body = strings.ReplaceAll(body, "\r", "\n")
 		body = expandTabs(body)
 		lines := wrapLines(body, width)
+		// #1697 case 1: the normal path caps at ToolBodyMaxLines (and
+		// streaming too) - the error path had NO cap, so a 200-line
+		// build/test failure flooded the body. Same cap, error styling.
+		if len(lines) > ToolBodyMaxLines {
+			lines = lines[:ToolBodyMaxLines]
+		}
 		return t.styles.ErrorStyle.Render(strings.Join(lines, "\n"))
 	}
 

--- a/internal/tool/plan_mode_tools.go
+++ b/internal/tool/plan_mode_tools.go
@@ -119,6 +119,14 @@ func (t ExitPlanModeTool) Execute(_ context.Context, input json.RawMessage) (Res
 	if args.Plan == "" {
 		return Result{IsError: true, Content: "plan content is required"}, nil
 	}
+	// #1697 case 3: guard on PlanMode - without it, a call OUTSIDE any plan
+	// period still "restored" (previous plan cycle's Supervised, silently
+	// DOWNGRADING a user who had switched to bypass in between; or the
+	// zero-value "" for a first-ever call, feeding SetMode an invalid
+	// mode).
+	if t.Switcher.Mode() != permission.PlanMode {
+		return Result{IsError: true, Content: "exit_plan_mode: not in plan mode (nothing to exit)"}, nil
+	}
 
 	// Always restore the mode from before entering plan mode.
 	mode := t.Switcher.RestoreMode(t.DefaultMode)


### PR DESCRIPTION
Case 1 (Med): the error path fed wrapLines output through with NO line cap while the normal path caps at `ToolBodyMaxLines` (and streaming too) - a 200-line build/test failure flooded the body. Same cap, error styling.

Case 3 (Med): exit_plan_mode had no PlanMode guard - a call outside any plan period still 'restored' the previous cycle's Supervised (**silently downgrading** a user who had switched to bypass in between) or fed SetMode the zero-value invalid mode on a first-ever call.

(Case 2 - open_editor fallback honesty - and the Low items stay for follow-up.)

Isolated worktree (fresh origin/main): chat+tool packages PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)