### PR TITLE
fix(tool,tunnel): Windows clipboard read UTF-8 + write fallback; zero-expiry descriptors rejected (#1822)

### DIFF
--- a/internal/tool/clipboard.go
+++ b/internal/tool/clipboard.go
@@ -128,7 +128,12 @@ func clipboardReadCmd(ctx context.Context) (*exec.Cmd, error) {
 	case "darwin":
 		return exec.CommandContext(ctx, "pbpaste"), nil
 	case "windows":
-		return exec.CommandContext(ctx, "powershell", "-NoProfile", "-Command", "Get-Clipboard"), nil
+		// #1822 case 1: Get-Clipboard emits through [Console]::OutputEncoding,
+		// which Windows PowerShell 5.1 defaults to the OEM code page (936 on
+		// CJK machines) - Go then UTF-8-decoded GBK bytes into mojibake.
+		// The #1642-2 "symmetric fix" set only the WRITE side's encodings.
+		return exec.CommandContext(ctx, "powershell", "-NoProfile", "-Command",
+			"[Console]::OutputEncoding=[Text.Encoding]::UTF8; Get-Clipboard"), nil
 	default: // linux, freebsd, etc.
 		if path, _ := exec.LookPath("wl-paste"); path != "" {
 			return exec.CommandContext(ctx, path), nil
@@ -152,7 +157,20 @@ func clipboardWriteCmd(ctx context.Context) (*exec.Cmd, error) {
 		// #1642-2: clip.exe decodes stdin with the SYSTEM ANSI code page
 		// (GBK/936 etc.) - CJK/emoji wrote mojibake while the READ side
 		// already uses PowerShell UTF-8. Symmetric Set-Clipboard fixes it.
-		return exec.CommandContext(ctx, "powershell", "-NoProfile", "-Command", "$OutputEncoding=[Console]::InputEncoding=[Text.Encoding]::UTF8; Set-Clipboard -Value ([Console]::In.ReadToEnd())"), nil
+		// #1822 case 2: a hard-coded "powershell" broke Nano Server/Server
+		// Core containers (no Windows PowerShell) where clip.exe works -
+		// mirror the Linux three-tier degradation: powershell, then pwsh,
+		// then clip.exe (old behavior, mojibake limitation beats nothing).
+		if path, _ := exec.LookPath("powershell"); path != "" {
+			return exec.CommandContext(ctx, path, "-NoProfile", "-Command", "$OutputEncoding=[Console]::InputEncoding=[Text.Encoding]::UTF8; Set-Clipboard -Value ([Console]::In.ReadToEnd())"), nil
+		}
+		if path, _ := exec.LookPath("pwsh"); path != "" {
+			return exec.CommandContext(ctx, path, "-NoProfile", "-Command", "$OutputEncoding=[Console]::InputEncoding=[Text.Encoding]::UTF8; Set-Clipboard -Value ([Console]::In.ReadToEnd())"), nil
+		}
+		if path, _ := exec.LookPath("clip.exe"); path != "" {
+			return exec.CommandContext(ctx, path), nil
+		}
+		return nil, fmt.Errorf("no clipboard utility found (powershell, pwsh, or clip.exe)")
 	default:
 		if path, _ := exec.LookPath("wl-copy"); path != "" {
 			return exec.CommandContext(ctx, path), nil

--- a/internal/tunnel/share_protocol.go
+++ b/internal/tunnel/share_protocol.go
@@ -213,6 +213,12 @@ func requestIssuedShareSession(ctx context.Context, relayURL string, cfg ShareRu
 	if err != nil {
 		return ShareDescriptor{}, ShareDescriptor{}, fmt.Errorf("issue share session renew expiry: %w", err)
 	}
+	// #1822 case 3: omitempty lets a relay omit the expiries and the zero
+	// values sailed through with ambiguous IsZero semantics (never-expires
+	// vs already-expired). An incomplete descriptor is an error.
+	if authExpiresAt.IsZero() || renewExpiresAt.IsZero() {
+		return ShareDescriptor{}, ShareDescriptor{}, fmt.Errorf("issue share session: incomplete descriptor (missing expiry)")
+	}
 	shareMode := strings.TrimSpace(issued.ShareMode)
 	if shareMode == "" {
 		shareMode = ShareModeV3
@@ -327,6 +333,10 @@ func refreshIssuedShareSession(ctx context.Context, relayURL string, server Shar
 	renewExpiresAt, err := parseShareTimestamp(refreshed.RenewExpiresAt)
 	if err != nil {
 		return ShareDescriptor{}, ShareDescriptor{}, fmt.Errorf("refresh share session renew expiry: %w", err)
+	}
+	// #1822 case 3: same zero-expiry rejection on the refresh path.
+	if authExpiresAt.IsZero() || renewExpiresAt.IsZero() {
+		return ShareDescriptor{}, ShareDescriptor{}, fmt.Errorf("refresh share session: incomplete descriptor (missing expiry)")
 	}
 	updatedServer = server
 	if refreshed.ProtocolVersion != 0 {

--- a/internal/tunnel/share_protocol_1822_test.go
+++ b/internal/tunnel/share_protocol_1822_test.go
@@ -1,0 +1,38 @@
+package tunnel
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// #1822 case 3: omitempty expiries must not silently pass validation
+// (zero time = ambiguous IsZero semantics). Pins the parse-level shape:
+// an expiry-less descriptor decodes to zero times with NO parse error,
+// which is exactly the state the new validation guard rejects.
+func Test1822OmittedExpiryParsesToZero(t *testing.T) {
+	payload := `{"protocol_version":4,"room_id":"r","server_auth_ticket":"s","client_auth_ticket":"c"}`
+	var issued relayIssuedShareSessionResponse
+	if err := json.NewDecoder(strings.NewReader(payload)).Decode(&issued); err != nil {
+		t.Fatal(err)
+	}
+	auth, err1 := parseShareTimestamp(issued.AuthExpiresAt)
+	renew, err2 := parseShareTimestamp(issued.RenewExpiresAt)
+	if err1 != nil || err2 != nil {
+		t.Fatalf("parse errors: %v %v", err1, err2)
+	}
+	if !auth.IsZero() || !renew.IsZero() {
+		t.Fatal("omitted expiries must decode to zero times (the state validation now rejects)")
+	}
+	// Well-formed timestamps still parse.
+	var good relayIssuedShareSessionResponse
+	payload2 := `{"protocol_version":4,"auth_expires_at":"2026-01-02T15:04:05Z","renew_expires_at":"2026-01-09T15:04:05Z"}`
+	if err := json.NewDecoder(strings.NewReader(payload2)).Decode(&good); err != nil {
+		t.Fatal(err)
+	}
+	ga, err := parseShareTimestamp(good.AuthExpiresAt)
+	gr, err2 := parseShareTimestamp(good.RenewExpiresAt)
+	if err != nil || err2 != nil || ga.IsZero() || gr.IsZero() {
+		t.Fatalf("valid expiries must parse non-zero: %v %v %v %v", ga, gr, err, err2)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1822 (all three cases).

1. **Case 1 (Med)**: read-side Get-Clipboard now sets `[Console]::OutputEncoding=UTF8` — CJK round-trip completes (#1642-2 fixed only the write side).
2. **Case 2 (Med)**: write path degrades powershell → pwsh → clip.exe (LookPath tiers, Linux pattern) — Nano Server/Server Core containers regain clipboard writes.
3. **Case 3 (Low-Med)**: issue AND refresh validation reject zero (omitted) expiries as incomplete descriptors.

## Verification evidence (review)
Isolated worktree: tool **46.5s** + tunnel **14.0s** PASS (p=1); GOOS=windows build OK. Pin: omitted-expiry decodes to zero-times-no-error (the exact state the new guard rejects) + valid-timestamp parse guard. Clipboard commands are Windows-runtime behavior — cross-compiled, exercised by real Windows CI per policy.

Closes #1822

Generated with [ggcode](https://github.com/topcheer/ggcode)
