### PR TITLE
fix(cron): tombstone-first migration; one-shot drops logged (#1531)

### DIFF
--- a/internal/cron/migration.go
+++ b/internal/cron/migration.go
@@ -14,9 +14,15 @@ import (
 // --- Legacy types for migration from workspace-scoped to session-scoped ---
 
 // workspaceBucket groups jobs under a workspace key (old format).
+// MigratedTo is the #1531 crash-window tombstone: set to the target
+// session-store path BEFORE the new store is written, so an instance that
+// crashes between the two writes leaves a durable marker instead of letting
+// the next session re-migrate (double fire). Absent in pre-#1531 stores
+// (zero value "" = not migrated).
 type workspaceBucket struct {
-	Workspace string    `json:"workspace"`
-	Jobs      []jobJSON `json:"jobs"`
+	Workspace  string    `json:"workspace"`
+	Jobs       []jobJSON `json:"jobs"`
+	MigratedTo string    `json:"migrated_to,omitempty"`
 }
 
 // oldStoreFile is the old top-level structure keyed by SHA256(workspace dir).
@@ -87,9 +93,40 @@ func MigrateWorkspaceJobs(oldStorePath, newSessionPath, workspaceDir string) {
 	// a failed write leaves the old store untouched and a later start can
 	// retry, instead of losing the jobs forever.
 	var migrated []jobJSON
+	oneShotDropped := 0 // #1531 case C: one-shots are intentionally not migrated
 	for _, j := range bucket.Jobs {
 		if j.Recurring {
 			migrated = append(migrated, j)
+		} else {
+			oneShotDropped++
+		}
+	}
+	if oneShotDropped > 0 {
+		debug.Log("cron", "MigrateWorkspaceJobs: dropping %d one-shot job(s) from workspace %s (one-shots are not migrated; they fire once and are gone)", oneShotDropped, workspaceDir)
+	}
+
+	// #1531 case B: the new-store write and the old-store removal were two
+	// separate atomic writes with a crash window between them - a kill in
+	// that gap left the bucket in place, so the NEXT session (different
+	// store path, Stat no-op) re-migrated the same recurring jobs and both
+	// sessions scheduled them (double fire). Tombstone-first closes it:
+	// stamp the bucket with the migration target BEFORE writing the new
+	// store. A later instance seeing a tombstone skips when the target
+	// store exists (jobs durably migrated) and re-migrates only when the
+	// target vanished (crashed before the new-store write landed).
+	if bucket.MigratedTo != "" {
+		if _, err := os.Stat(bucket.MigratedTo); err == nil {
+			debug.Log("cron", "MigrateWorkspaceJobs: workspace %s already migrated to %s by a previous instance; skipping", workspaceDir, bucket.MigratedTo)
+			return
+		}
+		// Tombstone points at a store that never landed (crash between the
+		// two writes). Fall through and migrate into THIS session instead.
+	}
+	bucket.MigratedTo = newSessionPath
+	sf[wsKey] = bucket
+	if out, err := json.MarshalIndent(sf, "", "  "); err == nil {
+		if err := util.AtomicWriteFile(oldStorePath, out, 0644); err != nil {
+			debug.Log("cron", "MigrateWorkspaceJobs: failed to write tombstone: %v (proceeding; the crash window stays open this once)", err)
 		}
 	}
 	if len(migrated) > 0 {

--- a/internal/cron/migration_1531_test.go
+++ b/internal/cron/migration_1531_test.go
@@ -1,0 +1,83 @@
+package cron
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #1531 case B: a tombstone stamped BEFORE the new-store write closes the
+// crash window between the two atomic writes - the next instance must skip
+// when the tombstone target exists, and re-migrate only when it vanished.
+func Test1531TombstoneSkipsWhenTargetExists(t *testing.T) {
+	dir := t.TempDir()
+	oldStore := filepath.Join(dir, "old.json")
+	target := filepath.Join(dir, "sessions", "s1.json")
+	ws := t.TempDir()
+
+	// Old store with the tombstone already pointing at a landed target.
+	writeOldStore(t, oldStore, ws, target)
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(`{"jobs":[]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	MigrateWorkspaceJobs(oldStore, filepath.Join(dir, "sessions", "s2.json"), ws)
+
+	// The bucket must remain untouched (skip, not delete) and the new
+	// session store must NOT have been created.
+	data, err := os.ReadFile(oldStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == "" {
+		t.Fatal("old store vanished on skip")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sessions", "s2.json")); err == nil {
+		t.Fatal("skip must not write a second session store (double fire)")
+	}
+}
+
+// #1531 case B: tombstone whose target never landed (crash between the two
+// writes) must re-migrate into the CURRENT session exactly once.
+func Test1531TombstoneRetriesWhenTargetMissing(t *testing.T) {
+	dir := t.TempDir()
+	oldStore := filepath.Join(dir, "old.json")
+	deadTarget := filepath.Join(dir, "gone.json")
+	ws := t.TempDir()
+
+	writeOldStore(t, oldStore, ws, deadTarget) // target file does not exist
+
+	MigrateWorkspaceJobs(oldStore, filepath.Join(dir, "s2.json"), ws)
+
+	// Re-migrated: the bucket leaves the old store. With no other buckets
+	// left the whole file is removed (len(sf)==0 path).
+	data, err := os.ReadFile(oldStore)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if len(data) != 0 && string(data) != "{}" {
+		t.Fatalf("bucket must be removed after successful re-migration, got %s", data)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "s2.json")); err != nil {
+		t.Fatal("re-migration must land the new session store")
+	}
+}
+
+func writeOldStore(t *testing.T, path, ws, migratedTo string) {
+	t.Helper()
+	bucket := workspaceBucket{Workspace: ws, Jobs: []jobJSON{
+		{ID: "j1", CronExpr: "0 * * * *", Prompt: "hi", Recurring: true},
+	}, MigratedTo: migratedTo}
+	sf := oldStoreFile{workspaceKey(ws): bucket}
+	out, err := json.MarshalIndent(sf, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, out, 0644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1531 (cases B/C; case A landed by 0dcf0bd9 and case D by #683's PricingUnknown — verified by direct read, not re-fixed).

1. **Case B (Low)**: tombstone-first migration — the bucket is stamped with the target session-store path BEFORE the new store is written. A later instance skips when the target exists (no double fire), re-migrates into its own session only when the target vanished (crash between writes). Tombstone-write failure degrades to today's behavior.
2. **Case C (Low)**: one-shot drops during migration now log a count instead of vanishing silently.

## Verification evidence (review)
Isolated worktree: cron **1.1s** + cmd **5.2s** + cost **0.5s** PASS (p=1). Pins: skip-when-target-exists (no second store written) and retry-when-target-missing (bucket removed, new store lands). The retry pin's first draft assumed the empty old store persisted as `{}` — actual code removes the file; assertion corrected to accept either.

Closes #1531

Generated with [ggcode](https://github.com/topcheer/ggcode)
