### PR TITLE
fix(agent): fingerprint sibling separation; failed edits not source changes (#1486 D/E)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3597,7 +3597,13 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// "12 tool calls", not "12 edits"); only failed mutation edits
 			// feed the per-file counts (handled inside recordToolCall).
 			a.solutionFixation.recordToolCall(tc.Name, string(tc.Arguments), result.IsError)
-			a.redundantReverify.recordEdit(tc.Name)
+			// #1486 case E: a FAILED edit_file/write_file changed nothing on
+			// disk - counting it as editsSince wrongly told the reverify
+			// detector "sources changed since your last verify" and
+			// suppressed a legitimate redundant-rerun warning.
+			if !result.IsError {
+				a.redundantReverify.recordEdit(tc.Name)
+			}
 			if fixationHint := a.solutionFixation.checkAndWarn(); fixationHint != "" {
 				debug.Log("agent", "Iteration %d: solution fixation detector triggered", i+1)
 				a.injectGuidance(fixationHint)

--- a/internal/agent/recurring_1486_test.go
+++ b/internal/agent/recurring_1486_test.go
@@ -1,0 +1,51 @@
+package agent
+
+import "testing"
+
+// #1486 case D: sibling packages must not collide into one fingerprint.
+func Test1486PathPrefixKeepsSiblingPackages(t *testing.T) {
+	a := stripPathToBasename("a/util.go:42")
+	b := stripPathToBasename("b/util.go:42")
+	if a == b {
+		t.Fatalf("a/util.go and b/util.go must fingerprint apart, got %q both", a)
+	}
+	if stripPathToBasename("./internal/agent/foo.go:1") != "internal/agent/foo.go:1" {
+		t.Fatalf("root-marker strip: %q", stripPathToBasename("./internal/agent/foo.go:1"))
+	}
+	// The same error in the same package spelled two ways still merges
+	// (the spelling tolerance the original pattern existed for).
+	if stripPathToBasename("./internal/agent/foo.go:1") != stripPathToBasename("internal/agent/foo.go:1") {
+		t.Fatal("same package with/without ./ must fingerprint equal")
+	}
+	// ../ forms strip too.
+	if stripPathToBasename("../pkg/x.go:3") != "pkg/x.go:3" {
+		t.Fatalf("../ strip: %q", stripPathToBasename("../pkg/x.go:3"))
+	}
+	// A bare basename with no directory passes through untouched.
+	if stripPathToBasename("main.go:7") != "main.go:7" {
+		t.Fatalf("bare basename must be untouched, got %q", stripPathToBasename("main.go:7"))
+	}
+}
+
+// #1486 case E: the !IsError gate lives at the agent call site - a failed
+// edit never reaches recordEdit, so identical re-verify still warns; a
+// successful edit bumps editsSince and legitimately suppresses the warning.
+func Test1486EditGateSemantics(t *testing.T) {
+	args := `{"command":"go test ./..."}`
+
+	// Failed edit path: agent.go no longer calls recordEdit, so the state
+	// sees zero edits between identical verifies -> warns.
+	s := newRedundantReverifyState()
+	s.recordToolCall("run_command", args, 1, false)
+	if h := s.recordToolCall("run_command", args, 2, false); h == "" {
+		t.Fatal("identical re-verify with no landed edit must still warn")
+	}
+
+	// Successful edit path: recordEdit runs, editsSince=1 -> no warning.
+	s2 := newRedundantReverifyState()
+	s2.recordToolCall("run_command", args, 1, false)
+	s2.recordEdit("edit_file")
+	if h := s2.recordToolCall("run_command", args, 2, false); h != "" {
+		t.Fatal("re-verify after a landed edit must not warn")
+	}
+}

--- a/internal/agent/recurring_error.go
+++ b/internal/agent/recurring_error.go
@@ -186,7 +186,13 @@ var (
 	// Matches sequences like ./a/b/ or /a/b/c/ and removes them so only
 	// the final file.ext remains. This makes fingerprints stable across
 	// path relocations (relative vs absolute, different root directories).
-	pathPrefixPattern = regexp.MustCompile(`(?:/?[\w.\-]+/)+`)
+	// #1486 case D: strip only leading root markers (./ ../ and absolute
+	// slashes). The old greedy `(?:/?[\w.\-]+/)+` removed ALL directory
+	// segments, so a/util.go:42 and b/util.go:42 collided into one
+	// fingerprint and distinct real errors merged their counts toward the
+	// soft/hard guidance gates. Named segments are kept: ./pkg/a/util.go
+	// -> pkg/a/util.go; a/util.go stays a/util.go.
+	pathPrefixPattern = regexp.MustCompile(`^(?:\.\./+|\./+|/+)+`)
 	// wsPattern collapses multiple whitespace into single space
 	wsPattern = regexp.MustCompile(`\s+`)
 )
@@ -267,10 +273,10 @@ func normalizeErrorLine(line string) string {
 	return s
 }
 
-// stripPathToBasename replaces directory path prefixes with empty string,
-// leaving only the basename. E.g. ./internal/agent/foo.go → foo.go,
-// /home/user/project/foo.go → foo.go. This makes fingerprints stable across
-// path relocations.
+// stripPathToBasename drops leading root markers only (#1486 case D):
+// ./internal/agent/foo.go → internal/agent/foo.go — the ./-vs-plain
+// spelling variance still merges, while sibling packages (a/util.go vs
+// b/util.go) no longer collide into one fingerprint.
 func stripPathToBasename(s string) string {
 	return pathPrefixPattern.ReplaceAllString(s, "")
 }


### PR DESCRIPTION
## Summary
Closes #1486 (cases D/E; cases A/B/C landed in earlier rounds — recordShellSourceMutation, PASS/RUN-line filtering in hasErrorMarkers, reckless_exec created-file exemption — verified by direct read, not re-fixed).

1. **Case D (Low-Med)**: pathPrefixPattern stripped ALL directory segments greedily — `a/util.go:42` and `b/util.go:42` collided into one fingerprint, merging distinct errors' counts toward the soft/hard guidance gates. Now only leading root markers (`./`, `../`, `/`) are stripped.
2. **Case E (Low)**: `redundantReverify.recordEdit` was called unconditionally — a failed edit (nothing landed) bumped editsSince and suppressed a legitimate redundant-rerun warning. Gated by `!result.IsError` at the call site; the shell channel keeps its deliberate includes-failures semantics (#1028).

## Verification evidence (review)
Isolated worktree: reverify/recurring/reckless subset PASS (p=1). Pins: sibling-package separation, `./`/`../` stripping, bare-basename passthrough, and the warn/suppress boundary across landed vs failed edits. The first D draft (anchored single-segment strip) was caught by its own pin — bare relative first segments still collided — and corrected to root-marker-only stripping before commit.

Closes #1486

Generated with [ggcode](https://github.com/topcheer/ggcode)
