### PR TITLE
fix(tool): mobile typeText pre-tap fails loud on both backends (#1694 case 1)

### DIFF
--- a/internal/tool/mobile_adb.go
+++ b/internal/tool/mobile_adb.go
@@ -232,15 +232,20 @@ func (a *androidBackend) typeText(ctx context.Context, device, ref, text string,
 		return Result{IsError: true, Content: "element reference requires a prior snapshot - tap the field first, then type"}, nil
 	}
 	// Tap the field first if coordinates provided
-	if x > 0 || y > 0 {
+	// #1694 case 1: x=0/y=0 are LEGAL edge coordinates - the old x>0||y>0
+	// skipped the pre-tap there (text landed wherever focus was). >= 0
+	// with both-set semantics keeps the intent.
+	if ref == "" && (x != 0 || y != 0) {
 		// #840: include the device selector - without it, multi-device setups
-		// fail 'more than one device/emulator', the error is swallowed below,
-		// and the text goes to whatever holds focus while the tool reports
-		// success.
+		// fail 'more than one device/emulator', the error was swallowed below,
+		// and the text went to whatever holds focus while the tool reported
+		// success. #1694: the swallow itself was the unfixed half - a failed
+		// pre-tap now fails LOUD (typing into the wrong control while
+		// reporting success is the worse outcome).
 		preArgs := adbDeviceArgs(device)
 		preArgs = append(preArgs, "shell", "input", "tap", strconv.Itoa(x), strconv.Itoa(y))
 		if _, _, err := runCommand(ctx, 5*time.Second, a.adbPath, preArgs...); err != nil {
-			// Non-fatal, continue with typing
+			return Result{IsError: true, Content: fmt.Sprintf("pre-tap at (%d,%d) failed: %v - aborting type to avoid sending text to the wrong control", x, y, err)}, nil
 		}
 		time.Sleep(200 * time.Millisecond)
 	}

--- a/internal/tool/mobile_ios_darwin.go
+++ b/internal/tool/mobile_ios_darwin.go
@@ -314,8 +314,13 @@ func (b *iosBackend) scaleForDevice(device string) (int, int) {
 }
 
 func (b *iosBackend) typeText(ctx context.Context, device, ref, text string, x, y int) (Result, error) {
-	if x > 0 || y > 0 {
-		b.tap(ctx, device, "", x, y)
+	if x != 0 || y != 0 {
+		// #1694 case 1: the discarded tap result was the iOS twin of the
+		// #840 swallow - a failed pre-tap typed into whatever held focus
+		// while reporting success. Fail loud now.
+		if tapRes, err := b.tap(ctx, device, "", x, y); err != nil || tapRes.IsError {
+			return Result{IsError: true, Content: fmt.Sprintf("pre-tap at (%d,%d) failed: %v - aborting type to avoid sending text to the wrong control", x, y, err)}, nil
+		}
 		time.Sleep(300 * time.Millisecond)
 	}
 	// Use AppleScript to type into the Simulator


### PR DESCRIPTION
The pre-tap error was swallowed on Android (the comment even described the #840 failure mode it was preserving) and the tap result discarded on iOS - a failed pre-tap typed the text into **whatever held focus while the tool reported success**. Both abort with an explicit error now.

Edge coordinates: `x=0/y=0` remain excluded only when BOTH are zero (no target at all); a single zero axis no longer skips the tap.

(Case 2 - the @eN reference contract failure across all three backends - is a larger design question about the snapshot-reference flow and stays for follow-up.)

Isolated worktree (fresh origin/main): Mobile family PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)