### PR TITLE
fix(agent): undo-blind pre-execution wiring + retrospective guidance (#1799)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2995,6 +2995,19 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 				a.fillCancelledToolResults(toolCalls[idx:], &toolResults)
 				return err
 			}
+			// #1799 case 1: undo-blind detection BEFORE execution. The old
+			// call site sat in the post-execution result loop: the blind edit
+			// had ALREADY landed on disk by the time the "read before editing"
+			// guidance arrived - exactly the compounding error this detector
+			// exists to prevent. The check is pure (state mutation records the
+			// undo/read/mutation sequence), so calling it pre-execution yields
+			// identical classification one step earlier; the hint rides the
+			// tool result so the LLM sees it in the same turn.
+			var undoBlindHint string
+			if ub := a.undoBlind.recordToolCall(tc.Name, tc.Arguments); ub != "" {
+				debug.Log("agent", "Iteration %d: undo-blind mutation detected (pre-execution)", i+1)
+				undoBlindHint = ub
+			}
 			// #1587-A: snapshot write-target existence BEFORE execution -
 			// the orphan detector consumes it post-execution.
 			a.orphanFile.recordPreExec(tc.Name, string(tc.Arguments), a.workingDir)
@@ -3886,17 +3899,8 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// Verification debt: track unverified modifications (SAUP-inspired).
 			// Detects when the agent stacks edits without building/testing.
 			a.verifDebt.recordToolCall(tc.Name, string(tc.Arguments))
-			// Undo-blind: detect mutations after undo/revert without re-reading.
-			if ubMsg := a.undoBlind.recordToolCall(tc.Name, tc.Arguments); ubMsg != "" {
-				debug.Log("agent", "Iteration %d: undo-blind continuation detected", i+1)
-				a.contextManager.Add(provider.Message{
-					Role: "user",
-					Content: []provider.ContentBlock{{
-						Type: "text",
-						Text: ubMsg,
-					}},
-				})
-			}
+			// Undo-blind moved to pre-execution (#1799 case 1) - see the
+			// loop above; the hint rides the tool result there.
 			// Premature commitment: record exploratory actions to track
 			// evidence gathering before the first edit.
 			a.prematureCommit.recordExploration(tc.Name, extractFileHints(tc.Name, tc.Arguments))
@@ -4343,7 +4347,7 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// Both vision and non-vision paths share the same hint assembly logic.
 			// originalContentLen was captured BEFORE the detector chain above (#952,
 			// #553 residual) so detector guidance never inflates waste metering.
