### PR TITLE
fix(desktop,config): OAuth status truth and silent renewal (#1805)

### DIFF
--- a/desktop/wailskit/chat.go
+++ b/desktop/wailskit/chat.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/topcheer/ggcode/internal/auth"
 	"log"
 	"os"
 	"path/filepath"
@@ -148,6 +149,7 @@ type ChatBridge struct {
 	a2aRegistry      *a2a.Registry
 	a2aRemoteTool    *a2a.RemoteTool
 	a2aRefreshCancel context.CancelFunc
+	oauthRenewCancel context.CancelFunc
 	lanchatHub       *lanchat.Hub
 
 	// Pending approval/ask_user requests from agent
@@ -1978,6 +1980,7 @@ func (b *ChatBridge) InitAgent(_ ...context.Context) error {
 
 	// Start A2A server for LAN agent-to-agent communication.
 	b.startA2A(b.cfg, a, b.registry)
+	b.startOAuthRenewalWatcher()
 
 	// Set interruption handler — agent checks for pending messages during compact etc.
 	// (mirrors Fyne line 836-839)
@@ -3781,8 +3784,57 @@ func (b *ChatBridge) startA2A(cfg *config.Config, ag *agent.Agent, reg *tool.Reg
 	}
 }
 
+// startOAuthRenewalWatcher silently renews an expired Anthropic OAuth token
+// (#1805 case 2): the running provider froze the access token at build time,
+// so a session that outlives expires_in 401'd on every message until restart
+// or a config change - despite a perfectly good refresh token. Once a minute,
+// when the stored token is OAuth+expired+refreshable, nudge
+// OnConfigProviderChanged: its resolve path performs the refresh (and the
+// #1805 case-1 cleanup when the refresh token is permanently dead).
+func (b *ChatBridge) startOAuthRenewalWatcher() {
+	if b.oauthRenewCancel != nil {
+		return // already running
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	b.oauthRenewCancel = cancel
+	safego.Go("desktop.oauth-renew-watcher", func() {
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if !anthropicOAuthNeedsRenewal() {
+					continue
+				}
+				if bridge := GetChatBridge(); bridge != nil {
+					bridge.OnConfigProviderChanged()
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+}
+
+// anthropicOAuthNeedsRenewal reports whether the stored Anthropic credential
+// is an OAuth token that is expired but refreshable (disk check only - the
+// actual refresh happens in the resolve path).
+func anthropicOAuthNeedsRenewal() bool {
+	info, err := auth.DefaultStore().Load(auth.ProviderAnthropic)
+	if err != nil || info == nil {
+		return false
+	}
+	return info.Type == "oauth" &&
+		info.IsExpired() &&
+		strings.TrimSpace(info.RefreshToken) != ""
+}
+
 // stopA2A shuts down the A2A server and cleans up.
 func (b *ChatBridge) stopA2A() {
+	if b.oauthRenewCancel != nil {
+		b.oauthRenewCancel()
+		b.oauthRenewCancel = nil
+	}
 	if b.a2aRefreshCancel != nil {
 		b.a2aRefreshCancel()
 		b.a2aRefreshCancel = nil

--- a/desktop/wailskit/config.go
+++ b/desktop/wailskit/config.go
@@ -1150,23 +1150,18 @@ func GetModelLimits(vendor, endpoint string) []ModelLimitInfo {
 }
 
 // AnthropicOAuthStatus reports whether the stored Anthropic OAuth token is
-// usable OR recoverable (#599 O2). Previously it returned raw
-// HasUsableToken: in the ~5.5-minute window between IsExpired (5-min
-// early) and HasUsableToken (+30s grace), and worse — for any expired
-// token with an intact RefreshToken — the UI flipped to "not connected",
-// nudging users through a full browser re-auth when a single silent
-// refresh would recover. Return true when the token is valid OR
-// refreshable (refresh token present); "dead" (no refresh token, no
-// usable access token) still reports false so the UI keeps prompting
-// for a real re-auth.
+// usable OR recoverable (#599 O2 - disk fields only, deliberately no network
+// probe: the #1805 permanent-failure cleanup lives in the resolve path that
+// already owns the network - config_vendor.go deletes the token on
+// invalid_grant, which flips this status by itself).
 func AnthropicOAuthStatus() bool {
 	store := auth.DefaultStore()
 	usable, err := store.HasUsableToken(auth.ProviderAnthropic)
 	if err == nil && usable {
 		return true // valid
 	}
-	// Refreshable probe: a stored token with an access token AND a refresh
-	// token can self-recover — count it as connected.
+	// Refreshable: a stored token with an access token AND a refresh token
+	// can self-recover — count it as connected.
 	if info, ierr := store.Load(auth.ProviderAnthropic); ierr == nil && info != nil {
 		if strings.TrimSpace(info.AccessToken) != "" && strings.TrimSpace(info.RefreshToken) != "" {
 			return true // refreshable

--- a/desktop/wailskit/oauth_1805_renewal_test.go
+++ b/desktop/wailskit/oauth_1805_renewal_test.go
@@ -1,0 +1,63 @@
+package wailskit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/topcheer/ggcode/internal/auth"
+)
+
+// #1805 case 2: the renewal watcher's trigger is a pure disk predicate -
+// oauth + expired + refreshable. Non-oauth, fresh, or unrefreshable
+// credentials must not fire (keeping the ticker a no-op for everyone else).
+func Test1805OAuthNeedsRenewal(t *testing.T) {
+	store := auth.DefaultStore()
+	original, origErr := store.Load(auth.ProviderAnthropic)
+	defer func() {
+		if original != nil {
+			_ = store.Save(original)
+		} else if origErr != nil {
+			_ = store.Delete(auth.ProviderAnthropic)
+		}
+	}()
+
+	fresh := &auth.Info{ProviderID: auth.ProviderAnthropic, Type: "oauth",
+		AccessToken: "at", RefreshToken: "rt", ExpiresAt: time.Now().Add(time.Hour)}
+	_ = store.Delete(auth.ProviderAnthropic)
+	if err := store.Save(fresh); err != nil {
+		t.Fatal(err)
+	}
+	if anthropicOAuthNeedsRenewal() {
+		t.Fatal("fresh oauth token must not need renewal")
+	}
+
+	expired := &auth.Info{ProviderID: auth.ProviderAnthropic, Type: "oauth",
+		AccessToken: "at", RefreshToken: "rt", ExpiresAt: time.Now().Add(-time.Hour)}
+	_ = store.Delete(auth.ProviderAnthropic)
+	if err := store.Save(expired); err != nil {
+		t.Fatal(err)
+	}
+	if !anthropicOAuthNeedsRenewal() {
+		t.Fatal("expired+refreshable oauth token must need renewal")
+	}
+
+	noRefresh := &auth.Info{ProviderID: auth.ProviderAnthropic, Type: "oauth",
+		AccessToken: "at", ExpiresAt: time.Now().Add(-time.Hour)}
+	_ = store.Delete(auth.ProviderAnthropic)
+	if err := store.Save(noRefresh); err != nil {
+		t.Fatal(err)
+	}
+	if anthropicOAuthNeedsRenewal() {
+		t.Fatal("expired token without refresh token must not trigger the watcher")
+	}
+
+	apiKey := &auth.Info{ProviderID: auth.ProviderAnthropic, Type: "api_key",
+		AccessToken: "at", ExpiresAt: time.Now().Add(-time.Hour)}
+	_ = store.Delete(auth.ProviderAnthropic)
+	if err := store.Save(apiKey); err != nil {
+		t.Fatal(err)
+	}
+	if anthropicOAuthNeedsRenewal() {
+		t.Fatal("api-key credential must never trigger the oauth watcher")
+	}
+}

--- a/internal/config/config_vendor.go
+++ b/internal/config/config_vendor.go
@@ -115,6 +115,19 @@ func (c *Config) ResolveEndpointSelection(vendor, endpoint, model string) (*Reso
 					// access token - downstream requests would 401 and mask the
 					// real cause (refresh failure). Fail loudly to trigger
 					// re-authentication.
+					// #1805 case 1: a PERMANENT rejection (invalid_grant - the refresh
+					// token was rotated on a Save that failed, or revoked) must also
+					// delete the stored token: the status bar reads disk fields and
+					// kept reporting "connected" while every chat 401'd, with /login
+					// as the only exit. Clearing the dead token flips the status to
+					// "not connected" immediately. Transient errors keep the token -
+					// the next resolve retries the refresh.
+					if isPermanentRefreshFailure(refreshErr) {
+						debug.Log("config", "claude oauth: refresh token permanently rejected (clearing dead token): %v", refreshErr)
+						if delErr := auth.DefaultStore().Delete(auth.ProviderAnthropic); delErr != nil {
+							debug.Log("config", "claude oauth: clearing dead token failed: %v", delErr)
+						}
+					}
 					debug.Log("config", "claude oauth: token refresh failed (re-authentication required): %v", refreshErr)
 					return nil, fmt.Errorf("claude oauth token refresh failed (run /login to re-authenticate): %w", refreshErr)
 				}
@@ -601,4 +614,15 @@ func (c *Config) SetEndpointModelLimits(vendor, endpoint string, contextWindow, 
 	vc.Endpoints[endpoint] = ep
 	c.Vendors[vendor] = vc
 	return c.SaveScoped("global")
+}
+
+// isPermanentRefreshFailure reports whether an OAuth refresh error is the
+// permanent invalid_grant rejection (rotated or revoked refresh token) as
+// opposed to a transient network/5xx failure (#1805 case 1).
+func isPermanentRefreshFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "invalid_grant") || strings.Contains(msg, "invalid refresh token")
 }

--- a/internal/config/vendor_1805_test.go
+++ b/internal/config/vendor_1805_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+// #1805 case 1: the resolve path must classify refresh failures so a
+// permanently dead (rotated/revoked) refresh token gets cleared while
+// transient errors keep the token for retry.
+func Test1805PermanentRefreshClassification(t *testing.T) {
+	if !isPermanentRefreshFailure(errors.New("oauth2: refresh failed: invalid_grant")) {
+		t.Fatal("invalid_grant must be permanent")
+	}
+	if !isPermanentRefreshFailure(errors.New("400 {\"error\":\"invalid_grant\"}")) {
+		t.Fatal("json-embedded invalid_grant must be permanent")
+	}
+	if isPermanentRefreshFailure(errors.New("dial tcp: i/o timeout")) {
+		t.Fatal("network timeout must NOT be permanent")
+	}
+	if isPermanentRefreshFailure(errors.New("500 internal server error")) {
+		t.Fatal("server error must NOT be permanent")
+	}
+	if isPermanentRefreshFailure(nil) {
+		t.Fatal("nil must not be permanent")
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1805 (both cases).

1. **Case 1 (Med)**: a permanently dead refresh token (invalid_grant after a failed rotated-token Save) is now deleted in the resolve path — the status bar flips to "not connected" immediately instead of lying "connected" while every chat 401s. Transient refresh errors keep the token for retry.
2. **Case 2 (Med)**: a one-minute renewal watcher nudges `OnConfigProviderChanged` when the stored credential is oauth+expired+refreshable — the resolve path silently refreshes, so sessions that outlive `expires_in` stop 401ing until restart.

## Verification evidence (review)
Isolated worktree: desktop/wailskit **12.1s** + internal/config **13.5s** PASS (p=1). Pins: permanent/transient refresh classification; renewal trigger predicate (fresh / expired+refreshable / no-refresh / api-key). Design correction caught by the existing #599 test: the first draft put a live network probe inside `AnthropicOAuthStatus`, which broke the determinism contract — reverted to a disk-only status with the network in the resolve path that already owns it.

Closes #1805

Generated with [ggcode](https://github.com/topcheer/ggcode)
