### PR TITLE
fix(agent): causal attribution skips succeeded read-only commands (#1528 case C)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3875,7 +3875,11 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// on the most common background-test failure path.
 			if tc.Name == "run_command" || tc.Name == "bash" || tc.Name == "powershell" || tc.Name == "start_command" || tc.Name == "wait_command" || tc.Name == "read_command_output" {
 				if result.IsError || looksLikeFailure(result.Content) {
-					if causalHint := a.causalAttribution.attributeFailure(result.Content); causalHint != "" {
+					// #1528 case C: pass the command text and exit status - a
+					// succeeded grep/cat of logs carrying "FAIL" must not be
+					// attributed as a build failure (shell bypasses the
+					// layer-1 tool-name filter).
+					if causalHint := a.causalAttribution.attributeFailureCmd(result.Content, extractStringField(tc.Arguments, "command"), result.IsError); causalHint != "" {
 						a.appendGuidance(&result, causalHint)
 					}
 				}

--- a/internal/agent/causal_attribution.go
+++ b/internal/agent/causal_attribution.go
@@ -226,6 +226,44 @@ func computeCRSDetail(edit causalEditStep, errorFiles []string, recencyRank int)
 	return score, fileMatch
 }
 
+// readCmdPrefixes lists read-only listing tools whose OUTPUT mimics
+// failure evidence (#1528 case C): run_command("grep -rn FAIL ./...")
+// exits 0, yet its output carries the literal FAIL plus path.go:line:
+// lines - character-for-character causalErrorFileRe's shape - so every
+// content gate passed and an innocent recent edit got blamed. Layer 1
+// (the tool-name filter at the call site) cannot see through the shell.
+var readCmdPrefixes = []string{"grep", "rg", "cat ", "head", "tail", "awk", "sed -n", "find ", "less", "bat "}
+
+// looksLikeReadCommand reports whether the command text begins with a
+// read-only listing tool.
+func looksLikeReadCommand(cmd string) bool {
+	c := strings.TrimSpace(cmd)
+	for _, p := range readCmdPrefixes {
+		if strings.HasPrefix(c, p) || strings.HasPrefix(c, "./"+p) {
+			return true
+		}
+	}
+	// Common compound prefixes: cd dir && grep ...
+	if i := strings.LastIndex(c, "&&"); i >= 0 {
+		return looksLikeReadCommand(c[i+2:])
+	}
+	if i := strings.LastIndex(c, "|"); i >= 0 {
+		return looksLikeReadCommand(c[i+1:])
+	}
+	return false
+}
+
+// attributeFailureCmd is the call-site entry that knows the command text
+// and exit status (#1528 case C): a SUCCEEDED read-only command whose
+// output merely contains "FAIL" (grep/cat of logs or sources) must not
+// be attributed as a build/test failure.
+func (s *causalAttributionState) attributeFailureCmd(output, cmd string, errored bool) string {
+	if !errored && looksLikeReadCommand(cmd) {
+		return ""
+	}
+	return s.attributeFailure(output)
+}
+
 // attributeFailure traces backward from a failure to identify the most
 // likely causal edit step(s). Returns formatted guidance or "".
 func (s *causalAttributionState) attributeFailure(output string) string {

--- a/internal/agent/causal_attribution_1528_test.go
+++ b/internal/agent/causal_attribution_1528_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import "testing"
+
+// #1528 case C: a SUCCEEDED read-only command whose output merely
+// contains "FAIL" (grep/cat of logs) must not be attributed as a
+// build/test failure - the shell bypassed the layer-1 tool-name filter.
+func Test1528ReadCommandBypassGuard(t *testing.T) {
+	if !looksLikeReadCommand("grep -rn FAIL ./...") {
+		t.Fatal("plain grep must be recognized")
+	}
+	if !looksLikeReadCommand("cat ci.log") {
+		t.Fatal("cat must be recognized")
+	}
+	if !looksLikeReadCommand("cd /tmp && grep FAIL x") {
+		t.Fatal("compound (&&) must look through to the final read")
+	}
+	if !looksLikeReadCommand("go test ./... | grep FAIL") {
+		t.Fatal("pipeline tail read must be recognized")
+	}
+	if looksLikeReadCommand("go build ./...") {
+		t.Fatal("build command must NOT be classified as read-only")
+	}
+	if looksLikeReadCommand("npm test") {
+		t.Fatal("test command must NOT be classified as read-only")
+	}
+
+	// Command-level: succeeded grep -> no attribution regardless of output.
+	s := newCausalAttributionState()
+	s.recordEdit("edit_file", "pkg/a.go", 1)
+	output := "--- FAIL: TestX\npkg/a.go:12: boom\nFAIL\n"
+	if got := s.attributeFailureCmd(output, "grep -rn FAIL ./...", false); got != "" {
+		t.Fatalf("succeeded grep must not attribute, got %q", got)
+	}
+	// Errored command still attributes (exit failure = real signal).
+	s2 := newCausalAttributionState()
+	s2.recordEdit("edit_file", "pkg/a.go", 1)
+	if got := s2.attributeFailureCmd(output, "go test ./...", true); got == "" {
+		t.Fatal("errored real test command with file evidence must attribute")
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1528 (case C; cases A/B landed by 6e964c57 — verified by direct read, not re-fixed; that commit explicitly deferred case C).

A succeeded read-only command (`grep -rn FAIL ./...`, `cat ci.log`) exits 0 but its output carries the literal FAIL plus path.go:line: lines — every content gate passed and an innocent recent edit got blamed. The shell bypasses the layer-1 tool-name filter. `attributeFailureCmd` now takes the command text + exit status at the single call site: succeeded read-only prefixes (grep/rg/cat/head/tail/awk/sed -n/find/less/bat, `&&`/`|` tails looked through) stay silent; errored commands and non-read commands unchanged.

## Verification evidence (review)
Isolated worktree: causal/attribution test subset PASS (p=1). Pin: prefix classification (plain/compound/pipeline/negative) + command-level pair (succeeded grep silent, errored real test attributes).

Closes #1528

Generated with [ggcode](https://github.com/topcheer/ggcode)
