### PR TITLE
fix(tui): diff file headers not colored as add/remove; mentions need boundary (#1718 cases 1+2)

### DIFF
--- a/internal/tui/completion.go
+++ b/internal/tui/completion.go
@@ -25,6 +25,10 @@ type Mention struct {
 
 // ParseMentions extracts @path references from user input.
 // Returns the cleaned message (with @path removed) and list of mentions.
+func isSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
 func ParseMentions(input string, workDir string) (string, []Mention, error) {
 	// #1425-A: canonicalize workDir for CONTAINMENT CHECKS only - if the
 	// caller-supplied workdir contains symlink components (macOS
@@ -47,6 +51,16 @@ func ParseMentions(input string, workDir string) (string, []Mention, error) {
 		idx := strings.Index(cleaned[searchFrom:], mentionPrefix)
 		if idx < 0 {
 			break
+		}
+		// #1718 case 2: DetectMention requires the @ to start the text or
+		// follow whitespace - ParseMentions accepted ANY position, so
+		// foo@bar.com's mid-token @ became a mention (workDir coincidence
+		// made Stat pass, the email got silently rewritten and the file
+		// content injected). Same guard, both sides.
+		abs := searchFrom + idx
+		if abs > 0 && !isSpaceByte(cleaned[abs-1]) {
+			searchFrom = abs + 1
+			continue
 		}
 		idx += searchFrom
 

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -29,14 +29,12 @@ func FormatDiff(diff string) string {
 			sb.WriteString(diffHeaderStyle.Render(line))
 			sb.WriteString("\n")
 			hasDiff = true
-		} else if strings.HasPrefix(line, "+") {
+		} else if hasDiff && strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
 			sb.WriteString(diffAddStyle.Render(line))
 			sb.WriteString("\n")
-			hasDiff = true
-		} else if strings.HasPrefix(line, "-") {
+		} else if hasDiff && strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "---") {
 			sb.WriteString(diffRemoveStyle.Render(line))
 			sb.WriteString("\n")
-			hasDiff = true
 		} else if hasDiff {
 			sb.WriteString(diffContextStyle.Render(line))
 			sb.WriteString("\n")


### PR DESCRIPTION
Case 1 (Low-Med): before the first @@, `hasDiff` is false but the +/- branches never checked it - `+++ b/x` rendered GREEN and `--- a/x` RED as content lines (`/diff` feeds raw git output, so every file header gained a fake add/remove pair).

Case 2 (Low): ParseMentions accepted an `@` at ANY position while DetectMention requires start-or-whitespace - `foo@bar.com`'s mid-token @ became a mention (a workDir coincidence made Stat pass, silently rewriting the email and injecting file content). Same guard on both sides.

(The config_mutation fail-nil rejection stands - all 33 producers set fail; the advisory items stay unfiled.)

Isolated worktree (fresh origin/main): tui package full PASS (12.4s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)