### PR TITLE
fix(agent): remove dead recordFirings and its misleading comment (#1534)

### DIFF
--- a/internal/agent/consensus.go
+++ b/internal/agent/consensus.go
@@ -82,15 +82,6 @@ func (s *consensusState) reset() {
 	s.currentStep = 0
 }
 
-// recordFirings logs multiple detector firings at once. Convenience wrapper
-// (kept for the batch-loop call sites and #952 tests) delegating to
-// recordFiring per name.
-func (s *consensusState) recordFirings(step int, detectorNames ...string) {
-	for _, n := range detectorNames {
-		s.recordFiring(n, step)
-	}
-}
-
 // recordFiring logs that a named detector produced guidance.
 // This should be called whenever ANY detector's check() returns non-empty.
 // #1446-C: step is the CURRENT tool-call/iteration index supplied by the
@@ -187,8 +178,8 @@ func (s *consensusState) check() string {
 }
 
 // checkOnly runs the consensus check WITHOUT scanning content (#952). Used by
-// the agent loop, where firings are recorded explicitly via recordFiring /
-// recordFirings at each detector call site: the content scan was both fragile
+// the agent loop, where firings are recorded explicitly via recordFiring at
+// each detector call site: the content scan was both fragile
 // (its baseline-offset window missed every detector whose guidance is appended
 // before the window starts — failureMode, errorCascade, ...) and a
 // false-positive vector (#147: raw tool output containing tag literals).


### PR DESCRIPTION
## Summary
Closes #1534.

- **Cases A+B**: verified ALREADY FIXED on main by a parallel change — keyless `- |` list-item block scalars covered by the list branch; `| # comment` headers stripped; both carry regression pins. No duplicate changes made.
- **Case C (Low, dead code + misleading comment)**: `recordFirings` had zero callers repo-wide (the comment claimed it was "kept for the batch-loop call sites and #952 tests" — neither exists). Dead wrapper removed; checkOnly comment corrected.

## Verification evidence (review)
Isolated worktree: agent suite **22.2s PASS** (p=1 OOM-safe). Caller analysis via repo-wide grep including tests before deletion.

Closes #1534

Generated with [ggcode](https://github.com/topcheer/ggcode)
