### PR TITLE
fix(agent): concurrent-map detector covers pkg-level vars, var-make, compound/incr writes (#1533)

### DIFF
--- a/internal/agent/concurrent_map_1533_test.go
+++ b/internal/agent/concurrent_map_1533_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// #1533: three proof-gap regressions in the concurrent-map detector.
+func find1533(t *testing.T, src string) int {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", "package p\n"+src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(findConcurrentMapAccess(fset, f))
+}
+
+// Case A: package-level var map + goroutine write - the headline
+// cross-goroutine registry scenario went silent after #1445.
+func Test1533A_PackageLevelVarMapSeeded(t *testing.T) {
+	n := find1533(t, `
+var counters map[string]int
+
+func worker() {
+	go func() { counters["k"] = 1 }()
+}`)
+	if n != 1 {
+		t.Fatalf("package-level map write must fire, got %d", n)
+	}
+}
+
+// Case B: `var m = make(map...)` - inferred declaration shape.
+func Test1533B_VarMakeValueSpec(t *testing.T) {
+	n := find1533(t, `
+func worker() {
+	var m = make(map[string]int)
+	go func() { m["k"] = 1 }()
+}`)
+	if n != 1 {
+		t.Fatalf("var m = make(...) write must fire, got %d", n)
+	}
+}
+
+// Case C: compound assignment and increment shapes.
+func Test1533C_CompoundAndIncDec(t *testing.T) {
+	n := find1533(t, `
+func worker() {
+	m := make(map[string]int)
+	go func() { m["k"] += 1 }()
+}`)
+	if n != 1 {
+		t.Fatalf("m[k] += v must fire, got %d", n)
+	}
+	n = find1533(t, `
+func worker() {
+	m := make(map[string]int)
+	go func() { m["k"]++ }()
+}`)
+	if n != 1 {
+		t.Fatalf("m[k]++ must fire, got %d", n)
+	}
+}
+
+// Slice fan-out (the #1445 core target) must stay quiet.
+func Test1533_SliceFanoutStaysQuiet(t *testing.T) {
+	n := find1533(t, `
+func fan(out []int) {
+	for i := range out {
+		go func() { out[i] = 1 }()
+	}
+}`)
+	if n != 0 {
+		t.Fatalf("slice fan-out must not fire, got %d", n)
+	}
+}
+
+// hasSync still clears warnings on the new shapes.
+func Test1533_SyncStillSuppresses(t *testing.T) {
+	n := find1533(t, `
+var counters map[string]int
+var mu sync.Mutex
+
+func worker() {
+	go func() {
+		mu.Lock()
+		counters["k"]++
+		mu.Unlock()
+	}()
+}`)
+	if n != 0 {
+		t.Fatalf("sync-guarded write must not fire, got %d", n)
+	}
+}

--- a/internal/agent/concurrent_map_check.go
+++ b/internal/agent/concurrent_map_check.go
@@ -147,6 +147,35 @@ func countConcurrentMapIssues(src string) int {
 func findConcurrentMapAccess(fset *token.FileSet, file *ast.File) []concurrentMapInstance {
 	var instances []concurrentMapInstance
 
+	// #1533-A: package-level `var counters map[string]int` is the canonical
+	// cross-goroutine shared-registry shape - the top-level GenDecl loop used
+	// to be skipped entirely (only FuncDecls were analyzed), so the detector's
+	// headline scenario went silent after #1445 required declaration proof.
+	pkgMaps := map[string]bool{}
+	for _, topDecl := range file.Decls {
+		gd, ok := topDecl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			if _, isMap := vs.Type.(*ast.MapType); isMap {
+				for _, name := range vs.Names {
+					pkgMaps[name.Name] = true
+				}
+				continue
+			}
+			for i, val := range vs.Values {
+				if isMapValuedExpr(val) && i < len(vs.Names) {
+					pkgMaps[vs.Names[i].Name] = true
+				}
+			}
+		}
+	}
+
 	for _, topDecl := range file.Decls {
 		fn, ok := topDecl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
@@ -155,7 +184,7 @@ func findConcurrentMapAccess(fset *token.FileSet, file *ast.File) []concurrentMa
 
 		// Collect function-level info (#1445-A: the FuncDecl seeds map-typed
 		// params/receivers into the declaration-proof set internally).
-		info := analyzeFuncForMapConcurrency(fn)
+		info := analyzeFuncForMapConcurrency(fn, pkgMaps)
 		if len(info.unsyncMapWrites) == 0 || !info.hasGoStatement {
 			continue
 		}
@@ -186,11 +215,17 @@ type mapConcurrencyInfo struct {
 // analyzeFuncForMapConcurrency inspects a function for concurrent map
 // access patterns (#1445-A: takes the FuncDecl so map-typed params and
 // receivers seed the declaration-proof set BEFORE the write scan).
-func analyzeFuncForMapConcurrency(fn *ast.FuncDecl) mapConcurrencyInfo {
+func analyzeFuncForMapConcurrency(fn *ast.FuncDecl, pkgMaps map[string]bool) mapConcurrencyInfo {
 	body := fn.Body
 	info := mapConcurrencyInfo{
 		unsyncMapWrites: make(map[string]token.Pos),
 		mapDeclared:     make(map[string]bool),
+	}
+	// #1533-A: package-level maps are proof BEFORE the inspect pass - the
+	// write detection consults mapDeclared while walking, so seeding after
+	// the call (as an earlier draft did) was a no-op.
+	for name := range pkgMaps {
+		info.mapDeclared[name] = true
 	}
 	// Params/receiver declared as maps are proof (func worker(m map...)).
 	seed := func(fl *ast.FieldList) {
@@ -238,6 +273,16 @@ func analyzeFuncForMapConcurrency(fn *ast.FuncDecl) mapConcurrencyInfo {
 					if _, isMap := vs.Type.(*ast.MapType); isMap {
 						for _, name := range vs.Names {
 							info.mapDeclared[name.Name] = true
+						}
+						continue
+					}
+					// #1533-B: `var m = make(map[string]int)` and
+					// `var m = map[string]int{}` fall between the DeclStmt
+					// (Type-only) and AssignStmt (isMapValuedExpr) branches -
+					// the idiomatic inferred declaration was never proven.
+					for i, val := range vs.Values {
+						if isMapValuedExpr(val) && i < len(vs.Names) {
+							info.mapDeclared[vs.Names[i].Name] = true
 						}
 					}
 				}
@@ -290,9 +335,30 @@ func analyzeFuncForMapConcurrency(fn *ast.FuncDecl) mapConcurrencyInfo {
 				}
 			}
 
+		case *ast.IncDecStmt:
+			// #1533-C: m[k]++ (concurrent counters are a top real-world
+			// concurrent-map crash shape) - IncDecStmt is NOT an AssignStmt,
+			// so it escaped the switch entirely.
+			if idx, ok := node.X.(*ast.IndexExpr); ok {
+				name := mapVarName(idx.X)
+				if name != "" && (strings.Contains(name, ".") || info.mapDeclared[name]) {
+					if _, exists := info.unsyncMapWrites[name]; !exists {
+						info.unsyncMapWrites[name] = node.Pos()
+					}
+				}
+			}
+
 		case *ast.AssignStmt:
-			// Detect map write: m[k] = v
-			if node.Tok == token.ASSIGN || node.Tok == token.DEFINE {
+			// Detect map write: m[k] = v  (#1533-C: and m[k] += v etc. -
+			// compound assignments used to be filtered out alongside :=/=).
+			isAssignTok := node.Tok == token.ASSIGN || node.Tok == token.DEFINE ||
+				node.Tok == token.ADD_ASSIGN || node.Tok == token.SUB_ASSIGN ||
+				node.Tok == token.MUL_ASSIGN || node.Tok == token.QUO_ASSIGN ||
+				node.Tok == token.REM_ASSIGN || node.Tok == token.AND_ASSIGN ||
+				node.Tok == token.OR_ASSIGN || node.Tok == token.XOR_ASSIGN ||
+				node.Tok == token.SHL_ASSIGN || node.Tok == token.SHR_ASSIGN ||
+				node.Tok == token.AND_NOT_ASSIGN
+			if isAssignTok {
 				for _, lhs := range node.Lhs {
 					if idx, ok := lhs.(*ast.IndexExpr); ok {
 						// #1445-A: plain identifiers need declaration proof (a


### PR DESCRIPTION
## Summary
Closes #1533 (cases A/B/C; case D retained per adjudication).

1. **Case A (Med-High)**: package-level `var counters map[string]int` + goroutine write — the detector's headline cross-goroutine registry scenario — went silent after #1445 (top-level GenDecls never analyzed). Pkg-level maps (typed + inferred) now seed every function's proof set BEFORE the inspect pass (post-analysis seeding would be a no-op — the walk consults the map live).
2. **Case B (Med)**: `var m = make(map...)` fell between the DeclStmt (Type-only) and AssignStmt branches — DeclStmt now inspects vs.Values.
3. **Case C (Med)**: `m[k] += v` filtered and `m[k]++` outside the switch — compound tokens + IncDecStmt branch now detect.

## Verification evidence (review)
Isolated worktree: agent suite **21.9s PASS** (p=1 OOM-safe). Five pins: pkg-level fire / var-make fire / += fire / ++ fire / slice fan-out stays quiet / sync still suppresses — including both #1445 regression guards. The failed-first-draft (seed-after-analysis) was caught by the case-A pin before commit.

Closes #1533

Generated with [ggcode](https://github.com/topcheer/ggcode)
