### PR TITLE
fix(im,tui): feishu STT strict contract; clearing a limit stays session-level (#1743 cases 1+2)

### DIFF
--- a/internal/im/feishu_adapter.go
+++ b/internal/im/feishu_adapter.go
@@ -162,7 +162,19 @@ func resolveFeishuSTTConfig(global config.IMSTTConfig, extra map[string]interfac
 		if global.Provider == "" && global.BaseURL == "" && global.APIKey == "" {
 			return nil
 		}
+		// #1743 case 2: the sibling contract (discord/slack/qq) is a
+		// 3-field STRICT check on the resolved config - a global with
+		// url+key but no Model built a primary that ALWAYS failed at
+		// openai.go ("STT is not configured") on every voice message,
+		// instead of falling straight to local whisper.
+		if strings.TrimSpace(global.BaseURL) == "" || strings.TrimSpace(global.APIKey) == "" || strings.TrimSpace(global.Model) == "" {
+			return nil
+		}
 		return &global
+	}
+	// Same strictness for the extras-resolved shape.
+	if strings.TrimSpace(cfg.BaseURL) == "" || strings.TrimSpace(cfg.APIKey) == "" || strings.TrimSpace(cfg.Model) == "" {
+		return nil
 	}
 	return &cfg
 }

--- a/internal/tui/model_panel.go
+++ b/internal/tui/model_panel.go
@@ -383,6 +383,14 @@ func (m *Model) handleModelPanelEditKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 		} else if field == "max_tokens" {
 			mt = n
 		}
+		if n == 0 {
+			// #1743 case 1: clearing the field is a SESSION-level intent -
+			// persisting the zero wipes the endpoint default every future
+			// session inherits (and the running agent keeps the old value
+			// while the UI already reads the wiped config). Skip the
+			// endpoint write entirely on a clear.
+			return *m, nil
+		}
 		if err := m.config.SetEndpointModelLimits(vendor, endpoint, cw, mt); err != nil {
 			panel.message = fmt.Sprintf(m.t("panel.model.endpoint_save_failed"), err)
 			return *m, nil


### PR DESCRIPTION
Case 1 (Med): clearing a model-panel field persisted the zero to the **ENDPOINT config** - wiping the default every future session inherits, while the running agent kept the old value and the UI read the wiped config (a three-way split). A clear now stays session-level.

Case 2 (Med-Low): feishu's STT resolver returned a primary on url+key-no-model - a primary that **ALWAYS failed** at openai.go on every voice message instead of falling to local whisper. The sibling contract (discord/slack/qq: BaseURL+APIKey+Model all required) is now mirrored for both the global and extras shapes.

(Case 3 - the 10min bound vs first-run whisper download - needs a warm-up/probe design decision and stays for follow-up.)

Isolated worktree (fresh origin/main): Feishu/STT + ModelPanel families PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)