### PR TITLE
fix(im,agentruntime,desktop): multi-pending text replies need an index (#1657)

### DIFF
--- a/desktop/ggcode-desktop-wails/app.go
+++ b/desktop/ggcode-desktop-wails/app.go
@@ -2131,6 +2131,12 @@ func (a *App) startIMAdapters() {
 			})
 			return nil
 		},
+		PendingApprovals: func() []string {
+			if a == nil || a.chat == nil {
+				return nil
+			}
+			return chat.PendingApprovalIDs()
+		},
 		CurrentApproval: func() (string, string, bool) {
 			if a == nil || a.chat == nil {
 				return "", "", false

--- a/desktop/wailskit/chat.go
+++ b/desktop/wailskit/chat.go
@@ -3050,6 +3050,18 @@ func (b *ChatBridge) RespondApproval(requestID, decision string) {
 
 }
 
+// PendingApprovalIDs returns the pending approval request IDs in
+// registration order (#1657 case 2) - the text bridge uses this to detect
+// ambiguous bare "y" replies when several approvals are pending.
+func (b *ChatBridge) PendingApprovalIDs() []string {
+	reqs := b.interactions.PendingApprovals()
+	ids := make([]string, 0, len(reqs))
+	for _, r := range reqs {
+		ids = append(ids, r.ID)
+	}
+	return ids
+}
+
 func (b *ChatBridge) PendingApprovalRequest() (string, string, bool) {
 	req, ok := b.interactions.FirstPendingApproval()
 	if !ok {

--- a/internal/agentruntime/interactions.go
+++ b/internal/agentruntime/interactions.go
@@ -2,6 +2,7 @@ package agentruntime
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	"github.com/topcheer/ggcode/internal/permission"
@@ -125,6 +126,24 @@ func (b *InteractionBroker) PendingAskUser(id string) (AskUserRequest, bool) {
 		return AskUserRequest{}, false
 	}
 	return waiter.request, true
+}
+
+// PendingApprovals returns all pending approval requests in registration
+// order (#1657 case 2): text-path callers need to know when a bare "y" is
+// ambiguous (2+ pending) and to offer index-based disambiguation.
+func (b *InteractionBroker) PendingApprovals() []ApprovalRequest {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	waiters := make([]approvalWaiter, 0, len(b.approvals))
+	for _, w := range b.approvals {
+		waiters = append(waiters, w)
+	}
+	sort.Slice(waiters, func(i, j int) bool { return waiters[i].seq < waiters[j].seq })
+	reqs := make([]ApprovalRequest, 0, len(waiters))
+	for _, w := range waiters {
+		reqs = append(reqs, w.request)
+	}
+	return reqs
 }
 
 func (b *InteractionBroker) FirstPendingApproval() (ApprovalRequest, bool) {

--- a/internal/im/interactive_text_bridge.go
+++ b/internal/im/interactive_text_bridge.go
@@ -3,16 +3,41 @@ package im
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	toolpkg "github.com/topcheer/ggcode/internal/tool"
 )
 
 type InteractiveTextBridge struct {
-	Submit          func(context.Context, string, string) error // (ctx, text, adapterName)
-	CurrentApproval func() (requestID, toolName string, ok bool)
-	ResolveApproval func(requestID, decision string)
-	CurrentAskUser  func() (requestID string, req toolpkg.AskUserRequest, ok bool)
-	ResolveAskUser  func(requestID string, response toolpkg.AskUserResponse)
+	Submit func(context.Context, string, string) error // (ctx, text, adapterName)
+	// PendingApprovals returns the pending approval request IDs in
+	// registration order (#1657 case 2). Optional: when wired and more than
+	// one approval is pending, a bare "y"/"a"/"n" is ambiguous and is NOT
+	// resolved blindly - the reply must carry the target's 1-based index
+	// (e.g. "y 2"); otherwise the text falls through to Submit so the user
+	// and the agent both see it instead of a random approval being decided.
+	PendingApprovals func() []string
+	CurrentApproval  func() (requestID, toolName string, ok bool)
+	ResolveApproval  func(requestID, decision string)
+	CurrentAskUser   func() (requestID string, req toolpkg.AskUserRequest, ok bool)
+	ResolveAskUser   func(requestID string, response toolpkg.AskUserResponse)
+}
+
+// approvalIndexFromText extracts a 1-based approval index from a reply like
+// "y 2", "2 y", or "n 1" (n pending). Returns ok=false when absent or out of
+// range.
+func approvalIndexFromText(text string, n int) (int, bool) {
+	if n <= 1 {
+		return 0, false
+	}
+	for _, tok := range strings.Fields(text) {
+		v, err := strconv.Atoi(tok)
+		if err == nil && v >= 1 && v <= n && strconv.Itoa(v) == tok {
+			return v, true
+		}
+	}
+	return 0, false
 }
 
 func (b *InteractiveTextBridge) SubmitInboundMessage(ctx context.Context, msg InboundMessage) error {
@@ -31,6 +56,21 @@ func (b *InteractiveTextBridge) SubmitInboundMessage(ctx context.Context, msg In
 					decision = "always_allow"
 				} else if route.Decision.String() == "allow" {
 					decision = "allow"
+				}
+				// #1657 case 2: with 2+ pending approvals a bare "y" is
+				// ambiguous - resolving it hit whichever the selector picked
+				// (possibly the dangerous one). Only resolve when the reply
+				// carries the target's index; otherwise fall through to
+				// Submit so the ambiguity is VISIBLE instead of decided
+				// blind. Single pending stays one-tap.
+				if b.PendingApprovals != nil {
+					if ids := b.PendingApprovals(); len(ids) > 1 {
+						if idx, ok := approvalIndexFromText(text, len(ids)); ok {
+							b.ResolveApproval(ids[idx-1], decision)
+							return nil
+						}
+						return b.Submit(ctx, text, msg.Envelope.Adapter)
+					}
 				}
 				b.ResolveApproval(requestID, decision)
 				return nil

--- a/internal/im/interactive_text_bridge_1657_test.go
+++ b/internal/im/interactive_text_bridge_1657_test.go
@@ -1,0 +1,96 @@
+package im
+
+import (
+	"context"
+	"testing"
+)
+
+// #1657 case 2: disambiguation index extraction for multi-pending replies.
+func Test1657ApprovalIndexFromText(t *testing.T) {
+	if idx, ok := approvalIndexFromText("y 2", 3); !ok || idx != 2 {
+		t.Fatalf(`"y 2" -> (%d,%v), want (2,true)`, idx, ok)
+	}
+	if idx, ok := approvalIndexFromText("2 y", 3); !ok || idx != 2 {
+		t.Fatalf(`"2 y" -> (%d,%v), want (2,true)`, idx, ok)
+	}
+	if idx, ok := approvalIndexFromText("n 1", 2); !ok || idx != 1 {
+		t.Fatalf(`"n 1" -> (%d,%v), want (1,true)`, idx, ok)
+	}
+	// Bare decision with no index: not extractable.
+	if _, ok := approvalIndexFromText("y", 3); ok {
+		t.Fatal(`"y" with 3 pending must NOT carry an index`)
+	}
+	// Out of range / non-integer tokens are not indexes.
+	if _, ok := approvalIndexFromText("y 9", 3); ok {
+		t.Fatal(`"y 9" out of range must not match`)
+	}
+	if _, ok := approvalIndexFromText("y 02", 3); ok {
+		t.Fatal(`leading-zero token must not match (strconv round-trip guard)`)
+	}
+	// Single pending: no disambiguation needed.
+	if _, ok := approvalIndexFromText("y 1", 1); ok {
+		t.Fatal("n<=1 must never consume an index")
+	}
+}
+
+// #1657 case 2: with 2+ pending, a bare decision must fall through to
+// Submit (visible) instead of resolving a blind target; an indexed reply
+// resolves exactly the indexed approval; single pending stays one-tap.
+func Test1657MultiPendingDisambiguation(t *testing.T) {
+	mkMsg := func(text string) InboundMessage {
+		return InboundMessage{Envelope: Envelope{Adapter: "qq"}, Text: text}
+	}
+
+	// Bare "y", two pending: falls through to Submit, nothing resolved.
+	submitted := ""
+	b := &InteractiveTextBridge{
+		Submit: func(_ context.Context, text, _ string) error {
+			submitted = text
+			return nil
+		},
+		PendingApprovals: func() []string { return []string{"id-1", "id-2"} },
+		CurrentApproval:  func() (string, string, bool) { return "id-1", "run_command", true },
+		ResolveApproval: func(requestID, decision string) {
+			t.Fatalf("bare y with 2 pending must not resolve, resolved %s=%s", requestID, decision)
+		},
+	}
+	if err := b.SubmitInboundMessage(nil, mkMsg("y")); err != nil {
+		t.Fatal(err)
+	}
+	if submitted != "y" {
+		t.Fatalf("bare y must fall through to Submit, got %q", submitted)
+	}
+
+	// "y 2", two pending: resolves exactly id-2 with allow.
+	resolved := ""
+	b2 := &InteractiveTextBridge{
+		Submit: func(context.Context, string, string) error {
+			t.Fatal("indexed reply must not fall through")
+			return nil
+		},
+		PendingApprovals: func() []string { return []string{"id-1", "id-2"} },
+		CurrentApproval:  func() (string, string, bool) { return "id-1", "run_command", true },
+		ResolveApproval:  func(requestID, decision string) { resolved = requestID + ":" + decision },
+	}
+	if err := b2.SubmitInboundMessage(nil, mkMsg("y 2")); err != nil {
+		t.Fatal(err)
+	}
+	if resolved != "id-2:allow" {
+		t.Fatalf(`"y 2" must resolve id-2:allow, got %q`, resolved)
+	}
+
+	// Single pending: bare "y" stays one-tap (resolves directly).
+	resolved = ""
+	b3 := &InteractiveTextBridge{
+		Submit:           func(context.Context, string, string) error { return nil },
+		PendingApprovals: func() []string { return []string{"only"} },
+		CurrentApproval:  func() (string, string, bool) { return "only", "run_command", true },
+		ResolveApproval:  func(requestID, decision string) { resolved = requestID + ":" + decision },
+	}
+	if err := b3.SubmitInboundMessage(nil, mkMsg("y")); err != nil {
+		t.Fatal(err)
+	}
+	if resolved != "only:allow" {
+		t.Fatalf("single pending bare y must resolve, got %q", resolved)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1657 (case 1-(2); case 1-(1) deterministic FirstPending\* already landed by 51ef5cd8 — verified, not re-fixed).

Multi-pending text replies now require correlation: the bridge wires an optional PendingApprovals selector (broker seq-ordered list; desktop ChatBridge.PendingApprovalIDs). With 2+ pending approvals a bare "y"/"a"/"n" is no longer resolved blindly — it must carry the target's 1-based index ("y 2"); without one it falls through to Submit so the ambiguity is visible to user and agent. Single-pending behavior unchanged; unwired embedders unchanged. Sweep items B/C were adjudicated Low/self-healing in the issue.

## Verification evidence (review)
Isolated worktree: im **95.4s** + agentruntime **13.1s** + wailskit **11.1s** PASS (p=1); desktop app module builds under goolm tag (embed placeholder for dist only). Pins: index extraction (in-range/round-trip/no-bare) + three-scenario bridge behavior.

Closes #1657

Generated with [ggcode](https://github.com/topcheer/ggcode)
