### PR TITLE
fix(extract): OOXML template family registered; zip preview snaps to rune boundary (#1727 cases 1+3)

### DIFF
--- a/internal/extract/archive.go
+++ b/internal/extract/archive.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/topcheer/ggcode/internal/util"
 )
@@ -264,7 +265,14 @@ func listZip(data []byte) ([]archiveFile, error) {
 		// convention) while staying within the per-entry budget.
 		if int64(len(d)) > limit {
 			marker := []byte(fmt.Sprintf("\n[truncated at %d bytes]", limit))
-			d = append(d[:limit-int64(len(marker))], marker...)
+			cut := limit - int64(len(marker))
+			// #1727 case 3: the nested-path branch above already snaps to
+			// a rune boundary (#547/#301 lineage); this zip-preview cut
+			// sliced mid-UTF-8 - CJK entries truncated to invalid bytes.
+			for cut > 0 && !utf8.RuneStart(d[cut]) {
+				cut--
+			}
+			d = append(d[:cut], marker...)
 		}
 		totalRead += int64(len(d))
 		files = append(files, archiveFile{name: f.Name, data: d})

--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -41,6 +41,17 @@ func init() {
 	defaultRegistry.Register(".docm", &docxExtractor{})
 	defaultRegistry.Register(".xlsm", &xlsxExtractor{})
 	defaultRegistry.Register(".pptm", &pptxExtractor{})
+	// #1727 case 1: the OOXML TEMPLATE family - same zip the library
+	// parses directly (.dotx/.dotm word, .xltx/.xltm/.xlam excel,
+	// .potx/.potm powerpoint). #1540 fixed only the three macro-enabled
+	// documents; templates still went in as raw binary.
+	defaultRegistry.Register(".dotx", &docxExtractor{})
+	defaultRegistry.Register(".dotm", &docxExtractor{})
+	defaultRegistry.Register(".xltx", &xlsxExtractor{})
+	defaultRegistry.Register(".xltm", &xlsxExtractor{})
+	defaultRegistry.Register(".xlam", &xlsxExtractor{})
+	defaultRegistry.Register(".potx", &pptxExtractor{})
+	defaultRegistry.Register(".potm", &pptxExtractor{})
 	// OpenDocument
 	defaultRegistry.Register(".odt", &odfExtractor{subFormat: "odt"})
 	defaultRegistry.Register(".ods", &odfExtractor{subFormat: "ods"})


### PR DESCRIPTION
Case 1 (Med): #1540 fixed only the three macro-enabled documents - the OOXML **template family** (`.dotx/.dotm/.xltx/.xltm/.xlam/.potx/.potm`, same zip the library parses directly) still had `IsDocumentFile=false` and went into context as raw binary.

Case 3 (Low): the zip-preview truncation sliced mid-UTF-8 while the nested-path branch in the SAME file already snaps to rune boundaries (#547/#301 lineage) - CJK entries truncated to invalid bytes.

(Case 2 - the French i18n proofreading sweep - is its own word-list-scale PR and stays with the #1725 family project.)

Isolated worktree (fresh origin/main): extract package full PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)