### PR TITLE
fix(util): symlink fallback copy checks Close error (#1845)

### DIFF
--- a/internal/util/symlink_windows.go
+++ b/internal/util/symlink_windows.go
@@ -96,9 +96,19 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
 
 	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	// #1845: Close flushes network-redirector delayed writes (SMB close-
+	// time failures). A dropped Close error let a silently TRUNCATED
+	// copy report success - the caller then believed the fallback
+	// "link" existed while the content was incomplete.
+	if cerr := out.Close(); err == nil {
+		err = cerr
+	}
+	if err != nil {
 		return err
 	}
 	info, err := os.Stat(src)


### PR DESCRIPTION
## Summary
Closes #1845 (case 1; cases 2-3 already adjudicated in the issue - falsified/downgraded).

- **Case 1 (Low-Med)**: copyFile dropped the Close error (`defer out.Close()`), so SMB-style close-time delayed-write failures reported success on a silently truncated fallback copy. Standard pattern applied: explicit close after io.Copy, propagate Close error, no double-close on the Copy-error path.

## Verification evidence (review)
Isolated worktree: **GOOS=windows build OK** (file is windows-tagged) + darwin util suite PASS. Only production caller confirmed (debug-log compat path) per the issue's own blast-radius analysis.

Closes #1845

Generated with [ggcode](https://github.com/topcheer/ggcode)
