### PR TITLE
fix(tool): streaming range read records and conflict-checks (#1698 case 2)

### DIFF
--- a/internal/tool/read_file.go
+++ b/internal/tool/read_file.go
@@ -102,6 +102,12 @@ func (t ReadFile) Execute(ctx context.Context, input json.RawMessage) (Result, e
 			if err != nil {
 				return Result{IsError: true, Content: err.Error()}, nil
 			}
+			// #1698 case 2: the streaming path skipped BOTH guards the
+			// small-file path runs - stale-read detection never saw a
+			// >10MB ranged read (write_file's CheckStale went blind) and
+			// merge-conflict markers slipped through unflagged.
+			defaultFileTracker.RecordRead(args.Path)
+			text += CheckContentForConflicts(text)
 			return Result{Content: text}, nil
 		}
 		// Count lines so the agent knows the range to use


### PR DESCRIPTION
The >10MB ranged-read path skipped BOTH guards the small-file path runs: stale-read detection never saw the read (**write_file's CheckStale went blind for large files**) and merge-conflict markers slipped through unflagged. `RecordRead` + `CheckContentForConflicts` now run on both paths.

(Case 1 - binary/image sniffing on the streaming path - and case 3 - the restart reason announcement contract - stay for follow-up.)

Isolated worktree (fresh origin/main): Read families PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)