-			a.applyToolResultGuidance(&result, loopGuidance, searchParamHint, redundancyHint, equivHint)
+			a.applyToolResultGuidance(&result, loopGuidance, searchParamHint, redundancyHint, equivHint, undoBlindHint)
 			if len(result.Images) > 0 && a.SupportsVision() {
 				imgs := make([]provider.ContentImage, len(result.Images))
 				for i, ri := range result.Images {

--- a/internal/agent/branch_guard.go
+++ b/internal/agent/branch_guard.go
@@ -1,8 +1,13 @@
 package agent
 
-// branch_guard.go implements Protected Branch Edit Warning — a pre-edit guard
-// that warns when the agent is about to modify files on a protected branch
-// (main, master, develop, release/*).
+// branch_guard.go implements Protected Branch Edit Warning — a post-edit
+// informational guard that fires after the first file edit of a run lands
+// on a protected branch (main, master, develop, release/*), warning before
+// the NEXT edit/commit rather than blocking the one that already happened.
+// (#1799 case 2: the header previously claimed "a pre-edit guard … warns
+// when the agent is about to modify files" — the wiring is in the
+// mutatesSourceTree result-handling branch, i.e. post-execution; the body
+// text and one-shot latch were already consistent with that.)
 //
 // Research basis: In 2025-2026, all major coding agents added branch protection
 // awareness as a safety feature:

--- a/internal/agent/guidance_coalesce.go
+++ b/internal/agent/guidance_coalesce.go
@@ -277,15 +277,20 @@ func appendSuppressedSummary(result, suppressed []string) []string {
 //   - overuseHint: tool overuse guidance
 func (a *Agent) applyToolResultGuidance(
 	result *tool.Result,
-	loopGuidance, searchParamHint, redundancyHint, equivHint string,
+	loopGuidance, searchParamHint, redundancyHint, equivHint, undoBlindHint string,
 ) {
-	if loopGuidance == "" && searchParamHint == "" && redundancyHint == "" && equivHint == "" {
+	if loopGuidance == "" && searchParamHint == "" && redundancyHint == "" && equivHint == "" && undoBlindHint == "" {
 		return
 	}
 
 	var hints []string
 	if searchParamHint != "" {
 		hints = append(hints, searchParamHint)
+	}
+	if undoBlindHint != "" {
+		// #1799 case 1: computed BEFORE execution, attached to the result of
+		// the very call it warned about.
+		hints = append(hints, undoBlindHint)
 	}
 	if loopGuidance != "" {
 		hints = append(hints, loopGuidance)

--- a/internal/agent/undo_blind.go
+++ b/internal/agent/undo_blind.go
@@ -132,9 +132,10 @@ func (s *undoBlindState) recordToolCall(toolName string, argsJSON []byte) string
 				s.warnCount++
 				delete(s.pendingUndoFiles, "*")
 				return fmt.Sprintf(
-					"[undo-blind] A tree-wide revert/reset was performed but you are editing " +
-						"without re-reading the affected files first. The file contents may differ " +
-						"from what you remember. Read the file(s) you are about to edit before proceeding.",
+					"[undo-blind] A tree-wide revert/reset was performed and this edit ran without " +
+						"re-reading the affected files first - its anchors may have come from the " +
+						"pre-revert contents. Read the file(s) you just edited back NOW, verify the " +
+						"result is what you intended, and re-read before every further edit.",
 				)
 			}
 		}
@@ -144,9 +145,9 @@ func (s *undoBlindState) recordToolCall(toolName string, argsJSON []byte) string
 				s.warnCount++
 				delete(s.pendingUndoFiles, fp)
 				return fmt.Sprintf(
-					"[undo-blind] You are editing %s after an undo/revert operation on this file "+
-						"without re-reading it first. The undo may have restored content different from "+
-						"your current mental model. Read %s before editing to avoid compounding errors.",
+					"[undo-blind] This edit to %s ran after an undo/revert on the file without "+
+						"a re-read - it may have used stale pre-revert anchors. Read %s back NOW "+
+						"and verify what actually landed; re-read before every further edit.",
 					fp, fp,
 				)
 			}
@@ -163,8 +164,8 @@ func (s *undoBlindState) recordToolCall(toolName string, argsJSON []byte) string
 						s.warnCount++
 						delete(s.pendingUndoFiles, p)
 						return fmt.Sprintf(
-							"[undo-blind] You are editing %s after an undo/revert on this file "+
-								"without re-reading it first. Read %s before editing.",
+							"[undo-blind] This edit to %s ran after an undo/revert on the file "+
+								"without a re-read. Read %s back and verify what landed.",
 							p, p,
 						)
 					}

--- a/internal/agent/zz_issue607_test.go
+++ b/internal/agent/zz_issue607_test.go
@@ -112,7 +112,7 @@ func TestIssue607_B2_ToolResultHintsRespectBudget(t *testing.T) {
 	// budget must start suppressing.
 	for i := 0; i < guidanceBudgetPerTurn; i++ {
 		res := &tool.Result{Content: "ok"}
-		a.applyToolResultGuidance(res, "", "[advisory-"+string(rune('a'+i))+"] hint number "+string(rune('a'+i)), "", "")
+		a.applyToolResultGuidance(res, "", "[advisory-"+string(rune('a'+i))+"] hint number "+string(rune('a'+i)), "", "", "")
 		if !strings.Contains(res.Content, "[advisory-") {
 			t.Fatalf("result %d: advisory hint unexpectedly suppressed before budget cap; content=%q", i, res.Content)
 		}
@@ -120,7 +120,7 @@ func TestIssue607_B2_ToolResultHintsRespectBudget(t *testing.T) {
 
 	// Next result in the SAME turn must be suppressed by the budget.
 	res := &tool.Result{Content: "ok"}
-	a.applyToolResultGuidance(res, "", "[advisory-over] should be suppressed", "", "")
+	a.applyToolResultGuidance(res, "", "[advisory-over] should be suppressed", "", "", "")
 	if strings.Contains(res.Content, "[advisory-over]") {
 		t.Errorf("tool-result hint bypassed per-turn budget cap (B2); content=%q", res.Content)
 	}
@@ -133,11 +133,11 @@ func TestIssue607_B2_CriticalHintPassesExhaustedBudget(t *testing.T) {
 	a := issue607Agent()
 	for i := 0; i < guidanceBudgetPerTurn; i++ {
 		res := &tool.Result{Content: "ok"}
-		a.applyToolResultGuidance(res, "", "[advisory-"+string(rune('a'+i))+"] filler", "", "")
+		a.applyToolResultGuidance(res, "", "[advisory-"+string(rune('a'+i))+"] filler", "", "", "")
 	}
 	// Critical hint still injects even with the budget exhausted.
 	res := &tool.Result{Content: "ok"}
-	a.applyToolResultGuidance(res, "[CRITICAL] critical failure detected", "", "", "")
+	a.applyToolResultGuidance(res, "[CRITICAL] critical failure detected", "", "", "", "")
 	if !strings.Contains(res.Content, "[CRITICAL]") {
 		t.Error("critical hint suppressed by exhausted budget; want bypass")
 	}
@@ -157,7 +157,7 @@ func TestIssue607_B3_ConflictHintCountsTowardCap(t *testing.T) {
 	// total injections across the turn.
 	a.applyToolResultGuidance(res, "",
 		"[analysis-paralysis] ACT NOW: make your best-guess edit.",
-		"[explore-expand] Explore more to understand before editing.", "")
+		"[explore-expand] Explore more to understand before editing.", "", "")
 
 	injectedMsgs := a.guidanceBudget.injected
 	if injectedMsgs > guidanceBudgetPerTurn {
@@ -175,7 +175,7 @@ func TestIssue607_B3_MetaHintDedupedAcrossResults(t *testing.T) {
 
 	// First result in the turn: the hint is injected.
 	res1 := &tool.Result{Content: "ok"}
-	a.applyToolResultGuidance(res1, "", conflict, "", "")
+	a.applyToolResultGuidance(res1, "", conflict, "", "", "")
 	if !strings.Contains(res1.Content, "[analysis-paralysis]") {
 		t.Fatalf("first result: expected advisory hint; content=%q", res1.Content)
 	}
@@ -184,7 +184,7 @@ func TestIssue607_B3_MetaHintDedupedAcrossResults(t *testing.T) {
 	// duplicate tag must be suppressed (cross-result dedup).
 	for i := 2; i <= 3; i++ {
 		res := &tool.Result{Content: "ok"}
-		a.applyToolResultGuidance(res, "", conflict, "", "")
+		a.applyToolResultGuidance(res, "", conflict, "", "", "")
 		if strings.Contains(res.Content, "[analysis-paralysis]") {
 			t.Errorf("result %d: duplicate hint repeated across tool results; content=%q", i, res.Content)
 		}
@@ -202,7 +202,7 @@ func TestIssue607_B3_ConflictDetectionStripsCoalescedSummaries(t *testing.T) {
 	res := &tool.Result{Content: "ok"}
 	a.applyToolResultGuidance(res, "",
 		"[analysis-paralysis] ACT NOW: make your best-guess edit.",
-		"[explore-expand] Explore more to understand before editing.", "")
+		"[explore-expand] Explore more to understand before editing.", "", "")
 	if strings.Contains(res.Content, "[guidance-conflict]") {
 		t.Errorf("pseudo-conflict fabricated from [guidance-coalesced] summary: %q", res.Content)
 	}
@@ -251,7 +251,7 @@ func TestIssue607_B3_ConflictHintDoesNotExceedCap(t *testing.T) {
 	res := &tool.Result{Content: "ok"}
 	a.applyToolResultGuidance(res, "",
 		"[analysis-paralysis] ACT NOW: make your best-guess edit.",
-		"[explore-expand] Explore more to understand before editing.", "")
+		"[explore-expand] Explore more to understand before editing.", "", "")
 
 	messages := strings.Count(res.Content, "\n\n")
 	// content "ok" + N injected hints => N-1 separators of the hints


### PR DESCRIPTION
## Summary
Closes #1799 (both cases — detector wiring vs. wording, #1798 family extension).

1. **Case 1 (Med)**: undoBlind now checks pre-execution (same segment as batch-coupling / searchParamGuard) with the hint riding the tool result through `applyToolResultGuidance` (new `undoBlindHint` arg); the three messages are retrospective ("read the file you just edited back NOW, verify what landed"). Classification is unchanged — `recordToolCall` is a pure state machine; one step earlier yields identical decisions.
2. **Case 2 (Low)**: branch_guard's header now states its real position (post-edit informational; warns before the NEXT edit/commit).

## Verification evidence (review)
Isolated worktree: **internal/agent full suite 24.2s PASS** (p=1), including the untouched undo_blind unit tests (state machine unchanged) and updated zz_issue607 call sites (signature extension). Vet clean.

Closes #1799

Generated with [ggcode](https://github.com/topcheer/ggcode)
