### PR TITLE
fix(lanchat): bound sender-side presence response parsing (#1627)

### DIFF
--- a/internal/lanchat/hub.go
+++ b/internal/lanchat/hub.go
@@ -908,9 +908,15 @@ func (h *Hub) sendPresence(peer Participant) {
 	// TCP succeeded — mark peer TCP as up
 	h.recordTransportResult(peer.NodeID, "tcp", true)
 
-	// The response contains the peer's own presence — learn it too
+	// The response contains the peer's own presence — learn it too.
+	// #1627 case C: the sender side parsed the peer's response body with
+	// no ceiling — a malicious/compromised LAN peer could stream an
+	// unbounded "presence" and json.Decoder would buffer it all. Presence
+	// payloads are tiny; bound the read (io.LimitReader keeps the decode
+	// semantic - oversize input simply fails to decode and is ignored,
+	// matching this path's best-effort nature).
 	var peerInfo Participant
-	if err := json.NewDecoder(resp.Body).Decode(&peerInfo); err == nil && peerInfo.NodeID != "" {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, lanchatMaxBodyBytes)).Decode(&peerInfo); err == nil && peerInfo.NodeID != "" {
 		var cb func(Participant)
 		var participant Participant
 		h.mu.Lock()


### PR DESCRIPTION
## Summary
Closes #1627.

Cases A/B verified already landed on main by 86592c0e (all four receive endpoints capped, 413 via `*http.MaxBytesError`) — not re-fixed. This PR lands the explicitly-noted remaining rider: the sender side (hub.go presence POST) parsed the peer's response body unbounded — a compromised LAN peer could stream an unbounded "presence" into memory. Bounded with `io.LimitReader(resp.Body, lanchatMaxBodyBytes)`; best-effort decode semantics preserved (oversize → decode fails → ignored, matching surrounding handling).

## Verification evidence (review)
Isolated worktree: lanchat suite **3.8s PASS** (p=1). Cases A/B verified by direct read of handlers.go (four MaxBytesReader sites + four errors.As branches).

Closes #1627

Generated with [ggcode](https://github.com/topcheer/ggcode)
