### PR TITLE
fix(agent): verification debt partial repayment, code-actions grounding, bare-path scopes (#1784)

### DIFF
--- a/internal/agent/verif_debt_1784_test.go
+++ b/internal/agent/verif_debt_1784_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import "testing"
+
+// #1784 case 1: partial verification partially repays the debt.
+func Test1784PartialVerificationRepayment(t *testing.T) {
+	v := newVerificationDebtState()
+	// Edit two packages (2 debt each via multiple files or count).
+	for i := 0; i < 4; i++ {
+		v.recordToolCall("edit_file", `{"file_path":"/w/internal/agent/a`+string(rune('0'+i))+`.go","old_text":"a","new_text":"b"}`)
+		v.recordToolCall("edit_file", `{"file_path":"/w/internal/config/c`+string(rune('0'+i))+`.go","old_text":"a","new_text":"b"}`)
+	}
+	if v.debt != 8 {
+		t.Fatalf("debt after 8 edits = %d, want 8", v.debt)
+	}
+	// Verify ONLY internal/config: half the packages covered -> debt halves.
+	v.recordToolCall("run_command", `{"command":"# verify config only\ngo test ./internal/config/"}`)
+	if v.debt != 4 {
+		t.Fatalf("debt after half-scope verification = %d, want 4 (partial repayment)", v.debt)
+	}
+	// Whole-tree verification clears everything.
+	v.recordToolCall("run_command", `{"command":"# verify all\ngo test ./..."}`)
+	if v.debt != 0 {
+		t.Fatalf("debt after whole-tree verification = %d, want 0", v.debt)
+	}
+}
+
+// #1784 case 2: lsp_code_actions is grounding (read-only enumeration), not
+// verification - it must NOT reset debt.
+func Test1784CodeActionsIsGrounding(t *testing.T) {
+	v := newVerificationDebtState()
+	// Two edits: a full verification reset would give 0; grounding gives 1.
+	v.recordToolCall("edit_file", `{"file_path":"/w/x/y.go","old_text":"a","new_text":"b"}`)
+	v.recordToolCall("edit_file", `{"file_path":"/w/x/z.go","old_text":"a","new_text":"b"}`)
+	v.recordToolCall("lsp_code_actions", `{"path":"/w/x/y.go","start_line":1,"start_character":0,"end_line":1,"end_character":1}`)
+	if v.debt != 1 {
+		t.Fatalf("lsp_code_actions debt = %d, want 1 (grounding reduces by 1, not reset)", v.debt)
+	}
+	if v.lastAction != debtGrounding {
+		t.Fatalf("lsp_code_actions classified %v, want debtGrounding", v.lastAction)
+	}
+}
+
+// #1784 case 3: bare relative package paths count as scopes.
+func Test1784BarePathScopes(t *testing.T) {
+	scopes := parseGoPackageScopes("go test internal/agent/ internal/config/")
+	if len(scopes) != 2 || scopes[0] != "internal/agent" || scopes[1] != "internal/config" {
+		t.Fatalf("bare relative paths not collected: %v", scopes)
+	}
+	// ./ forms still work.
+	scopes = parseGoPackageScopes("go test ./internal/agent/")
+	if len(scopes) != 1 || scopes[0] != "internal/agent" {
+		t.Fatalf("./ forms broken: %v", scopes)
+	}
+	// Flags/urls/whole-tree yield nil or empty (whole-tree).
+	if s := parseGoPackageScopes("go build ./..."); s != nil {
+		t.Fatalf("./... should collapse elsewhere, got %v", s)
+	}
+	if s := parseGoPackageScopes("go test -run X https://example.com"); len(s) != 0 {
+		t.Fatalf("flags/urls must not be scopes, got %v", s)
+	}
+}

--- a/internal/agent/verification_debt.go
+++ b/internal/agent/verification_debt.go
@@ -93,9 +93,13 @@ var verificationDebtTools = map[string]debtAction{
 	"batch_replace":   debtModifying,
 
 	// Verifying: explicit validation
-	"run_command":      debtVerifying,
-	"lsp_diagnostics":  debtVerifying,
-	"lsp_code_actions": debtVerifying,
+	"run_command":     debtVerifying,
+	"lsp_diagnostics": debtVerifying,
+	// #1784 case 2: lsp_code_actions only ENUMERATES available quickfixes -
+	// it executes no check, has no pass/fail semantics, and is read-only
+	// like the other lsp_* members classified as grounding above. Counting
+	// it as verification reset the debt on a no-op call.
+	"lsp_code_actions": debtGrounding,
 }
 
 // classifyDebtAction determines the debt action for a tool call.
@@ -188,10 +192,11 @@ type verificationDebtState struct {
 	maxDebt        int // peak debt this run
 	warningsIssued int
 	lastAction     debtAction
+	editedPkgs     map[string]bool // packages of files modified since last full verification (#1784)
 }
 
 func newVerificationDebtState() *verificationDebtState {
-	return &verificationDebtState{}
+	return &verificationDebtState{editedPkgs: make(map[string]bool)}
 }
 
 func (v *verificationDebtState) reset() {
@@ -203,6 +208,7 @@ func (v *verificationDebtState) reset() {
 	v.maxDebt = 0
 	v.warningsIssued = 0
 	v.lastAction = debtNeutral
+	v.editedPkgs = make(map[string]bool)
 }
 
 // recordToolCall updates the debt state based on the tool call.
@@ -215,6 +221,11 @@ func (v *verificationDebtState) recordToolCall(toolName, args string) {
 	case debtModifying:
 		v.modifyCount++
 		v.debt++
+		for _, f := range extractFileHints(toolName, []byte(args)) {
+			if pkg := fileToPkgKey(f); pkg != "" {
+				v.editedPkgs[pkg] = true
+			}
+		}
 		if v.debt > v.maxDebt {
 			v.maxDebt = v.debt
 		}
@@ -228,9 +239,20 @@ func (v *verificationDebtState) recordToolCall(toolName, args string) {
 		}
 	case debtVerifying:
 		v.verifyCount++
-		// Verification resets debt entirely -- build/test results are the
-		// ground truth that validates prior modifications.
-		v.debt = 0
+		// #1784 case 1: verification used to reset the debt ENTIRELY even when
+		// it covered a fraction of the edited packages - edit 5 packages, run
+		// 1 package's tests, and the debt read zero. Partial repayment: scale
+		// the reset by the fraction of edited files whose package is covered
+		// by the verification's scopes. When scopes can't be determined, the
+		// verification is treated as full (the pre-#1784 behavior) - better
+		// to clear on an unmeasurable verification than to nag forever.
+		if v.debt > 0 {
+			if covered, total, ok := v.verificationCoverage(args); ok && total > 0 && covered < total {
+				v.debt = v.debt * (total - covered) / total
+			} else {
+				v.debt = 0
+			}
+		}
 	case debtNeutral:
 		// No change to debt
 	}
@@ -260,4 +282,100 @@ func (v *verificationDebtState) maybeWarn() string {
 			"assumption propagates through all subsequent edits.",
 		v.debt,
 	)
+}
+
+// verificationCoverage estimates what fraction of the edited surface a
+// verification call covers (#1784 case 1). It needs the edited-file set,
+// which the debt state starts tracking on every modifying call. Returns
+// (covered, total, ok); ok=false when scopes cannot be determined (treat as
+// full coverage).
+func (v *verificationDebtState) verificationCoverage(args string) (int, int, bool) {
+	scopes, ok := extractVerificationScopes(args)
+	if !ok {
+		return 0, 0, false
+	}
+	if len(v.editedPkgs) == 0 {
+		return 0, 0, false
+	}
+	total := len(v.editedPkgs)
+	covered := 0
+	for pkg := range v.editedPkgs {
+		// Normalize absolute editor paths to relative for matching.
+		rel := strings.TrimPrefix(pkg, "/")
+		for _, sc := range scopes {
+			if sc == "." || rel == sc || strings.HasPrefix(rel, sc+"/") ||
+				strings.HasSuffix(rel, "/"+sc) {
+				covered++
+				break
+			}
+		}
+	}
+	return covered, total, true
+}
+
+// fileToPkgKey maps an edited file path to a package directory key
+// (slash-separated, no leading ./) for coverage matching.
+func fileToPkgKey(f string) string {
+	f = strings.TrimPrefix(f, "./")
+	i := strings.LastIndexByte(f, '/')
+	if i < 0 {
+		return ""
+	}
+	return f[:i]
+}
+
+// extractVerificationScopes pulls the package paths a verification command
+// targets. Returns ok=false when the command is scope-free (whole-tree
+// build/vet) or the scopes cannot be parsed.
+func extractVerificationScopes(args string) ([]string, bool) {
+	cmd := eaExtractCommand(args)
+	if cmd == "" {
+		return nil, false
+	}
+	if !isVerificationCommand(cmd) {
+		return nil, false // classifyDebtAction already treats this as neutral
+	}
+	scopes := parseGoPackageScopes(cmd)
+	if scopes == nil {
+		// Whole-tree verification (bare go build/test/vet with no package
+		// args) or unparsable targets: treat as full coverage.
+		return []string{"."}, true
+	}
+	return scopes, true
+}
+
+// parseGoPackageScopes extracts package path arguments from a Go tool
+// invocation. Returns nil when no explicit package args are present
+// (whole-tree). Handles ./... forms, ./dir forms, AND bare internal
+// relative paths like "internal/agent/" (#1784 case 3 parity: Go accepts
+// them without ./).
+func parseGoPackageScopes(cmd string) []string {
+	fields := strings.Fields(cmd)
+	var scopes []string
+	for _, f := range fields {
+		f = strings.TrimSuffix(f, "...")
+		f = strings.TrimRight(f, "/")
+		if f == "" {
+			continue
+		}
+		if strings.HasPrefix(f, "./") || strings.HasPrefix(f, "../") {
+			scopes = append(scopes, strings.TrimPrefix(f, "./"))
+			continue
+		}
+		// Bare relative internal path: contains a slash, no colon (urls),
+		// starts with a letter, and isn't a flag.
+		if !strings.HasPrefix(f, "-") && strings.Contains(f, "/") &&
+			!strings.Contains(f, ":") && isASCIIPathStart(f) {
+			scopes = append(scopes, strings.TrimSuffix(f, "/"))
+		}
+	}
+	return scopes
+}
+
+func isASCIIPathStart(f string) bool {
+	if f == "" {
+		return false
+	}
+	c := f[0]
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }

--- a/internal/agent/verify_coverage_gap.go
+++ b/internal/agent/verify_coverage_gap.go
@@ -358,24 +358,40 @@ func coverageExtractVerifyScopes(cmd string) []string {
 
 	fields := strings.Fields(lc)
 
-	// Collect every ./-prefixed token as a scope.
+	// Collect every package-scope token (#1784 case 3: ./ prefix is
+	// OPTIONAL - "go test internal/agent/ internal/config/" is legal Go
+	// and previously produced zero scopes, degrading to ["."] where the
+	// last-edited-package heuristic marked only ONE package verified while
+	// the explicitly listed others got UNVERIFIED warnings).
 	var scopes []string
 	for _, f := range fields {
-		if !strings.HasPrefix(f, "./") {
-			continue
-		}
-		if strings.Contains(f, "...") {
+		if strings.Contains(f, "...") && (strings.HasPrefix(f, "./") || strings.HasPrefix(f, "../")) {
 			return []string{"ALL"}
+		}
+		isRel := strings.HasPrefix(f, "./") || strings.HasPrefix(f, "../")
+		if !isRel {
+			// Bare relative internal path: slash, no colon (urls), letter
+			// start, not a flag, and NOT a fully-qualified Go module path
+			// (first segment with a dot = domain-like: github.com/... stays
+			// unextractable per #354 - it can't be mapped to repo dirs).
+			if strings.HasPrefix(f, "-") || !strings.Contains(f, "/") ||
+				strings.Contains(f, ":") || !isASCIIPathStart(f) ||
+				firstSegHasDot(f) {
+				continue
+			}
+		}
+		if !isRel && !strings.HasSuffix(f, "/") && !strings.Contains(f, "/") {
+			continue
 		}
 		r := strings.TrimRight(f, "/")
 		r = strings.TrimPrefix(r, "./")
-		if r != "" {
+		if r != "" && r != "." {
 			// #550 B1: any NAMED directory is a real package scope — "./db/"
 			// previously failed the len>2 test and inflated to ALL, marking
 			// every edited package VERIFIED and masking the exact coverage
 			// gap this detector exists to surface.
 			scopes = append(scopes, r)
-		} else {
+		} else if isRel {
 			return []string{"ALL"} // "./" alone
 		}
 	}
@@ -524,4 +540,15 @@ func coveragePkgInScope(pkg, scope string) bool {
 		return strings.Contains("/"+tail+"/", "/"+head+"/")
 	}
 	return false
+}
+
+// firstSegHasDot reports whether the first path segment of f contains a dot
+// (domain-like: github.com, golang.org) - the signature of a fully-qualified
+// Go module path, which #354 keeps unextractable.
+func firstSegHasDot(f string) bool {
+	i := strings.IndexByte(f, '/')
+	if i < 0 {
+		return false
+	}
+	return strings.Contains(f[:i], ".")
 }


### PR DESCRIPTION
## Summary
Closes #1784 (all 3 cases — verification debt / coverage gap family).

1. **Case 1 (Med)**: verification repayment is now proportional to the edited-package coverage instead of a full reset; unmeasurable verifications (whole-tree / unparsable) still clear fully.
2. **Case 2 (Med)**: lsp_code_actions reclassified debtVerifying → debtGrounding (read-only enumeration, no pass/fail semantics); lsp_diagnostics stays verifying.
3. **Case 3 (Med)**: bare relative package paths ("go test internal/agent/") now count as scopes — no more bogus UNVERIFIED warnings for explicitly listed packages. Fully-qualified module paths stay unextractable per the #354 pin.

## Verification evidence (review)
Isolated worktree: internal/agent **22.8s PASS** (p=1). Pins: partial repayment (half-scope halves, whole-tree clears), grounding classification, bare-path collection + regressions. Two real traps caught during development: the existing #354 regression test caught my first draft collecting module paths (fixed with the domain-like first-segment exclusion), and debugging exposed that single-line `# cmd` strings are comment-stripped entirely — the tests use the production two-line envelope form.

Closes #1784

Generated with [ggcode](https://github.com/topcheer/ggcode)
