### PR TITLE
fix(tui): twitch bind-path enable on Update loop; create chain guarded ensure (#1767)

### DIFF
--- a/internal/tui/twitch_panel.go
+++ b/internal/tui/twitch_panel.go
@@ -294,10 +294,20 @@ func (m *Model) createTwitchAdapterCmd(spec string) tea.Cmd {
 		}
 		// #1367 family batch 3 final sweep: config write moved onto
 		// the Update loop via configMutationMsg (see config_mutation.go).
+		// #1767 case 1: the create path was fixed but the BIND path still
+		// enabled the adapter inside the Cmd goroutine (SetIMAdapterEnabled
+		// map write + save while the render loop ranges the same map).
+		// The enable decision now lives here, in apply, on the Update loop.
 		return configMutationMsg{
 			apply: func(m *Model) error {
 				m.config.IM.Enabled = true
-				return m.config.AddIMAdapter(name, adapter)
+				if err := m.config.AddIMAdapter(name, adapter); err != nil {
+					return err
+				}
+				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+					return m.config.SetIMAdapterEnabled(name, true)
+				}
+				return nil
 			},
 			next: func(m *Model) tea.Cmd {
 				return func() tea.Msg {
@@ -351,7 +361,13 @@ func (m *Model) startTwitchAdapterIfNeeded(name string) error {
 }
 
 func (m *Model) ensureTwitchRuntime() error {
-	return m.ensureCurrentWorkspaceIMManager(m.t("panel.twitch.error.config_unavailable"), "", true)
+	// #1767 case 2: route through the guarded brother - the imEnsure
+	// single-flight in ensureStartedCurrentWorkspaceIMRuntime collapses
+	// concurrent Cmd goroutines into one InitRuntime (duplicate instance
+	// registrations otherwise) and blocks waiters on the starter's REAL
+	// outcome (#1379-D/#1417-A). The unguarded ensureCurrentWorkspaceIMManager
+	// raced the config map and the imManager field against the Update loop.
+	return m.ensureStartedCurrentWorkspaceIMRuntime(m.t("panel.twitch.error.config_unavailable"), "", true)
 }
 
 func (m *Model) bindTwitchEntry(entry twitchBindingEntry) tea.Cmd {


### PR DESCRIPTION
## Summary
Closes #1767 (cases 1-2; initial case 3 was falsified in the issue — cap=1 buffered channel, bare send mathematically non-blocking).

1. **Case 1 (Med)**: bind-path auto-enable (SetIMAdapterEnabled map write + save) ran in the Cmd goroutine against the render loop's map range — #1367-family crash. Enable decision moved into configMutationMsg.apply (Update loop); defensive fallback retained in startTwitchAdapterIfNeeded for its other caller.
2. **Case 2 (Med)**: create/next() chain used the unguarded ensureCurrentWorkspaceIMManager in a Cmd goroutine — ensureTwitchRuntime now routes through the imEnsure single-flight guarded brother (#1379-D/#1417-A semantics).

## Verification evidence (review)
Isolated worktree: tui suite **9.8s PASS** (p=1). Guard routing verified against im_runtime_shared.go structure (startIMRuntimeChain delegates through the guarded wrapper).

Closes #1767

Generated with [ggcode](https://github.com/topcheer/ggcode)
