### PR TITLE
fix(agent,tool): drop bare oldest/最近的 entries; word-boundary term scoring (#1710 cases 2+3)

### DIFF
--- a/internal/agent/ambiguity_point.go
+++ b/internal/agent/ambiguity_point.go
@@ -144,7 +144,6 @@ var ambiguityPatterns = []struct {
 	{"latest items", ambQuantityVague, "how many of the latest items"},
 	{"latest entries", ambQuantityVague, "how many entries and by what cutoff"},
 	{"latest results", ambQuantityVague, "how many results and by what cutoff"},
-	{"oldest", ambQuantityVague, "how many of the oldest items"},
 
 	// Vague direction (for modifications)
 	{"improve the", ambDirectionVague, "improve toward what goal -- performance, readability, security?"},
@@ -178,7 +177,6 @@ var ambiguityPatterns = []struct {
 	{"重命名", ambNamingVague, "the new name convention and whether to update all references"},
 	{"改名", ambNamingVague, "the new name convention and whether to update all references"},
 	{"最新的", ambQuantityVague, "how many of the latest items, and by what cutoff"},
-	{"最近的", ambQuantityVague, "the time window or count for 'recent'"},
 	{"随便", ambScopeVague, "which specific item or criteria"},
 	{"大概", ambQuantityVague, "the exact count or selection criteria"},
 }

--- a/internal/tool/web_search_quality.go
+++ b/internal/tool/web_search_quality.go
@@ -172,6 +172,31 @@ func tokenizeQuery(query string) []string {
 
 // scoreResult computes a 0-100 relevance score based on query term overlap
 // with the title (weight 3x) and snippet (weight 1x).
+// containsTermAtBoundary reports whether term appears in hay delimited by
+// non-alphanumerics on both sides (substring hits inside longer words do
+// not count).
+func containsTermAtBoundary(hay, term string) bool {
+	if term == "" {
+		return false
+	}
+	for i := 0; i+len(term) <= len(hay); i++ {
+		if hay[i:i+len(term)] != term {
+			continue
+		}
+		beforeOK := i == 0 || !isAlphaNumByte(hay[i-1])
+		after := i + len(term)
+		afterOK := after == len(hay) || !isAlphaNumByte(hay[after])
+		if beforeOK && afterOK {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlphaNumByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
 func scoreResult(queryTerms []string, res searchResult) int {
 	if len(queryTerms) == 0 {
 		return 50 // neutral score when no query terms
@@ -182,10 +207,15 @@ func scoreResult(queryTerms []string, res searchResult) int {
 
 	var titleHits, snippetHits int
 	for _, term := range queryTerms {
-		if strings.Contains(titleLower, term) {
+		// #1710 case 3: bare Contains hit substrings - 'go' matched
+		// google/golang, 'api' matched rapid - systematically inflating
+		// pages that merely CONTAIN the query inside bigger words. The
+		// ambiguity side got word boundaries (#381/#1438); the scoring
+		// side never did.
+		if containsTermAtBoundary(titleLower, term) {
 			titleHits++
 		}
-		if strings.Contains(snippetLower, term) {
+		if containsTermAtBoundary(snippetLower, term) {
 			snippetHits++
 		}
 	}


### PR DESCRIPTION
Case 2 (Low-Med, #1521 residue): the bare `oldest` entry survived next to the two phrase forms #1521 removed, and the Chinese side (`最近的`) was never touched - same-family missed-sync, seventh instance.

Case 3 (Med-Low): `scoreResult` used bare Contains - `go` matched google/golang, `api` matched rapid, systematically inflating pages that merely contain the query inside bigger words. The ambiguity side got word boundaries (#381/#1438); the scoring side never did.

(Case 1 - exit_worktree's unpushed-commit gate - and the Low items stay for follow-up.)

Isolated worktree (fresh origin/main): Ambiguity+SearchQuality families PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)