### PR TITLE
fix(agent): normalized strategy signatures; stagnation threshold 3 (#1498 cases C/D)

### DIFF
--- a/internal/agent/strategy_1498_test.go
+++ b/internal/agent/strategy_1498_test.go
@@ -1,0 +1,59 @@
+package agent
+
+import "testing"
+
+// #1498 case C: strategy signatures must be order-insensitive and drop
+// read-only observation tools - {read,run} and {run,read} are ONE strategy,
+// and pure read noise must not fabricate distinct strategies.
+func Test1498StrategySignatureNormalized(t *testing.T) {
+	a := seStrategySignature([]string{"read_file", "run_command"})
+	b := seStrategySignature([]string{"run_command", "read_file"})
+	if a != b {
+		t.Fatal("order-insensitivity violated: {read,run} vs {run,read} must be one strategy")
+	}
+	if a != seStrategySignature([]string{"run_command"}) {
+		t.Fatal("read-only tools must be dropped from the signature")
+	}
+	// Duplicates collapse (a set, not a multiset).
+	if seStrategySignature([]string{"edit_file", "edit_file"}) != seStrategySignature([]string{"edit_file"}) {
+		t.Fatal("duplicate recovery tools must collapse")
+	}
+	// All-read between errors is not a strategy at all (matches empty sig).
+	if seStrategySignature([]string{"read_file", "grep", "glob"}) != seStrategySignature(nil) {
+		t.Fatal("pure observation must equal the empty (no-strategy) signature")
+	}
+	// Genuinely different recovery sets stay distinct.
+	if seStrategySignature([]string{"edit_file"}) == seStrategySignature([]string{"run_command"}) {
+		t.Fatal("different recovery tools must remain distinct strategies")
+	}
+}
+
+// #1498 case D: stagnation fires on the THIRD consecutive same-tool+target
+// failure, not the second (a verbatim transient retry is endorsed recovery,
+// not a rut).
+func Test1498StagnationThresholdThree(t *testing.T) {
+	if stagnationFailureThreshold != 3 {
+		t.Fatalf("threshold must be 3, got %d", stagnationFailureThreshold)
+	}
+	s := newStrategyStagnationState()
+	tool, target := "run_command", "go get example.com/pkg"
+	// First failure: no fire.
+	if s.recordAttempt(tool, target, false) {
+		t.Fatal("first failure must not fire")
+	}
+	// Second (verbatim retry, transient-recovery-endorsed): no fire.
+	if s.recordAttempt(tool, target, false) {
+		t.Fatal("second failure must not fire (verbatim transient retry)")
+	}
+	// Third identical failure: fire.
+	if !s.recordAttempt(tool, target, false) {
+		t.Fatal("third consecutive identical failure must fire")
+	}
+	// A success resets the streak.
+	s2 := newStrategyStagnationState()
+	s2.recordAttempt(tool, target, false)
+	s2.recordAttempt(tool, target, false)
+	if s2.recordAttempt(tool, target, true) {
+		t.Fatal("success must reset the streak")
+	}
+}

--- a/internal/agent/strategy_exhaustion.go
+++ b/internal/agent/strategy_exhaustion.go
@@ -52,6 +52,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -165,7 +166,7 @@ func (s *seStrategyExhaustionState) recordToolCall(toolName string, isError bool
 	// between the previous and current occurrence.
 	if cl.fingerprintsSeen > 0 && len(cl.toolsSinceLastError) > 0 {
 		sig := seStrategySignature(cl.toolsSinceLastError)
-		if !cl.strategySignatures[sig] {
+		if sig != seStrategySignature(nil) && !cl.strategySignatures[sig] {
 			cl.strategySignatures[sig] = true
 			debug.Log("agent", "strategy exhaustion: new distinct strategy #%d for error %s",
 				len(cl.strategySignatures), fp[:seMin(16, len(fp))])
@@ -220,11 +221,40 @@ func seFingerprintError(content string) string {
 	return hex.EncodeToString(h[:8])
 }
 
-// seStrategySignature computes a hash of the recovery tool-name sequence
-// to identify distinct strategies. Two sequences with the same set of tools
-// in the same order are considered the same strategy.
+// seRecoveryIrrelevantTools lists tools whose appearance between two
+// occurrences of an error carries no recovery information (#1498 case C):
+// reads/observations are context gathering, not strategy. Counting them
+// made {read}{run}{read,run}{run,read} four "distinct strategies" out of
+// pure noise - order-sensitivity alone could satisfy the 4-signature gate.
+var seRecoveryIrrelevantTools = map[string]bool{
+	"read_file": true, "grep": true, "glob": true, "search_files": true,
+	"list_directory": true, "code_search": true, "lsp_hover": true,
+	"lsp_symbols": true, "lsp_definition": true, "lsp_references": true,
+	"lsp_diagnostics": true, "web_search": true,
+}
+
+// seStrategySignature computes a hash of the recovery tool SET to identify
+// distinct strategies. Two recovery attempts using the same set of
+// MUTATION/recovery tools are the same strategy regardless of order
+// (#1498 case C: the old order-sensitive Join let {read,run} and {run,read}
+// count as two strategies - pure ordering noise inflated the "distinct
+// strategies" count toward the exhaustion gate). Read-only observation
+// tools are dropped before signing: they are context gathering, not a
+// strategy change.
 func seStrategySignature(tools []string) string {
-	joined := strings.Join(tools, "|")
+	set := make(map[string]bool, len(tools))
+	for _, t := range tools {
+		if seRecoveryIrrelevantTools[t] {
+			continue
+		}
+		set[t] = true
+	}
+	names := make([]string, 0, len(set))
+	for t := range set {
+		names = append(names, t)
+	}
+	sort.Strings(names)
+	joined := strings.Join(names, "|")
 	h := sha256.Sum256([]byte(joined))
 	return hex.EncodeToString(h[:8])
 }

--- a/internal/agent/strategy_exhaustion_test.go
+++ b/internal/agent/strategy_exhaustion_test.go
@@ -193,16 +193,19 @@ func TestStrategyExhaustion_StrategySignature(t *testing.T) {
 		t.Fatal("identical sequences should have same signature")
 	}
 
-	// Different order = different signature.
+	// #1498 case C: different ORDER = same signature (order-sensitivity let
+	// pure noise fabricate distinct strategies); different TOOL SET =
+	// different signature. grep is a read-only observation tool and is
+	// dropped from signatures entirely.
 	sig3 := seStrategySignature([]string{"run_command", "edit_file"})
-	if sig1 == sig3 {
-		t.Fatal("different order should have different signature")
+	if sig1 != sig3 {
+		t.Fatal("different order of the same recovery set must have same signature")
 	}
 
-	// Different tools = different signature.
-	sig4 := seStrategySignature([]string{"grep", "run_command"})
+	// Different recovery tools = different signature.
+	sig4 := seStrategySignature([]string{"edit_file", "write_file"})
 	if sig1 == sig4 {
-		t.Fatal("different tools should have different signature")
+		t.Fatal("different recovery tool sets should have different signature")
 	}
 }
 

--- a/internal/agent/strategy_stagnation.go
+++ b/internal/agent/strategy_stagnation.go
@@ -48,8 +48,12 @@ const (
 	stagnationHistorySize = 8
 
 	// stagnationFailureThreshold: consecutive same-tool+target failures
+	// (#1498 case D: was 2 - a single transient failure retried verbatim,
+	// the exact recovery transient_retry endorses, got branded "local
+	// minimum / STOP retrying / waste of tokens" on its SECOND failure.
+	// Three consecutive failures with no approach change is a real rut.)
 	// needed to trigger a warning.
-	stagnationFailureThreshold = 2
+	stagnationFailureThreshold = 3
 
 	// stagnationMaxWarnings: max warnings per run.
 	stagnationMaxWarnings = 2

--- a/internal/agent/strategy_stagnation_test.go
+++ b/internal/agent/strategy_stagnation_test.go
@@ -14,9 +14,16 @@ func TestStrategyStagnation_BasicFailure(t *testing.T) {
 		t.Fatal("first failure should not trigger")
 	}
 
-	// Second consecutive failure - should trigger
+	// Second consecutive failure - should not trigger either
+	// (#1498 case D: a verbatim transient retry is endorsed recovery, not a
+	// rut; threshold raised from 2 to 3)
+	if s.recordAttempt("edit_file", args, false) {
+		t.Fatal("second consecutive failure should not trigger")
+	}
+
+	// Third consecutive failure - should trigger
 	if !s.recordAttempt("edit_file", args, false) {
-		t.Fatal("second consecutive failure should trigger")
+		t.Fatal("third consecutive failure should trigger")
 	}
 }
 
@@ -57,15 +64,17 @@ func TestStrategyStagnation_MaxWarnings(t *testing.T) {
 	args := `{"file_path":"/tmp/test.go"}`
 
 	s.recordAttempt("edit_file", args, false)
+	s.recordAttempt("edit_file", args, false)
 	if !s.recordAttempt("edit_file", args, false) {
-		t.Fatal("should trigger first warning")
+		t.Fatal("should trigger first warning on the third failure")
 	}
 
 	s.recordAttempt("edit_file", args, true) // reset
 
 	s.recordAttempt("edit_file", args, false)
+	s.recordAttempt("edit_file", args, false)
 	if !s.recordAttempt("edit_file", args, false) {
-		t.Fatal("should trigger second warning")
+		t.Fatal("should trigger second warning on the third failure")
 	}
 
 	s.recordAttempt("edit_file", args, true) // reset


### PR DESCRIPTION
## Summary
Closes #1498 (cases C/D; cases A/B fixed in earlier rounds — %c out of the integer-verb list and errorLinesRe extended — verified by direct read, not re-fixed).

1. **Case C (Med-High)**: strategy signatures are now the sorted SET of recovery-relevant tools (read-only observation tools dropped; all-observation intervals count as no strategy) — ordering noise can no longer fabricate "distinct strategies" toward the exhaustion gate.
2. **Case D (Med)**: stagnation threshold 2→3 — a verbatim transient retry (endorsed recovery) is no longer branded a rut; also stops the back-to-back double-fire burning the warning budget.

Existing tests encoding the old semantics updated deliberately (order-sensitivity assertion inverted to pin the fix; threshold-2 firing moved to 3).

## Verification evidence (review)
Isolated worktree: strategy/stagnation/sql-injection/error-regression subset PASS (p=1), including the six untouched exhaustion tests. New pins: set collapse, observation dropping, empty-signature equality, 2-no/3-yes boundary, success reset.

Closes #1498

Generated with [ggcode](https://github.com/topcheer/ggcode)
