### PR TITLE
fix(tui): vi tone marks; 5 missing catalog keys; stopped adapters stay stopped (#1734 c1, #1735 c1+2)

### DIFF
--- a/internal/tui/i18n_en.go
+++ b/internal/tui/i18n_en.go
@@ -761,6 +761,14 @@ func enCatalog(key string) string {
 		return "current: %s (latest: %s)"
 	case "update.unknown":
 		return "not checked yet"
+	case "update.restarting":
+		return "Restarting to apply the update..."
+	case "label.tools":
+		return "Tools"
+	case "label.active":
+		return "Active"
+	case "label.tasks":
+		return "tasks"
 	case "update.check_failed":
 		return "check failed: %s"
 	case "update.unavailable":

--- a/internal/tui/i18n_vi.go
+++ b/internal/tui/i18n_vi.go
@@ -1118,7 +1118,7 @@ Chuột:
 	case "shell.empty":
 		return "Lệnh shell trống."
 	case "shell.already_running":
-		return "Da co lenh shell dang chay - cho hoan thanh hoac Esc de huy."
+		return "Đã có lệnh shell đang chạy - chờ hoàn thành hoặc Esc để hủy."
 	case "lanchat.unavailable":
 		return "LAN Chat không khả dụng."
 	case "reflect.no_agent":

--- a/internal/tui/i18n_zh.go
+++ b/internal/tui/i18n_zh.go
@@ -772,6 +772,14 @@ func zhCatalog(key string) string {
 		return "当前：%s（最新：%s）"
 	case "update.unknown":
 		return "尚未检查"
+	case "update.restarting":
+		return "正在重启以应用更新..."
+	case "label.tools":
+		return "工具调用"
+	case "label.active":
+		return "进行中"
+	case "label.tasks":
+		return "个任务"
 	case "update.check_failed":
 		return "检查失败：%s"
 	case "update.unavailable":

--- a/internal/tui/im_edit.go
+++ b/internal/tui/im_edit.go
@@ -322,7 +322,12 @@ func (m *Model) isAdapterRunning(name string) bool {
 	}
 	for _, state := range m.imManager.Snapshot().Adapters {
 		if state.Name == name {
-			return true
+			// #1735 case 2: stopAdapter leaves the entry with
+			// Status="disconnected" (nothing deletes it) - a name-only
+			// match treated a STOPPED adapter as running, so editing any
+			// field of a manually-stopped (or crash-marked) adapter
+			// silently restarted it. Only live entries hot-reload.
+			return state.Status != "disconnected"
 		}
 	}
 	return false

--- a/internal/tui/provider_panel.go
+++ b/internal/tui/provider_panel.go
@@ -911,7 +911,7 @@ func (m *Model) handleProviderPanelKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		// Vendors[""] zero-values and the enter-commit persisted a phantom
 		// "" vendor into the yaml.
 		if panel.selectedVendor() == "" {
-			panel.message = m.t("provider.panel.no_vendor_selected")
+			panel.message = m.t("panel.provider.no_vendor_selected") // #1735: the defined key is panel.provider.* - the reversed prefix never matched
 			return *m, nil
 		}
 		vc := m.config.Vendors[panel.selectedVendor()]
@@ -932,7 +932,7 @@ func (m *Model) handleProviderPanelKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	case "m":
 		// #1387-C: same empty-state guard as "b".
 		if panel.selectedVendor() == "" {
-			panel.message = m.t("provider.panel.no_vendor_selected")
+			panel.message = m.t("panel.provider.no_vendor_selected") // #1735: the defined key is panel.provider.* - the reversed prefix never matched
 			return *m, nil
 		}
 		panel.startEditing("custom model", panel.selectedModel())


### PR DESCRIPTION
#1734 case 1 (Low-Med): the vi `shell.already_running` line was bare ASCII - every diacritic missing against fully-toned neighbors.

#1735 case 1 (Med): five consumed keys had no catalog definition (raw keys visible in the chat/sidebar): `update.restarting` / `label.tools` / `label.active` / `label.tasks` added to en+zh (other languages fall back like the existing 80-key gap), and `provider.panel.no_vendor_selected` was a reversed-prefix typo that never matched the defined `panel.provider.*` key (consumer renamed, zero new definitions needed). The CI consumed-keys-vs-catalog check is proposed in the issue for the #1725 project.

#1735 case 2 (Med-Low): `isAdapterRunning` matched by name only, but `stopAdapter` leaves the entry `Status=disconnected` - editing any field of a manually-stopped adapter silently restarted it. Live entries only.

Isolated worktree (fresh origin/main): tui package full PASS (10.2s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)