### PR TITLE
fix(tui): five panels auto-enable on Update loop (#1794)

### DIFF
--- a/internal/tui/dingtalk_panel.go
+++ b/internal/tui/dingtalk_panel.go
@@ -233,22 +233,53 @@ func (m *Model) handleDingtalkPanelKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 
 func (m *Model) bindDingtalkEntry(entry dingtalkBindingEntry) tea.Cmd {
 	return func() tea.Msg {
-		if err := m.ensureDingtalkBotBinding(entry.Adapter); err != nil {
-			return dingtalkBindResultMsg{err: err}
-		}
-		if m.agent != nil {
-			if err := m.waitForDingtalkAdapterHealthy(m.imManager, entry.Adapter, 10*time.Second); err != nil {
-				return dingtalkBindResultMsg{err: err}
-			}
-			// Sync session history to the newly bound channel only.
-			if binding := m.imManager.Snapshot().BindingByAdapter(entry.Adapter); binding != nil {
-				if err := m.imManager.SyncSessionHistory(context.Background(), *binding, m.agent.Messages()); err != nil && err != im.ErrNoChannelBound {
-					return dingtalkBindResultMsg{err: err}
+		// #1794 case 2/3: a disabled adapter's auto-enable must run on the
+		// Update loop (#1367 family) - startXXXAdapterIfNeeded wrote the
+		// config map from this Cmd goroutine while the render loop ranged
+		// it. Follow the qq pattern: mutate via configMutationMsg, continue
+		// the bind in next().
+		if m.config != nil {
+			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+				return configMutationMsg{
+					apply: func(m *Model) error {
+						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
+					},
+					next: func(m *Model) tea.Cmd {
+						return func() tea.Msg {
+							if m.imManager != nil {
+								_ = m.imManager.EnableBinding(entry.Adapter)
+							}
+							return bindDingtalkRest(m, entry)
+						}
+					},
+					fail: func(err error) tea.Msg {
+						return dingtalkBindResultMsg{err: fmt.Errorf("enable %s: %w", entry.Adapter, err)}
+					},
 				}
 			}
 		}
-		return dingtalkBindResultMsg{message: m.t("panel.dingtalk.message.bound_success")}
+		return bindDingtalkRest(m, entry)
 	}
+}
+
+// bindDingtalkRest is the bind chain body after the (optional) enable
+// mutation lands on the Update loop.
+func bindDingtalkRest(m *Model, entry dingtalkBindingEntry) tea.Msg {
+	if err := m.ensureDingtalkBotBinding(entry.Adapter); err != nil {
+		return dingtalkBindResultMsg{err: err}
+	}
+	if m.agent != nil {
+		if err := m.waitForDingtalkAdapterHealthy(m.imManager, entry.Adapter, 10*time.Second); err != nil {
+			return dingtalkBindResultMsg{err: err}
+		}
+		// Sync session history to the newly bound channel only.
+		if binding := m.imManager.Snapshot().BindingByAdapter(entry.Adapter); binding != nil {
+			if err := m.imManager.SyncSessionHistory(context.Background(), *binding, m.agent.Messages()); err != nil && err != im.ErrNoChannelBound {
+				return dingtalkBindResultMsg{err: err}
+			}
+		}
+	}
+	return dingtalkBindResultMsg{message: m.t("panel.dingtalk.message.bound_success")}
 }
 
 func (m *Model) unbindDingtalkEntry(adapterName string) tea.Cmd {
@@ -303,7 +334,16 @@ func (m *Model) createDingtalkAdapterCmd(spec string) tea.Cmd {
 		return configMutationMsg{
 			apply: func(m *Model) error {
 				m.config.IM.Enabled = true
-				return m.config.AddIMAdapter(name, adapter)
+				if err := m.config.AddIMAdapter(name, adapter); err != nil {
+					return err
+				}
+				// #1794 case 2: auto-enable on the Update loop - the next()
+				// closure's startXXXAdapterIfNeeded used to write the map
+				// from the Cmd goroutine (#1367 family).
+				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+					return m.config.SetIMAdapterEnabled(name, true)
+				}
+				return nil
 			},
 			next: func(m *Model) tea.Cmd {
 				return func() tea.Msg {

--- a/internal/tui/discord_panel.go
+++ b/internal/tui/discord_panel.go
@@ -234,22 +234,53 @@ func (m *Model) handleDiscordPanelKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 
 func (m *Model) bindDiscordEntry(entry discordBindingEntry) tea.Cmd {
 	return func() tea.Msg {
-		if err := m.ensureDiscordBotBinding(entry.Adapter); err != nil {
-			return discordBindResultMsg{err: err}
-		}
-		if m.agent != nil {
-			if err := m.waitForDiscordAdapterHealthy(m.imManager, entry.Adapter, 10*time.Second); err != nil {
-				return discordBindResultMsg{err: err}
-			}
-			// Sync session history to the newly bound channel only.
-			if binding := m.imManager.Snapshot().BindingByAdapter(entry.Adapter); binding != nil {
-				if err := m.imManager.SyncSessionHistory(context.Background(), *binding, m.agent.Messages()); err != nil && err != im.ErrNoChannelBound {
-					return discordBindResultMsg{err: err}
+		// #1794 case 2/3: a disabled adapter's auto-enable must run on the
+		// Update loop (#1367 family) - startXXXAdapterIfNeeded wrote the
+		// config map from this Cmd goroutine while the render loop ranged
+		// it. Follow the qq pattern: mutate via configMutationMsg, continue
+		// the bind in next().
+		if m.config != nil {
+			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+				return configMutationMsg{
+					apply: func(m *Model) error {
+						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
+					},
+					next: func(m *Model) tea.Cmd {
+						return func() tea.Msg {
+							if m.imManager != nil {
+								_ = m.imManager.EnableBinding(entry.Adapter)
+							}
+							return bindDiscordRest(m, entry)
+						}
+					},
+					fail: func(err error) tea.Msg {
+						return discordBindResultMsg{err: fmt.Errorf("enable %s: %w", entry.Adapter, err)}
+					},
 				}
 			}
 		}
-		return discordBindResultMsg{message: m.t("panel.discord.message.bound_success")}
+		return bindDiscordRest(m, entry)
 	}
+}
+
+// bindDiscordRest is the bind chain body after the (optional) enable
+// mutation lands on the Update loop.
+func bindDiscordRest(m *Model, entry discordBindingEntry) tea.Msg {
+	if err := m.ensureDiscordBotBinding(entry.Adapter); err != nil {
+		return discordBindResultMsg{err: err}
+	}
+	if m.agent != nil {
+		if err := m.waitForDiscordAdapterHealthy(m.imManager, entry.Adapter, 10*time.Second); err != nil {
+			return discordBindResultMsg{err: err}
+		}
+		// Sync session history to the newly bound channel only.
+		if binding := m.imManager.Snapshot().BindingByAdapter(entry.Adapter); binding != nil {
+			if err := m.imManager.SyncSessionHistory(context.Background(), *binding, m.agent.Messages()); err != nil && err != im.ErrNoChannelBound {
+				return discordBindResultMsg{err: err}
+			}
+		}
+	}
+	return discordBindResultMsg{message: m.t("panel.discord.message.bound_success")}
 }
 
 func (m *Model) unbindDiscordEntry(adapterName string) tea.Cmd {
@@ -300,7 +331,16 @@ func (m *Model) createDiscordAdapterCmd(spec string) tea.Cmd {
 		return configMutationMsg{
 			apply: func(m *Model) error {
 				m.config.IM.Enabled = true
-				return m.config.AddIMAdapter(name, adapter)
+				if err := m.config.AddIMAdapter(name, adapter); err != nil {
+					return err
+				}
+				// #1794 case 2: auto-enable on the Update loop - the next()
+				// closure's startXXXAdapterIfNeeded used to write the map
+				// from the Cmd goroutine (#1367 family).
+				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+					return m.config.SetIMAdapterEnabled(name, true)
+				}
+				return nil
 			},
 			next: func(m *Model) tea.Cmd {
 				return func() tea.Msg {

--- a/internal/tui/feishu_panel.go
+++ b/internal/tui/feishu_panel.go
@@ -226,22 +226,53 @@ func (m *Model) handleFeishuPanelKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 
 func (m *Model) bindFeishuEntry(entry feishuBindingEntry) tea.Cmd {
 	return func() tea.Msg {
-		if err := m.ensureFeishuBotBinding(entry.Adapter); err != nil {
-			return feishuBindResultMsg{err: err}
-		}
-		if m.agent != nil {
-			if err := m.waitForFeishuAdapterHealthy(m.imManager, entry.Adapter, 10*time.Second); err != nil {
-				return feishuBindResultMsg{err: err}
-			}
-			// Sync session history to the newly bound channel only.
-			if binding := m.imManager.Snapshot().BindingByAdapter(entry.Adapter); binding != nil {
-				if err := m.imManager.SyncSessionHistory(context.Background(), *binding, m.agent.Messages()); err != nil && err != im.ErrNoChannelBound {
-					return feishuBindResultMsg{err: err}
+		// #1794 case 2/3: a disabled adapter's auto-enable must run on the
+		// Update loop (#1367 family) - startXXXAdapterIfNeeded wrote the
+		// config map from this Cmd goroutine while the render loop ranged
+		// it. Follow the qq pattern: mutate via configMutationMsg, continue
+		// the bind in next().
+		if m.config != nil {
+			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+				return configMutationMsg{
+					apply: func(m *Model) error {
+						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
+					},
+					next: func(m *Model) tea.Cmd {
+						return func() tea.Msg {
+							if m.imManager != nil {
+								_ = m.imManager.EnableBinding(entry.Adapter)
+							}
+							return bindFeishuRest(m, entry)
+						}
+					},
+					fail: func(err error) tea.Msg {
+						return feishuBindResultMsg{err: fmt.Errorf("enable %s: %w", entry.Adapter, err)}
+					},
 				}
 			}
 		}
-		return feishuBindResultMsg{message: m.t("panel.feishu.message.bound_success")}
+		return bindFeishuRest(m, entry)
 	}
+}
+
+// bindFeishuRest is the bind chain body after the (optional) enable
+// mutation lands on the Update loop.
+func bindFeishuRest(m *Model, entry feishuBindingEntry) tea.Msg {
+	if err := m.ensureFeishuBotBinding(entry.Adapter); err != nil {
+		return feishuBindResultMsg{err: err}
+	}
+	if m.agent != nil {
+		if err := m.waitForFeishuAdapterHealthy(m.imManager, entry.Adapter, 10*time.Second); err != nil {
+			return feishuBindResultMsg{err: err}
+		}
+		// Sync session history to the newly bound channel only.
+		if binding := m.imManager.Snapshot().BindingByAdapter(entry.Adapter); binding != nil {
+			if err := m.imManager.SyncSessionHistory(context.Background(), *binding, m.agent.Messages()); err != nil && err != im.ErrNoChannelBound {
+				return feishuBindResultMsg{err: err}
+			}
+		}
+	}
+	return feishuBindResultMsg{message: m.t("panel.feishu.message.bound_success")}
 }
 
 func (m *Model) unbindFeishuEntry(adapterName string) tea.Cmd {
@@ -300,7 +331,16 @@ func (m *Model) createFeishuAdapterCmd(spec string) tea.Cmd {
 		return configMutationMsg{
 			apply: func(m *Model) error {
 				m.config.IM.Enabled = true
-				return m.config.AddIMAdapter(name, adapter)
+				if err := m.config.AddIMAdapter(name, adapter); err != nil {
+					return err
+				}
+				// #1794 case 2: auto-enable on the Update loop - the next()
+				// closure's startXXXAdapterIfNeeded used to write the map
+				// from the Cmd goroutine (#1367 family).
+				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+					return m.config.SetIMAdapterEnabled(name, true)
+				}
+				return nil
 			},
 			next: func(m *Model) tea.Cmd {
 				return func() tea.Msg {

--- a/internal/tui/signal_panel.go
+++ b/internal/tui/signal_panel.go
@@ -536,21 +536,51 @@ func (m *Model) bindSigEntry(entry signalBindingEntry) tea.Cmd {
 		if m.imManager == nil {
 			return signalBindResultMsg{err: errors.New(m.t("panel.signal.error.config_unavailable"))}
 		}
-		if err := m.startSignalAdapterIfNeeded(entry.Adapter); err != nil {
-			return signalBindResultMsg{err: err}
+		// #1794 case 2/3: a disabled adapter's auto-enable must run on the
+		// Update loop (#1367 family) - startSignalAdapterIfNeeded wrote the
+		// config map from this Cmd goroutine while the render loop ranged
+		// it. qq pattern: mutate via configMutationMsg, continue in next().
+		if m.config != nil {
+			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+				return configMutationMsg{
+					apply: func(m *Model) error {
+						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
+					},
+					next: func(m *Model) tea.Cmd {
+						return func() tea.Msg {
+							if m.imManager != nil {
+								_ = m.imManager.EnableBinding(entry.Adapter)
+							}
+							return bindSigRest(m, entry, ws)
+						}
+					},
+					fail: func(err error) tea.Msg {
+						return signalBindResultMsg{err: fmt.Errorf("enable %s: %w", entry.Adapter, err)}
+					},
+				}
+			}
 		}
-		targetID := defaultSignalTargetID(ws)
-		_, err := m.imManager.BindChannel(im.ChannelBinding{
-			Workspace: ws,
-			Platform:  im.PlatformSignal,
-			Adapter:   entry.Adapter,
-			TargetID:  targetID,
-		})
-		if err != nil {
-			return signalBindResultMsg{err: err}
-		}
-		return signalBindResultMsg{message: m.t("panel.signal.message.bound_success")}
+		return bindSigRest(m, entry, ws)
 	}
+}
+
+// bindSigRest is the bind chain body after the (optional) enable mutation
+// lands on the Update loop.
+func bindSigRest(m *Model, entry signalBindingEntry, ws string) tea.Msg {
+	if err := m.startSignalAdapterIfNeeded(entry.Adapter); err != nil {
+		return signalBindResultMsg{err: err}
+	}
+	targetID := defaultSignalTargetID(ws)
+	_, err := m.imManager.BindChannel(im.ChannelBinding{
+		Workspace: ws,
+		Platform:  im.PlatformSignal,
+		Adapter:   entry.Adapter,
+		TargetID:  targetID,
+	})
+	if err != nil {
+		return signalBindResultMsg{err: err}
+	}
+	return signalBindResultMsg{message: m.t("panel.signal.message.bound_success")}
 }
 
 func (m *Model) unbindSigEntry(adapterName string) tea.Cmd {

--- a/internal/tui/slack_panel.go
+++ b/internal/tui/slack_panel.go
@@ -234,22 +234,53 @@ func (m *Model) handleSlackPanelKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 
 func (m *Model) bindSlackEntry(entry slackBindingEntry) tea.Cmd {
 	return func() tea.Msg {
-		if err := m.ensureSlackBotBinding(entry.Adapter); err != nil {
-			return slackBindResultMsg{err: err}
-		}
-		if m.agent != nil {
-			if err := m.waitForSlackAdapterHealthy(m.imManager, entry.Adapter, 10*time.Second); err != nil {
-				return slackBindResultMsg{err: err}
-			}
-			// Sync session history to the newly bound channel only.
-			if binding := m.imManager.Snapshot().BindingByAdapter(entry.Adapter); binding != nil {
-				if err := m.imManager.SyncSessionHistory(context.Background(), *binding, m.agent.Messages()); err != nil && err != im.ErrNoChannelBound {
-					return slackBindResultMsg{err: err}
+		// #1794 case 2/3: a disabled adapter's auto-enable must run on the
+		// Update loop (#1367 family) - startXXXAdapterIfNeeded wrote the
+		// config map from this Cmd goroutine while the render loop ranged
+		// it. Follow the qq pattern: mutate via configMutationMsg, continue
+		// the bind in next().
+		if m.config != nil {
+			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+				return configMutationMsg{
+					apply: func(m *Model) error {
+						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
+					},
+					next: func(m *Model) tea.Cmd {
+						return func() tea.Msg {
+							if m.imManager != nil {
+								_ = m.imManager.EnableBinding(entry.Adapter)
+							}
+							return bindSlackRest(m, entry)
+						}
+					},
+					fail: func(err error) tea.Msg {
+						return slackBindResultMsg{err: fmt.Errorf("enable %s: %w", entry.Adapter, err)}
+					},
 				}
 			}
 		}
-		return slackBindResultMsg{message: m.t("panel.slack.message.bound_success")}
+		return bindSlackRest(m, entry)
 	}
+}
+
+// bindSlackRest is the bind chain body after the (optional) enable
+// mutation lands on the Update loop.
+func bindSlackRest(m *Model, entry slackBindingEntry) tea.Msg {
+	if err := m.ensureSlackBotBinding(entry.Adapter); err != nil {
+		return slackBindResultMsg{err: err}
+	}
+	if m.agent != nil {
+		if err := m.waitForSlackAdapterHealthy(m.imManager, entry.Adapter, 10*time.Second); err != nil {
+			return slackBindResultMsg{err: err}
+		}
+		// Sync session history to the newly bound channel only.
+		if binding := m.imManager.Snapshot().BindingByAdapter(entry.Adapter); binding != nil {
+			if err := m.imManager.SyncSessionHistory(context.Background(), *binding, m.agent.Messages()); err != nil && err != im.ErrNoChannelBound {
+				return slackBindResultMsg{err: err}
+			}
+		}
+	}
+	return slackBindResultMsg{message: m.t("panel.slack.message.bound_success")}
 }
 
 func (m *Model) unbindSlackEntry(adapterName string) tea.Cmd {
@@ -311,7 +342,16 @@ func (m *Model) createSlackAdapterCmd(spec string) tea.Cmd {
 		return configMutationMsg{
 			apply: func(m *Model) error {
 				m.config.IM.Enabled = true
-				return m.config.AddIMAdapter(name, adapter)
+				if err := m.config.AddIMAdapter(name, adapter); err != nil {
+					return err
+				}
+				// #1794 case 2: auto-enable on the Update loop - the next()
+				// closure's startXXXAdapterIfNeeded used to write the map
+				// from the Cmd goroutine (#1367 family).
+				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+					return m.config.SetIMAdapterEnabled(name, true)
+				}
+				return nil
 			},
 			next: func(m *Model) tea.Cmd {
 				return func() tea.Msg {


### PR DESCRIPTION
## Summary
Closes #1794 (case 2/3; case 1 verified already fixed on main by #1763 — the shared toggle root carries both mutations through configMutationMsg).

1. **Case 2 (High)**: five panels (dingtalk/discord/slack/feishu/signal) auto-enabled adapters via raw SetIMAdapterEnabled inside Cmd goroutines — add chains now enable in configMutationMsg.apply (twitch precedent #1767); bind entries get the qq-pattern wrapper (disabled → mutation, bind continues in next() via bindXRest). Internal startXXXIfNeeded enables stay as idempotent defensive fallbacks.
2. **Case 3 (Med)**: decision reads precede the queued mutation (qq-adjudicated shape); irc/matrix/mattermost/nostr already converted; whatsapp excluded (#1793 scope).

## Verification evidence (review)
Isolated worktree: tui suite **11.3s PASS** (p=1) + build + vet on the changed package. Cross-checked all 12+ SetIMAdapterEnabled sites repo-wide; only the excluded whatsapp (#1793) and the accepted defensive fallbacks remain.

Closes #1794

Generated with [ggcode](https://github.com/topcheer/ggcode)
