### PR TITLE
fix(tool): notebook_edit records its write (#1696 case 1)

### DIFF
--- a/internal/tool/notebook_edit.go
+++ b/internal/tool/notebook_edit.go
@@ -209,6 +209,11 @@ func (t NotebookEdit) Execute(ctx context.Context, input json.RawMessage) (Resul
 	if err := atomicWriteFile(args.NotebookPath, output, 0644); err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("error writing notebook: %v", err)}, nil
 	}
+	// #1696 case 1: the package-wide contract - seven write sites call
+	// RecordWrite, notebook_edit was the lone exception. Without it,
+	// read(.ipynb) -> notebook_edit -> write_file tripped CheckStale's
+	// "modified externally" misreport on the agent's OWN edit.
+	defaultFileTracker.RecordWrite(args.NotebookPath)
 
 	return Result{Content: fmt.Sprintf("Notebook %s: %s operation completed (%d cells)", args.NotebookPath, args.Operation, len(cells))}, nil
 }


### PR DESCRIPTION
The package-wide contract: seven write sites call `defaultFileTracker.RecordWrite`, notebook_edit was the lone exception - `read(.ipynb) → notebook_edit → write_file` tripped CheckStale's 'modified externally' **misreport on the agent's own edit**.

(The pre-write CheckStale half and the Low items stay for follow-up, noted in the issue comment.)

Isolated worktree (fresh origin/main): Notebook family PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)