### PR TITLE
fix(config): active endpoint/vendor removal falls selection back (#1517)

### DIFF
--- a/internal/config/config_vendor.go
+++ b/internal/config/config_vendor.go
@@ -529,6 +529,36 @@ func (c *Config) RemoveEndpoint(vendor, endpoint string) error {
 	}
 	delete(vc.Endpoints, endpoint)
 	c.Vendors[vendor] = vc
+	// #1517 case C: if the removed endpoint was the ACTIVE selection, c.Endpoint
+	// dangles - ResolveActiveEndpoint fails "endpoint not configured" with no
+	// fallback branch, and NeedsOnboard treats any resolve error as needing
+	// re-onboarding, so every launch popped onboarding until the user manually
+	// changed the selection. Fall back to the first remaining endpoint under
+	// the same vendor.
+	if c.Vendor == vendor && c.Endpoint == endpoint {
+		c.Endpoint = ""
+		for name := range vc.Endpoints {
+			if c.Endpoint == "" || name < c.Endpoint {
+				c.Endpoint = name
+			}
+		}
+		if c.Endpoint == "" {
+			// No endpoints left under this vendor - fall back to another vendor.
+			for name, v := range c.Vendors {
+				if name == vendor {
+					continue
+				}
+				for epName := range v.Endpoints {
+					c.Vendor = name
+					c.Endpoint = epName
+					break
+				}
+				if c.Endpoint != "" {
+					break
+				}
+			}
+		}
+	}
 	return nil
 }
 
@@ -578,6 +608,23 @@ func (c *Config) RemoveVendor(name string) error {
 		return fmt.Errorf("vendor %q not found", name)
 	}
 	delete(c.Vendors, name)
+	// #1517 case C: same dangling-selection fallback as RemoveEndpoint -
+	// removing the ACTIVE vendor left c.Vendor dangling and popped
+	// onboarding on every launch until the selection was fixed manually.
+	if c.Vendor == name {
+		c.Vendor = ""
+		c.Endpoint = ""
+		for vName, v := range c.Vendors {
+			for epName := range v.Endpoints {
+				c.Vendor = vName
+				c.Endpoint = epName
+				break
+			}
+			if c.Endpoint != "" {
+				break
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/config/vendor_1517_test.go
+++ b/internal/config/vendor_1517_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"testing"
+)
+
+// #1517 case C: removing the ACTIVE endpoint/vendor must fall the selection
+// back to a remaining one instead of leaving it dangling (which made
+// NeedsOnboard pop onboarding on every launch).
+func Test1517RemoveActiveSelectionFallback(t *testing.T) {
+	// Active endpoint removed -> first remaining endpoint of same vendor.
+	c := &Config{
+		Vendor:   "v1",
+		Endpoint: "e2",
+		Vendors: map[string]VendorConfig{
+			"v1": {Endpoints: map[string]EndpointConfig{
+				"e1": {}, "e2": {}, "e3": {},
+			}},
+		},
+	}
+	if err := c.RemoveEndpoint("v1", "e2"); err != nil {
+		t.Fatal(err)
+	}
+	if c.Vendor != "v1" || c.Endpoint != "e1" {
+		t.Fatalf("expected fallback to v1/e1, got %s/%s", c.Vendor, c.Endpoint)
+	}
+
+	// Last endpoint of active vendor removed -> another vendor takes over.
+	c2 := &Config{
+		Vendor:   "v1",
+		Endpoint: "only",
+		Vendors: map[string]VendorConfig{
+			"v1": {Endpoints: map[string]EndpointConfig{"only": {}}},
+			"v2": {Endpoints: map[string]EndpointConfig{"a": {}}},
+		},
+	}
+	if err := c2.RemoveEndpoint("v1", "only"); err != nil {
+		t.Fatal(err)
+	}
+	if c2.Vendor != "v2" || c2.Endpoint != "a" {
+		t.Fatalf("expected fallback to v2/a, got %s/%s", c2.Vendor, c2.Endpoint)
+	}
+
+	// Active vendor removed -> another vendor takes over.
+	c3 := &Config{
+		Vendor:   "v1",
+		Endpoint: "x",
+		Vendors: map[string]VendorConfig{
+			"v1": {Endpoints: map[string]EndpointConfig{"x": {}}},
+			"v2": {Endpoints: map[string]EndpointConfig{"b": {}}},
+		},
+	}
+	if err := c3.RemoveVendor("v1"); err != nil {
+		t.Fatal(err)
+	}
+	if c3.Vendor != "v2" || c3.Endpoint != "b" {
+		t.Fatalf("expected fallback to v2/b, got %s/%s", c3.Vendor, c3.Endpoint)
+	}
+
+	// Non-active removal must not touch the selection.
+	c4 := &Config{
+		Vendor:   "v1",
+		Endpoint: "e1",
+		Vendors: map[string]VendorConfig{
+			"v1": {Endpoints: map[string]EndpointConfig{"e1": {}, "e2": {}}},
+		},
+	}
+	if err := c4.RemoveEndpoint("v1", "e2"); err != nil {
+		t.Fatal(err)
+	}
+	if c4.Vendor != "v1" || c4.Endpoint != "e1" {
+		t.Fatal("non-active removal must not change the selection")
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1517 (case C; cases A and B already landed on main in parallel — verified in place).

**Case C**: removing the ACTIVE endpoint/vendor falls the selection back — first remaining endpoint of the same vendor, then another vendor entirely when emptied. No more dangling `c.Endpoint` that made `NeedsOnboard` pop onboarding on every launch.

## Verification evidence (review)
Isolated worktree: internal/config **11.9s PASS** (p=1). Pins: same-vendor fallback / cross-vendor fallback (both paths) / non-active removal no-op.

Closes #1517

Generated with [ggcode](https://github.com/topcheer/ggcode)
