### PR TITLE
fix(agent): invalidation extractor learns notebook_path and file_ops source (#1733 case 1)

### DIFF
--- a/internal/agent/verify_hint.go
+++ b/internal/agent/verify_hint.go
@@ -508,6 +508,41 @@ func extractFilePathFromArgs(toolName string, args json.RawMessage) string {
 		}
 	}
 
+	// #1733 case 1: notebook_edit uses "notebook_path" and file_ops moves
+	// carry "source" - both were fileEditingTools (the gate) but the
+	// extractor returned "" for them, so checkEditInvalidation silently
+	// skipped and stale grep/lsp results went unflagged - for ALL FOUR
+	// consumers of this extractor (searchInvalidation, undo_blind,
+	// repetition_tracker, postEditVerifyHint). The sibling extractor
+	// below (#737) had learned these shapes; this one never did (#1547
+	// fixed the THIRD extractor only).
+	if v, ok := raw["notebook_path"]; ok {
+		var s string
+		if json.Unmarshal(v, &s) == nil && s != "" {
+			return s
+		}
+	}
+	if v, ok := raw["source"]; ok {
+		var s string
+		if json.Unmarshal(v, &s) == nil && s != "" {
+			return s
+		}
+	}
+	// file_ops nests its paths under operations[] (source/destination).
+	if opsRaw, ok := raw["operations"]; ok {
+		var ops []map[string]json.RawMessage
+		if json.Unmarshal(opsRaw, &ops) == nil {
+			for _, op := range ops {
+				if v, ok := op["source"]; ok {
+					var s string
+					if json.Unmarshal(v, &s) == nil && s != "" {
+						return s
+					}
+				}
+			}
+		}
+	}
+
 	return ""
 }
 

--- a/internal/agent/verify_hint_test.go
+++ b/internal/agent/verify_hint_test.go
@@ -530,3 +530,20 @@ func TestIsNonFailureExit(t *testing.T) {
 		t.Error("real failure exit codes must not be classified as non-failure")
 	}
 }
+
+// TestExtractFilePathFromArgsNotebookAndFileOps pins #1733 case 1: the
+// extractor must learn notebook_edit's notebook_path and file_ops's source
+// - both are fileEditingTools, and a "" return made checkEditInvalidation
+// skip for all four consumers.
+func TestExtractFilePathFromArgsNotebookAndFileOps(t *testing.T) {
+	if got := extractFilePathFromArgs("notebook_edit", json.RawMessage(`{"notebook_path":"/tmp/nb.ipynb","operation":"add"}`)); got != "/tmp/nb.ipynb" {
+		t.Fatalf("notebook_path not extracted: %q", got)
+	}
+	if got := extractFilePathFromArgs("file_ops", json.RawMessage(`{"operations":[{"action":"move","source":"/a.txt","destination":"/b.txt"}]}`)); got != "/a.txt" {
+		t.Fatalf("file_ops source not extracted: %q", got)
+	}
+	// Precedence unchanged for the classic shapes.
+	if got := extractFilePathFromArgs("edit_file", json.RawMessage(`{"file_path":"/c.txt"}`)); got != "/c.txt" {
+		t.Fatalf("classic file_path regressed: %q", got)
+	}
+}


### PR DESCRIPTION
notebook_edit and file_ops are `fileEditingTools`, but the extractor returned `""` for both - `checkEditInvalidation` silently skipped and stale grep/lsp results went unflagged, for **all four consumers** of this extractor (searchInvalidation, undo_blind, repetition_tracker, postEditVerifyHint).

The sibling extractor learned these shapes (#737); #1547 fixed the third one; this sibling never got the sync. Pinned with `TestExtractFilePathFromArgsNotebookAndFileOps` (new shapes + classic precedence).

(Case 2 - the qq i18n key across ten languages - goes with the #1725 word-list project.)

Isolated worktree (fresh origin/main): VerifyHint/Invalidation families PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)