### PR TITLE
fix(tool): bounded output head-cut rune straddle (#1820)

### DIFF
--- a/internal/tool/bounded_output.go
+++ b/internal/tool/bounded_output.go
@@ -63,10 +63,16 @@ func (w *boundedOutputWriter) Write(p []byte) (int, error) {
 		}
 		cut := snapForwardToRune(p, room)
 		w.head.Write(p[:cut])
-		// Bytes of a split rune dropped here are counted as overflow so the
-		// omitted-byte marker stays truthful.
-		w.overflow += int64(room - cut)
-		p = p[room:]
+		// #1820 case 1: p[room:] was wrong when cut > room (a multi-byte
+		// rune straddles the headCap boundary): p[room:cut] was already
+		// written to head AND duplicated into the tail, overflow was increased
+		// by room-cut (a NEGATIVE count - String's `overflow > 0` guard then
+		// skipped compaction and concatenated head+tail over headCap), and the
+		// tail began with bare continuation bytes (invalid UTF-8 garbage in
+		// the TUI). Continue from the cut, not from room; the split rune's
+		// bytes belong to the head, so overflow is NOT adjusted (room-cut is
+		// not "dropped" - it is retained).
+		p = p[cut:]
 	}
 
 	// Tail phase: append, compacting whenever the staging slice exceeds
@@ -107,6 +113,10 @@ func (w *boundedOutputWriter) String() string {
 			// rune-alignment contract every OTHER truncation point in Write
 			// upholds via snapForwardToRune.
 			cut := snapForwardToRune(tail, len(tail)-w.tailCap)
+			// #1820 case 3: the <=3 snapped bytes are DROPPED here but were never
+			// counted - Write's two snap sites both count, so the marker
+			// under-reported against its truthful contract.
+			w.overflow += int64(cut - (len(tail) - w.tailCap))
 			tail = tail[cut:]
 		}
 		if w.head.Len() == 0 {

--- a/internal/tool/bounded_output_test.go
+++ b/internal/tool/bounded_output_test.go
@@ -98,11 +98,17 @@ func BenchmarkBoundedOutputWriter_HeavyStream(b *testing.B) {
 // headCap boundary must not be split - the head cut snaps back to a rune
 // start and the dropped bytes are counted as overflow.
 func TestBoundedOutputWriterRuneSafeHeadCut(t *testing.T) {
-	// 3-byte CJK rune; headCap = 8. Write 7 ASCII bytes then force the cut
-	// mid-rune: 7 + first 1 byte of a 3-byte rune lands at exactly 8.
-	w := newBoundedOutputWriter(16) // headCap = 8
-	cjk := []byte("中")              // 3 bytes
-	w.Write([]byte("1234567"))      // 7 bytes
+	// #1820 case 2: this test NEVER exercised the head-cut path before -
+	// newBoundedOutputWriter(16) clamps to 4096 (headCap 2048), so the 17
+	// total input bytes always took the fast-path early return and the test
+	// was vacuously green. Construct the writer directly to keep headCap
+	// small and force the real cut. 3-byte CJK rune; headCap = 8: write 7
+	// ASCII bytes, then a rune whose first byte lands at exactly position 8 -
+	// snapForwardToRune must advance cut PAST room, and (case 1) the leftover
+	// slice must start at cut, not room.
+	w := &boundedOutputWriter{headCap: 8, tail: make([]byte, 0, 8), tailCap: 8}
+	cjk := []byte("中")         // 3 bytes
+	w.Write([]byte("1234567")) // 7 bytes
 	w.Write(append(append([]byte{}, cjk...), []byte("tail...")...))
 	out := w.String()
 	if !utf8.ValidString(out) {
@@ -110,6 +116,26 @@ func TestBoundedOutputWriterRuneSafeHeadCut(t *testing.T) {
 	}
 	if !strings.HasPrefix(out, "1234567") {
 		t.Errorf("head bytes lost, got %q", out)
+	}
+	// #1820 case 1 pin: the straddling rune's head-side bytes must NOT be
+	// duplicated into the tail (the old p[room:] duplicated p[room:cut]).
+	// With cut snapping past room, the tail starts after the full rune when
+	// it fits, or at a rune boundary otherwise; head never exceeds headCap+3.
+	if w.head.Len() > w.headCap+3 {
+		t.Errorf("head exceeded headCap+3 (rune snap bound): %d > %d", w.head.Len(), w.headCap+3)
+	}
+	// overflow must never be negative (the old room-cut addition could make
+	// it negative, disabling String's compaction branch entirely).
+	w.mu.Lock()
+	neg := w.overflow < 0
+	w.mu.Unlock()
+	if neg {
+		t.Error("overflow went negative - head-cut accounting is wrong")
+	}
+	// The rune either landed whole in the head (cut included it) or was
+	// dropped; the tail must never start with a continuation byte.
+	if len(w.tail) > 0 && w.tail[0]&0xC0 == 0x80 {
+		t.Error("tail starts with a bare continuation byte")
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes #1820 (all 3 cases — bounded output head-cut rune straddle).

1. **Case 1 (Med, triple error)**: `p = p[room:]` → `p = p[cut:]` — no more duplicated straddle bytes, negative overflow (which disabled String's compaction branch), or bare-continuation-byte tail. #1639 fixed this class at the other two cut points and missed the head.
2. **Case 2 (Med, vacuous test)**: the head-cut test now constructs the writer directly (headCap=8) so the boundary actually executes; additionally pins head ≤ headCap+3, overflow ≥ 0, tail never starts with a continuation byte.
3. **Case 3 (Low)**: String's tail-trim snap bytes now count into overflow (truthful marker).

## Verification evidence (review)
Isolated worktree: internal/tool **117.8s PASS** (p=1), Bounded subset 6/6. The bug was independently reproduced on two machines before fixing (overflow=-2, head.len=4098, tail="\xb8\xadXYZ").

Closes #1820

Generated with [ggcode](https://github.com/topcheer/ggcode)
