### PR TITLE
fix(tui,knight): signal panel esc during install; Windows lock errors surface (#1757)

### DIFF
--- a/internal/knight/lock_1757_windows_test.go
+++ b/internal/knight/lock_1757_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package knight
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #1757 case 2: ENOENT means "not held" (0, nil); other OpenFile failures
+// (e.g. permission) must surface as errors like the unix branch.
+func TestLockHeldByWindowsENOENTVsPerm1757(t *testing.T) {
+	dir := t.TempDir()
+	// No lock file at all.
+	pid, err := LockHeldBy(dir)
+	if pid != 0 || err != nil {
+		t.Fatalf("missing lock file: got (%d, %v), want (0, nil)", pid, err)
+	}
+
+	// Lock file exists but is unreadable/unopenable -> error, not silence.
+	lockDir := filepath.Join(dir, ".ggcode")
+	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(lockDir, "knight.lock")
+	if err := os.WriteFile(lockPath, []byte("    "), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LockHeldBy(dir); err == nil {
+		t.Fatal("permission failure must surface as an error, not (0, nil)")
+	}
+}

--- a/internal/knight/lock_windows.go
+++ b/internal/knight/lock_windows.go
@@ -117,7 +117,14 @@ func LockHeldBy(projDir string) (int, error) {
 	lockPath := filepath.Join(projDir, ".ggcode", "knight.lock")
 	f, err := os.OpenFile(lockPath, os.O_RDWR, 0600)
 	if err != nil {
-		return 0, nil // no lock file
+		// #1757 case 2: only a MISSING lock file means "not held" - a
+		// permission failure used to be silently swallowed here while the
+		// unix branch (post-#1576) reports it, leaving callers' pid,_ with
+		// a wrong "no lock" verdict and zero diagnostics.
+		if os.IsNotExist(err) {
+			return 0, nil // no lock file
+		}
+		return 0, err
 	}
 	defer f.Close()
 	// Read only the unlocked PID region (see readLockPID): whole-file reads

--- a/internal/tui/signal_panel.go
+++ b/internal/tui/signal_panel.go
@@ -294,6 +294,15 @@ func (m *Model) handleSignalPanelKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		return *m, nil
 	}
 	if panel.installing {
+		// #1757 case 1: the install runs up to ~2 minutes (Docker pull).
+		// Swallowing EVERY key left esc dead the whole time; ctrl+c had a
+		// pre-panel escape channel users didn't know about. Let both
+		// escape keys through so the panel is closable mid-install.
+		switch msg.String() {
+		case "esc", "ctrl+c":
+			m.closeSignalPanel()
+			return *m, nil
+		}
 		return *m, nil
 	}
 	if panel.editState.mode != imEditNone {


### PR DESCRIPTION
## Summary
Closes #1757.

1. **Case 1 (Low, UX)**: signal panel swallowed every key during the up-to-2-minute install — esc now closes the panel mid-install alongside ctrl+c (install Cmd continues in background; installing-reset loop unchanged).
2. **Case 2 (Low, #1576 Windows half)**: LockHeldBy Windows returned (0,nil) for any OpenFile failure — ENOENT keeps (0,nil), permission-class errors now return. Callers use pid,_ so impact is diagnostics, per the issue's assessment.

## Verification evidence (review)
Isolated worktree: knight **7.0s** + tui **10.6s** PASS (p=1). GOOS=windows build+vet OK. Windows-tagged pin: ENOENT→(0,nil) / chmod-000→error (runs on real Windows CI, per windows-real-machine-verify policy).

Closes #1757

Generated with [ggcode](https://github.com/topcheer/ggcode)
