### PR TITLE
fix(agent): irreversibility gate fires pre-execution; window stops self-grounding (#1798)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2985,6 +2985,22 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 				msgs = a.contextManager.Messages()
 			}
 		}
+		// #1798 case 1: the irreversibility gate is a PRE-action check - it
+		// used to sit in the post-execution result loop, so the "You are
+		// about to execute" warning arrived after the action had already
+		// happened (calibrated abstention had nothing to abstain from).
+		// Recording here also keeps the ledger entry alive for the
+		// post-execution recordOutcome revoke (#1776).
+		if a.irrevGate != nil {
+			for _, tc := range toolCalls {
+				if warn := a.irrevGate.recordAction(tc.Name, string(tc.Arguments)); warn != "" {
+					a.contextManager.Add(provider.Message{
+						Role:    "user",
+						Content: []provider.ContentBlock{{Type: "text", Text: warn}},
+					})
+				}
+			}
+		}
 		for idx, tc := range toolCalls {
 			if err := ctx.Err(); err != nil {
 				// Context cancelled mid-tool-execution. The assistant message
@@ -4142,15 +4158,6 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 							Content: []provider.ContentBlock{{Type: "text", Text: msg}},
 						})
 					}
-				}
-			}
-			// Irreversibility gate: warn on under-grounded high-impact actions.
-			if a.irrevGate != nil {
-				if warn := a.irrevGate.recordAction(tc.Name, string(tc.Arguments)); warn != "" {
-					a.contextManager.Add(provider.Message{
-						Role:    "user",
-						Content: []provider.ContentBlock{{Type: "text", Text: warn}},
-					})
 				}
 			}
 			// #1776 case 3 / #1877: a FAILED verification is not grounding.

