### PR TITLE
fix(tool): SIGKILL outcome authoritative; save_memory rejects blank keys (#1700 cases 1+2)

### DIFF
--- a/internal/tool/run_command_unix.go
+++ b/internal/tool/run_command_unix.go
@@ -31,13 +31,18 @@ func configureCommandCancellation(cmd *exec.Cmd) {
 			return nil
 		}
 		targets := snapshotCommandTargets(cmd.Process.Pid)
-		err := signalCommandTargets(targets, syscall.SIGTERM)
+		_ = signalCommandTargets(targets, syscall.SIGTERM)
 		time.Sleep(commandTerminateGracePeriod)
 		killErr := signalCommandTargets(targets, syscall.SIGKILL)
-		if err != nil {
-			return err
+		// #1700 case 1: a failed SIGTERM (e.g. group EPERM after the pid
+		// snapshot) masked a SUCCESSFUL SIGKILL termination - os/exec
+		// turns a non-ErrProcessDone Cancel error into the Wait() error,
+		// so an actually-dead process reported failure. The KILL outcome
+		// is the authoritative one.
+		if killErr != nil {
+			return killErr
 		}
-		return killErr
+		return nil
 	}
 	cmd.WaitDelay = commandWaitDelay
 }

--- a/internal/tool/save_memory.go
+++ b/internal/tool/save_memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/topcheer/ggcode/internal/memory"
 )
@@ -98,6 +99,13 @@ func (t *SaveMemoryTool) Execute(ctx context.Context, input json.RawMessage) (Re
 	}
 
 	// Validate key
+	// #1700 case 2: an empty key slipped through (only the max length was
+	// checked), sanitizeKey turned it into "untitled" and sha256("")'s
+	// first bytes mapped EVERY empty key to the same file - silent mutual
+	// overwrites reported as "memory saved: ".
+	if strings.TrimSpace(params.Key) == "" {
+		return Result{IsError: true, Content: "key is required and cannot be blank"}, nil
+	}
 	if len(params.Key) > maxMemoryKeyLen {
 		return Result{IsError: true, Content: fmt.Sprintf("key too long: %d chars (max %d). Use a shorter identifier.", len(params.Key), maxMemoryKeyLen)}, nil
 	}


### PR DESCRIPTION
Case 1 (Low): a failed SIGTERM (group EPERM after the pid snapshot) masked a **successful SIGKILL** - os/exec turns a non-ErrProcessDone Cancel error into the Wait() error, so an actually-dead process reported failure.

Case 2 (Low): an empty key slipped the max-length-only check, `sanitizeKey` made it "untitled", and `sha256("")`'s prefix mapped EVERY blank key to the same file - silent mutual overwrites reported as `memory saved: `. Blank keys rejected.

Isolated worktree (fresh origin/main): SaveMemory+RunCommand families PASS, unix+windows GOOS builds, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)