### PR TITLE
fix(tui): model panel visible rows track the current height (#1742 case 2)

### DIFF
--- a/internal/tui/model_panel.go
+++ b/internal/tui/model_panel.go
@@ -85,11 +85,14 @@ func (m Model) renderModelPanel() string {
 	// Dynamically set model list visible rows based on available panel height.
 	// Reserve ~8 lines for panel chrome (title, vendor/endpoint info, hints).
 	availRows := m.panelAvailableHeight() - 8
-	if availRows > maxVisibleModelRows {
-		maxVisibleModelRows = availRows
-	} else if availRows < 6 {
-		maxVisibleModelRows = 6
+	// #1742 case 2: the old grow-only form kept a stale large max when the
+	// terminal SHRANK (avail=12 vs max=32 matched neither branch) - the
+	// list rendered past the panel with no scroll hint. Track the current
+	// height with a floor instead.
+	if availRows < 6 {
+		availRows = 6
 	}
+	maxVisibleModelRows = availRows
 	source := "built-in"
 	if panel.remote {
 		source = m.t("panel.model.source.remote")


### PR DESCRIPTION
The grow-only form kept a stale large max when the terminal **SHRANK** (avail=12 vs max=32 matched neither branch) - the list rendered past the panel with no scroll hint. Track the current height with a floor of 6 instead.

(Case 1 - background knight events clearing loading - is verified **already-fixed in-tree by #1890**: START no longer touches loading and completion only writes the system message; not re-fixed.)

Isolated worktree (fresh origin/main): ModelPanel+Knight families PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)