### PR TITLE
fix(util): WrapTransport proxy on cloned bases; staged timeouts; Truncate negative clamp (#1849)

### DIFF
--- a/internal/util/transport.go
+++ b/internal/util/transport.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -35,10 +36,35 @@ func WrapTransport(base *http.Transport) *http.Transport {
 	var t *http.Transport
 	if base != nil {
 		t = base.Clone()
+		// #1849 case 1: Clone preserves the base's Proxy verbatim - callers
+		// like a2a WithMTLS build a transport for its TLS fields only and
+		// leave Proxy nil, which silently meant DIRECT connection: the env
+		// proxy (ProxyFromEnvironment) and the Windows sysproxy chain both
+		// stopped working behind corporate proxies. Only honor an explicit
+		// caller-set Proxy; a nil Proxy gets the smart default.
+		if t.Proxy == nil {
+			t.Proxy = SmartProxyFunc()
+		}
 	} else {
 		t = &http.Transport{
 			Proxy: SmartProxyFunc(),
 		}
+	}
+	// #1849 case 3: staged timeouts for the fresh-transport paths - the
+	// a2a mTLS client runs with Client.Timeout == 0 on purpose (#1458-B),
+	// so without per-stage defaults a hung dial or silent peer could pin
+	// the connection for as long as the (possibly nil) context allows.
+	if t.DialContext == nil {
+		t.DialContext = (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext
+	}
+	if t.TLSHandshakeTimeout == 0 {
+		t.TLSHandshakeTimeout = 15 * time.Second
+	}
+	if t.ResponseHeaderTimeout == 0 {
+		t.ResponseHeaderTimeout = 10 * time.Minute
 	}
 	// Disable HTTP/2 globally to prevent a crash in net/http's http2 client
 	// conn readLoop on Windows (Go 1.26.x). The http2Framer.ReadFrameHeader

--- a/internal/util/truncate.go
+++ b/internal/util/truncate.go
@@ -5,8 +5,12 @@ import "unicode/utf8"
 // Truncate truncates a string to maxRunes runes, appending "..." if truncated.
 // Uses []rune to avoid UTF-8 multi-byte truncation.
 func Truncate(s string, maxRunes int) string {
-	if maxRunes < 0 {
-		return s
+	// #1849 case 2: width-arithmetic callers (terminal width minus
+	// padding, e.g. w-6 on a <10-wide terminal) leak negative values -
+	// returning the string untruncated broke fixed-width panel rendering.
+	// A negative budget means NO room: empty string.
+	if maxRunes <= 0 {
+		return ""
 	}
 	runes := []rune(s)
 	if len(runes) <= maxRunes {

--- a/internal/util/truncate_1849_test.go
+++ b/internal/util/truncate_1849_test.go
@@ -1,0 +1,28 @@
+package util
+
+import "testing"
+
+// #1849 case 2: width-arithmetic callers leak negative budgets on narrow
+// terminals - the old contract returned the string untruncated and broke
+// fixed-width panel rendering. Negative budget = no room = empty string.
+func Test1849TruncateNegativeClamp(t *testing.T) {
+	if got := Truncate("hello world", -3); got != "" {
+		t.Fatalf("negative budget must yield empty string, got %q", got)
+	}
+	if got := Truncate("hello", -1); got != "" {
+		t.Fatalf("negative budget must yield empty string, got %q", got)
+	}
+}
+
+// Regression guards for the untouched contract points.
+func Test1849TruncateContract(t *testing.T) {
+	if got := Truncate("hello", 5); got != "hello" {
+		t.Fatalf("exact fit must return as-is, got %q", got)
+	}
+	if got := Truncate("hello world", 8); got != "hello..." {
+		t.Fatalf("ellipsis truncation broken, got %q", got)
+	}
+	if got := Truncate("hello", 0); got != "" {
+		t.Fatalf("zero budget must be empty, got %q", got)
+	}
+}

--- a/internal/util/truncate_test.go
+++ b/internal/util/truncate_test.go
@@ -75,7 +75,9 @@ func TestTruncate(t *testing.T) {
 		{"maxRunes_1", "hello", 1, "h"},
 		{"empty", "", 10, ""},
 		{"multi_byte", "日本語テスト", 4, "日..."},
-		{"negative", "hello", -1, "hello"},
+		// #1849 case 2: negative budgets (width-arithmetic leaks on narrow
+		// terminals) mean NO room, not unlimited room.
+		{"negative", "hello", -1, ""},
 		{"zero", "hello", 0, ""},
 	}
 


### PR DESCRIPTION
## Summary
Closes #1849 (all three cases).

1. **Case 1 (High)**: cloned-base WrapTransport honored the base's nil Proxy = direct connection — the a2a WithMTLS corporate-proxy breakage. Explicit caller Proxy preserved; nil gets SmartProxyFunc().
2. **Case 2 (Med-Low)**: Truncate negative budgets (width-arithmetic leaks) now yield "" instead of untruncated text breaking fixed-width panels.
3. **Case 3 (Med-Low)**: staged timeout defaults (dial 30s/TLS 15s/resp-header 10m) on fresh transports; explicit non-zero caller values preserved.

## Verification evidence (review)
Isolated worktree: util + tui suites **PASS** (p=1). All 4 width-arithmetic Truncate callers checked (knight_panel ×2, view_sidebar, mcp.go max-guarded); 83 total callers reviewed for intentional-negative reliance — the pre-existing negative test expectation documented the old contract and was updated deliberately with the change called out in the commit message.

Closes #1849

Generated with [ggcode](https://github.com/topcheer/ggcode)
