### PR TITLE
fix(tui): imEnsure pre-built; inspector loadErr surfaces (#1737 cases 1+3)

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -548,6 +548,7 @@ func NewModel(a *agent.Agent, policy permission.PermissionPolicy) Model {
 	}
 
 	m := Model{
+		imEnsure:               &imEnsureGuard{}, // #1737 case 1: pre-built - lazy init raced across concurrent Cmd goroutines (duplicate starters, the exact registrations #1379-D killed)
 		input:                  ta,
 		chatList:               chat.NewList(80, 20),
 		chatStyles:             chat.DefaultStyles(),

--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -60,6 +60,22 @@ func (m Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 	case inspectorItemsLoadedMsg:
 		// Async-loaded session items for inspector panel — cache them
 		if m.inspectorPanel != nil && m.inspectorPanel.kind == msg.kind {
+			// #1737 case 3: loadErr was sent but never consumed - a failed
+			// load showed "no sessions yet" instead of the error, sending
+			// the user down the wrong path (e.g. creating a session over a
+			// transient read failure). Mirror the sync path's error state.
+			if msg.loadErr != nil {
+				// Mirror the sync path exactly (L92): an error item, not an
+				// empty list.
+				m.inspectorPanel.cachedItems = []inspectorPanelItem{{
+					Title:    inspectorText(m.currentLanguage(), "sessions_error"),
+					Detail:   msg.loadErr.Error(),
+					Disabled: true,
+				}}
+				m.inspectorPanel.itemsLoaded = true
+				m.inspectorPanel.loading = false
+				return m, nil
+			}
 			m.inspectorPanel.cachedItems = msg.items
 			m.inspectorPanel.itemsLoaded = true
 			m.inspectorPanel.loading = false


### PR DESCRIPTION
Case 1 (Med-High): the lazy `if m.imEnsure == nil` creation was itself unsynchronized - concurrent Cmd goroutines (bubbletea runs each Cmd in its own goroutine; seven IM panels race here) each built a guard, the writer's won, and **BOTH became starters on different guards**: concurrent InitRuntime+StartCurrentBindingAdapter+SetBridge - the exact duplicate-registration #1379-D tried to kill, defeated by its own guard's creation. The guard is now pre-built in NewModel's composite literal (the residual nil-check stays as test-harness belt-and-suspenders).

Case 3 (Med): the async inspector path sent `loadErr` but the consumer never read it - a failed load rendered **'no sessions yet'** (the sync path shows `sessions_error`), sending the user down the wrong path. The consumer now mirrors the sync path's error item.

(Case 2 - impersonate's cursor-driven version clobber - and the Low items stay for follow-up.)

Isolated worktree (fresh origin/main): tui package full PASS (10.5s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)