### PR TITLE
fix(util): reject WSL bash entry in Windows shell fallback (#1842)

### DIFF
--- a/internal/util/shell.go
+++ b/internal/util/shell.go
@@ -122,11 +122,29 @@ func detectShell(goos string, lookPath lookPathFunc, stat statFunc, getenv geten
 
 	for _, name := range []string{"bash.exe", "bash"} {
 		if path, err := lookPath(name); err == nil {
+			// #1842: LookPath("bash.exe") can hit C:\\Windows\\System32\\bash.exe
+			// - the WSL entry point, present on PATH whenever WSL is installed.
+			// It accepts -c but executes the command inside the LINUX
+			// subsystem, where Windows paths (C:\\...), cwd, git, and npm all
+			// break or misbehave - and the spec was mislabeled "git-bash". Skip
+			// System32 (case-insensitive) and keep searching; bare "bash" (a
+			// Git-Bash-on-PATH install) is unaffected because System32 never ships
+			// an extensionless bash.
+			if isWSLBashPath(path) {
+				continue
+			}
 			return ShellSpec{Path: path, Args: []string{"-c"}, Name: "git-bash"}, nil
 		}
 	}
 
-	return ShellSpec{}, fmt.Errorf("no supported shell found on Windows (expected PowerShell or Git Bash)")
+	return ShellSpec{}, fmt.Errorf("no supported shell found on Windows (expected PowerShell or Git Bash; note WSL bash is not a Windows shell)")
+}
+
+// isWSLBashPath reports whether a resolved bash path is the WSL entry
+// point under Windows System32 (case-insensitive).
+func isWSLBashPath(path string) bool {
+	p := strings.ReplaceAll(strings.ToLower(path), "\\", "/")
+	return strings.Contains(p, "/windows/system32/") || strings.HasSuffix(p, "/windows/system32/bash.exe")
 }
 
 func windowsGitBashCandidates(getenv getenvFunc) []string {

--- a/internal/util/shell_1842_test.go
+++ b/internal/util/shell_1842_test.go
@@ -1,0 +1,26 @@
+package util
+
+import "testing"
+
+// #1842: the System32 WSL entry point must be rejected so commands don't
+// silently execute inside the Linux subsystem.
+func Test1842WSLBashPathRejected(t *testing.T) {
+	for _, p := range []string{
+		`C:\Windows\System32\bash.exe`,
+		`C:\WINDOWS\system32\Bash.EXE`, // case-insensitive
+		`D:\Win10\Windows\System32\bash.exe`,
+	} {
+		if !isWSLBashPath(p) {
+			t.Errorf("WSL entry not rejected: %s", p)
+		}
+	}
+	for _, p := range []string{
+		`C:\Program Files\Git\bin\bash.exe`,
+		`C:\Users\me\scoop\apps\git\current\bin\bash.exe`,
+		`/usr/bin/bash`, // non-Windows passthrough
+	} {
+		if isWSLBashPath(p) {
+			t.Errorf("real bash wrongly rejected: %s", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1842 — the Windows shell fallback no longer accepts `C:\Windows\System32\bash.exe` (the WSL entry point): commands silently executed inside the Linux subsystem with broken Windows paths/cwd/git/npm, mislabeled "git-bash". The no-shell error now names WSL bash explicitly.

## Verification evidence (review)
Isolated worktree: internal/util **0.3s PASS** (p=1). Pins: three WSL entry spellings rejected (mixed case, non-C: drive); real Git Bash / scoop / non-Windows paths pass.

Closes #1842

Generated with [ggcode](https://github.com/topcheer/ggcode)
