### PR TITLE
fix(tool): iOS pre-tap error message carries the result text (#1970 nit)

### DIFF
--- a/internal/tool/mobile_ios_darwin.go
+++ b/internal/tool/mobile_ios_darwin.go
@@ -319,7 +319,13 @@ func (b *iosBackend) typeText(ctx context.Context, device, ref, text string, x, 
 		// #840 swallow - a failed pre-tap typed into whatever held focus
 		// while reporting success. Fail loud now.
 		if tapRes, err := b.tap(ctx, device, "", x, y); err != nil || tapRes.IsError {
-			return Result{IsError: true, Content: fmt.Sprintf("pre-tap at (%d,%d) failed: %v - aborting type to avoid sending text to the wrong control", x, y, err)}, nil
+			// #1970 nit: when only tapRes.IsError fired (err == nil), the %v
+			// rendered "<nil>" - carry the result text instead.
+			reason := error(err)
+			if reason == nil {
+				reason = fmt.Errorf("%s", tapRes.Content)
+			}
+			return Result{IsError: true, Content: fmt.Sprintf("pre-tap at (%d,%d) failed: %v - aborting type to avoid sending text to the wrong control", x, y, reason)}, nil
 		}
 		time.Sleep(300 * time.Millisecond)
 	}


### PR DESCRIPTION
When only `tapRes.IsError` fired (err == nil) the %v rendered "<nil>" - the review nit on #1970, one polish commit.

Isolated worktree (fresh origin/main): Mobile family PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)