### PR TITLE
fix(tui): snapshot replay keeps whitespace separator chunks (#1808)

### DIFF
--- a/internal/tui/tunnel.go
+++ b/internal/tui/tunnel.go
@@ -1445,8 +1445,19 @@ func tunnelSnapshotAgentEvents(agentID, textID, color string, events []subagent.
 	for _, ev := range events {
 		switch ev.Type {
 		case subagent.AgentEventReasoning:
+			// #1808: guard the EMPTY string only and normalize for the
+			// sentinel - do NOT trim. Pure-whitespace separator chunks
+			// (" ") are deliberately preserved by the runner (its comment
+			// warns trimming glues words together); routing them through
+			// NormalizeReasoningChunk returned "" here, so snapshot replay
+			// rebuilt the text with words glued - the runner's defense
+			// silently regressed on the replay path.
 			if ev.Text != "" {
-				reasoningBuf.WriteString(tunnel.NormalizeReasoningChunk(ev.Text))
+				if trimmed := strings.TrimSpace(ev.Text); trimmed == tunnel.RedactedReasoningSentinel {
+					reasoningBuf.WriteString(tunnel.RedactedReasoningPlaceholder)
+				} else {
+					reasoningBuf.WriteString(ev.Text)
+				}
 			}
 		case subagent.AgentEventToolCall:
 			flushReasoning(true)

--- a/internal/tui/tunnel_1808_test.go
+++ b/internal/tui/tunnel_1808_test.go
@@ -1,0 +1,54 @@
+package tui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/topcheer/ggcode/internal/subagent"
+	"github.com/topcheer/ggcode/internal/tunnel"
+)
+
+func snapshotReasoningChunk(t *testing.T, texts ...string) string {
+	t.Helper()
+	events := make([]subagent.AgentEvent, 0, len(texts))
+	for _, txt := range texts {
+		events = append(events, subagent.AgentEvent{Type: subagent.AgentEventReasoning, Text: txt})
+	}
+	out := tunnelSnapshotAgentEvents("a1", "t1", "32", events, "", "", "completed", "", "")
+	for _, ev := range out {
+		if ev.Type == tunnel.EventSubagentReasoning {
+			var data tunnel.SubagentReasoningData
+			if err := json.Unmarshal(ev.Data, &data); err == nil {
+				return data.Chunk
+			}
+		}
+	}
+	return ""
+}
+
+// #1808: snapshot replay must preserve pure-whitespace separator chunks
+// (the runner keeps them deliberately - trimming glues words together);
+// routing them through NormalizeReasoningChunk returned "" and replay
+// rebuilt the text with words glued.
+func Test1808ReplayPreservesWhitespaceChunks(t *testing.T) {
+	got := snapshotReasoningChunk(t, "hello ", " ", "world")
+	if got != "hello  world" {
+		t.Fatalf("whitespace separator must survive replay, got %q", got)
+	}
+}
+
+// #1808: sentinel replacement still works on the replay path, including
+// whitespace-padded forms (exact-match leaked them in the runner's stream
+// path; the replay path must not regress either direction).
+func Test1808ReplayReplacesSentinel(t *testing.T) {
+	for _, pad := range []string{"", "\n", " "} {
+		got := snapshotReasoningChunk(t, "before ", tunnel.RedactedReasoningSentinel+pad, " after")
+		if strings.Contains(got, tunnel.RedactedReasoningSentinel) {
+			t.Fatalf("sentinel (pad=%q) must never reach display, got %q", pad, got)
+		}
+		if !strings.Contains(got, tunnel.RedactedReasoningPlaceholder) {
+			t.Fatalf("placeholder (pad=%q) must be substituted, got %q", pad, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1808.

Snapshot replay routed every reasoning chunk through `NormalizeReasoningChunk`, whose TrimSpace-based empty branch ate the pure-whitespace separator chunks the runner deliberately preserves (its comment warns trimming glues words together) — reconnects/mobile replays rebuilt the text with words glued. The aggregation now guards only the empty string and substitutes the sentinel inline with TrimSpace matching — which also catches whitespace-padded sentinel forms the runner's exact-match leaked (the issue's附带 semantic-split finding, fixed on this path).

## Verification evidence (review)
Isolated worktree: tui **10.8s PASS** (p=1). Pins: separator survival (`"hello "+" "+"world"` → `"hello  world"`) and sentinel substitution across `""`, `"\n"`, `" "` paddings. The runner's streaming path was already correct — this is replay-path-only.

Closes #1808

Generated with [ggcode](https://github.com/topcheer/ggcode)
