### PR TITLE
fix(tool): knowledge_graph tags filter implemented; slug-collision overwrite disclosed (#1692 cases 3+4)

### DIFF
--- a/internal/tool/knowledge_graph.go
+++ b/internal/tool/knowledge_graph.go
@@ -214,7 +214,14 @@ func (t *KnowledgeGraphTool) doAdd(s *kgStore, p *kgParams) (Result, error) {
 	if err := t.save(s); err != nil {
 		return Result{IsError: true, Content: fmt.Sprintf("failed to save: %v", err)}, nil
 	}
-	return Result{Content: fmt.Sprintf("Node '%s' (%s) saved. Total: %d nodes.", id, nt, len(s.Nodes))}, nil
+	// #1692 case 4: distinct titles can collide on the slug ("C++ API" vs
+	// "c api" -> c-api) and the second save silently OVERWROTE the first
+	// node's fields while reporting a plain "saved".
+	note := ""
+	if ex, ok := s.Nodes[id]; ok && p.Title != "" && ex.Title != "" && !strings.EqualFold(ex.Title, p.Title) {
+		note = fmt.Sprintf(" (note: slug '%s' already existed with title %q - fields were overwritten)", id, ex.Title)
+	}
+	return Result{Content: fmt.Sprintf("Node '%s' (%s) saved%s. Total: %d nodes.", id, nt, note, len(s.Nodes))}, nil
 }
 
 func (t *KnowledgeGraphTool) doLink(s *kgStore, p *kgParams) (Result, error) {
@@ -251,6 +258,26 @@ func (t *KnowledgeGraphTool) doQuery(s *kgStore, p *kgParams) (Result, error) {
 	for _, n := range s.Nodes {
 		if p.Type != "" && n.Type != p.Type {
 			continue
+		}
+		// #1692 case 3: the parameter doc promises "query filter" for tags -
+		// doQuery never read p.Tags, so a tags-filtered query returned the
+		// UNFILTERED set. Node tags are lowercase (slugify); match case-
+		// insensitively, node must carry EVERY requested tag (AND).
+		if len(p.Tags) > 0 {
+			nodeTags := make(map[string]bool, len(n.Tags))
+			for _, t := range n.Tags {
+				nodeTags[strings.ToLower(t)] = true
+			}
+			ok := true
+			for _, want := range p.Tags {
+				if !nodeTags[strings.ToLower(want)] {
+					ok = false
+					break
+				}
+			}
+			if !ok {
+				continue
+			}
 		}
 		if q == "" {
 			matches = append(matches, n)


### PR DESCRIPTION
Case 3 (Med): the parameter doc promised 'query filter' for tags but doQuery never read p.Tags - a tags-filtered query returned the **unfiltered set** (the LLM trusting the doc got misled). Nodes must now carry every requested tag (AND, case-insensitive to match slugify).

Case 4 (Med): distinct titles collide on the slug (`C++ API` vs `c api` → c-api) and the second save silently **overwrote** the first node's fields - the result now discloses the collision.

(Case 1 - kitty ctx threading, the terminal-tool family's fourth instance - needs the full kittyAt call-chain pass like aad84217 did for iterm2; case 2 modifier keys and the Low items stay with it.)

Isolated worktree (fresh origin/main): KnowledgeGraph family PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)