### PR TITLE
fix(tool): warp rejects unknown modifiers; spam filter honors allowed_domains (#1709 cases 1+3)

### DIFF
--- a/internal/tool/warp_darwin.go
+++ b/internal/tool/warp_darwin.go
@@ -162,7 +162,10 @@ func (w *WarpTool) sendKeystroke(ctx context.Context, key string, modifiers stri
 		return fmt.Errorf("cancelled before keystroke: %w", err)
 	}
 
-	mods := parseModifiers(modifiers)
+	mods, mErr := parseModifiers(modifiers)
+	if mErr != nil {
+		return mErr
+	}
 	script := fmt.Sprintf(`tell application "System Events" to keystroke %q%s`, key, mods)
 	if err := exec.CommandContext(ctx, "osascript", "-e", script).Run(); err != nil {
 		return fmt.Errorf("keystroke script failed: %w", err)
@@ -179,7 +182,10 @@ func (w *WarpTool) sendKeyCode(ctx context.Context, code string, modifiers strin
 		return fmt.Errorf("cancelled before key code: %w", err)
 	}
 
-	mods := parseModifiers(modifiers)
+	mods, mErr := parseModifiers(modifiers)
+	if mErr != nil {
+		return mErr
+	}
 	script := fmt.Sprintf(`tell application "System Events" to key code %s%s`, code, mods)
 	if err := exec.CommandContext(ctx, "osascript", "-e", script).Run(); err != nil {
 		return fmt.Errorf("key code script failed: %w", err)
@@ -188,9 +194,9 @@ func (w *WarpTool) sendKeyCode(ctx context.Context, code string, modifiers strin
 }
 
 // parseModifiers converts "control,shift" to " using {control down, shift down}"
-func parseModifiers(mods string) string {
+func parseModifiers(mods string) (string, error) {
 	if mods == "" {
-		return ""
+		return "", nil
 	}
 	parts := strings.Split(mods, ",")
 	var valid []string
@@ -199,12 +205,20 @@ func parseModifiers(mods string) string {
 		switch p {
 		case "shift", "control", "option", "command":
 			valid = append(valid, p+" down")
+		case "":
+			// empty segment from a trailing comma - skip
+		default:
+			// #1709 case 1: unknown tokens ("ctrl"/"cmd"/"alt" synonyms)
+			// were silently DROPPED - 'ctrl+c' degraded to typing a bare
+			// 'c' into Warp while reporting success. Reject loudly (#880
+			// family) with the legal values so the caller can retry.
+			return "", fmt.Errorf("unknown modifier %q (legal: shift, control, option, command)", p)
 		}
 	}
 	if len(valid) == 0 {
-		return ""
+		return "", nil
 	}
-	return " using {" + strings.Join(valid, ", ") + "}"
+	return " using {" + strings.Join(valid, ", ") + "}", nil
 }
 
 func formatMods(mods string) string {

--- a/internal/tool/web_search_quality.go
+++ b/internal/tool/web_search_quality.go
@@ -92,10 +92,15 @@ func assessSearchResults(query string, results []searchResult, allowedDomains []
 	queryTerms := tokenizeQuery(query)
 
 	// Phase 1: Filter spam domains
+	// #1709 case 3: the user's explicit allowed_domains must EXEMPT from
+	// the spam list too - filterByDomain kept w3schools.com, then this
+	// phase killed every result and the tool answered "No results found"
+	// for the domain the user explicitly asked for (dedup had the
+	// exemption; the phases were asymmetric).
 	var filtered []searchResult
 	for _, res := range results {
 		domain := domainFromURL(res.URL)
-		if isSpamDomain(domain) {
+		if isSpamDomain(domain) && !allowed[domain] {
 			continue
 		}
 		filtered = append(filtered, res)


### PR DESCRIPTION
Case 1 (Med): parseModifiers silently DROPPED unknown tokens - `ctrl+c` degraded to typing a bare `c` into Warp while reporting success (#880 family: invalid input must error, not execute the wrong action). Legal values listed in the error.

Case 3 (Med): Phase-1 spam filtering ignored the `allowed_domains` exemption - the user explicitly allowed `w3schools.com`, filterByDomain kept it, then the spam phase killed EVERY result and the tool answered **'No results found' for the domain the user asked for** (dedup had the exemption; the phases were asymmetric).

(Case 2 - the proxy-path DNS-rebinding gap - needs an explicit product/security decision on proxy semantics and stays for follow-up.)

Isolated worktree (fresh origin/main): Search families PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)