--- a/internal/agent/irrev_gate.go
+++ b/internal/agent/irrev_gate.go
@@ -141,6 +141,19 @@ func irrevClassifyTool(toolName, args string) int {
 	case "file_ops", "batch_replace", "lsp_rename":
 		// lsp_rename applies LSP workspace edits across files (no dispatch-layer
 		// checkpoint, see agent_tool.go) -- same tier as file_ops/batch_replace.
+		// #1798 case 3: file_ops delete+recursive removes a whole directory -
+		// semantically equal to shell `rm -rf` (High) but used to sit a tier
+		// lower with a weaker threshold; the most dangerous file_ops shape
+		// had the weakest gate.
+		if toolName == "file_ops" {
+			var a struct {
+				Action    string `json:"action"`
+				Recursive bool   `json:"recursive"`
+			}
+			if json.Unmarshal([]byte(args), &a) == nil && a.Action == "delete" && a.Recursive {
+				return irrevTierHigh
+			}
+		}
 		return irrevTierMedium
 	case "start_command", "run_command":
 		// Commands are at least medium — could be anything
@@ -210,6 +223,9 @@ func irrevIsDestructiveCommand(args string) bool {
 		"chmod -r 777", "chown -r",
 		"git push origin --delete", "git branch -d",
 		"git tag -d", "git remote remove",
+		// #1798 case 4: #1621 claimed "BOTH paths missed stash drop" but
+		// only fixed the tool path - the shell table never gained it.
+		"git stash drop", "git stash clear",
 		"sudo rm", "shutdown", "reboot", "halt",
 	}
 	for _, p := range patterns {
@@ -267,6 +283,23 @@ func (s *irrevGateState) recordAction(toolName, args string) string {
 	tier := irrevClassifyTool(toolName, args)
 	isGrounding := irrevIsGroundingAction(toolName)
 
+	// #1798 case 2: snapshot the window BEFORE appending the current call -
+	// the current call used to count itself as its own grounding evidence
+	// (run_command's Medium warning was mathematically unreachable, and two
+	// consecutive destructive commands served as each other's proof).
+	// Grounding still only counts the ledger, never success/failure of the
+	// current in-flight call (recordOutcome handles that retroactively).
+	recentGrounding := 0
+	start := len(s.grounding) - irrevGroundingWindow
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < len(s.grounding); i++ {
+		if s.grounding[i] {
+			recentGrounding++
+		}
+	}
+
 	// Track grounding history
 	if len(s.grounding) >= irrevMaxHistory {
 		s.grounding = s.grounding[1:]
@@ -280,18 +313,6 @@ func (s *irrevGateState) recordAction(toolName, args string) string {
 	// Only gate medium+ irreversibility actions
 	if tier < irrevTierMedium {
 		return ""
-	}
-
-	// Check grounding depth in recent window
-	recentGrounding := 0
-	start := len(s.grounding) - irrevGroundingWindow
-	if start < 0 {
-		start = 0
-	}
-	for i := start; i < len(s.grounding); i++ {
-		if s.grounding[i] {
-			recentGrounding++
-		}
 	}
 
 	// Tier-based thresholds: higher irreversibility needs more grounding

--- a/internal/agent/irrev_gate_1798_test.go
+++ b/internal/agent/irrev_gate_1798_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import "testing"
+
+// #1798: four gate-integrity regressions.
+func newGateForTest() *irrevGateState { return newIrrevGateState() }
+
+// Case 2: a lone run_command (grounding itself, Medium tier) must now WARN -
+// the window must not count the current call as its own evidence.
+func Test1798CurrentCallNotOwnGrounding(t *testing.T) {
+	s := newGateForTest()
+	if w := s.recordAction("run_command", `{"command":"go build ./..."}`); w == "" {
+		t.Fatal("under-grounded run_command (Medium) must warn - self-grounding made it unreachable")
+	}
+	// With one PRIOR grounding, the window has evidence -> quiet.
+	s2 := newGateForTest()
+	s2.recordAction("read_file", `{}`)
+	if w := s2.recordAction("run_command", `{"command":"go build ./..."}`); w != "" {
+		t.Fatalf("grounded run_command must stay quiet, got: %s", w)
+	}
+}
+
+// Case 3: file_ops delete+recursive is High (parity with rm -rf).
+func Test1798FileOpsRecursiveDeleteHigh(t *testing.T) {
+	s := newGateForTest()
+	if w := s.recordAction("file_ops", `{"operations":[{"action":"delete","source":"/tmp/x","recursive":true}]}`); w == "" {
+		t.Fatal("recursive dir delete with zero grounding must warn (High tier)")
+	}
+	// Plain single-file delete keeps Medium: one grounding suffices.
+	s2 := newGateForTest()
+	s2.recordAction("read_file", `{}`)
+	if w := s2.recordAction("file_ops", `{"operations":[{"action":"delete","source":"/tmp/x/f.txt"}]}`); w != "" {
+		t.Fatalf("single-file delete with 1 grounding must stay quiet, got: %s", w)
+	}
+}
+
+// Case 4: shell stash drop reaches the High pattern table.
+func Test1798ShellStashDropHigh(t *testing.T) {
+	s := newGateForTest()
+	if w := s.recordAction("run_command", `{"command":"git stash drop stash@{0}"}`); w == "" {
+		t.Fatal("shell stash drop with zero grounding must warn")
+	}
+}
+
+// Regression: well-grounded destructive action stays quiet.
+func Test1798GroundedHighQuiet(t *testing.T) {
+	s := newGateForTest()
+	s.recordAction("run_command", `{"command":"go test ./..."}`)
+	s.recordAction("git_status", `{}`)
+	if w := s.recordAction("run_command", `{"command":"git push --force"}`); w != "" {
+		t.Fatalf("2 prior groundings must satisfy High threshold, got: %s", w)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1798 (all four Med cases).

1. **Case 1**: gate wiring moved from the post-execution result loop to the pre-execution batch section (batch-coupling pattern) — "You are about to execute" now precedes execution; #1776 recordOutcome ordering preserved (entry exists before the revoke check).
2. **Case 2**: grounding window snapshot precedes the current-call append — run_command's Medium warning (mathematically unreachable via self-grounding) now fires; consecutive destructive commands no longer vouch for each other.
3. **Case 3**: file_ops delete+recursive → High (rm -rf parity); single-file delete keeps Medium.
4. **Case 4**: shell pattern table gains "git stash drop"/"git stash clear" (#1621 fixed only the tool path).

## Verification evidence (review)
Isolated worktree: agent suite **21.8s PASS** (p=1). Six pins across the four cases plus regression guards (prior-grounding quiets run_command; 2-grounding push --force stays quiet).

Closes #1798

Generated with [ggcode](https://github.com/topcheer/ggcode)
