### PR TITLE
fix(im): twitch mention strip matches the gate's tokenization (#1747)

### DIFF
--- a/internal/im/twitch_adapter.go
+++ b/internal/im/twitch_adapter.go
@@ -638,11 +638,24 @@ func stripTwitchMention(text, nick string) string {
 	// cleanly ("@bot @bot double" -> "double").
 	ln := strings.ToLower(nick)
 	kept := make([]string, 0, len(strings.Fields(text)))
-	for _, tok := range strings.Fields(text) {
-		if strings.ToLower(strings.TrimPrefix(tok, "@")) == ln {
-			continue
+	for _, word := range strings.Fields(text) {
+		// #1747: the gate tokenizes with FieldsFunc (any non
+		// letter/digit/underscore is a separator), so "@ggcode," passed the
+		// gate but the Fields+TrimPrefix strip kept "ggcode," - the mention
+		// survived into the agent's prompt. Tokenize each word the SAME way
+		// and drop it when ANY of its tokens is the nick.
+		drop := false
+		for _, tok := range strings.FieldsFunc(strings.ToLower(word), func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
+		}) {
+			if tok == ln {
+				drop = true
+				break
+			}
 		}
-		kept = append(kept, tok)
+		if !drop {
+			kept = append(kept, word)
+		}
 	}
 	return strings.Join(kept, " ")
 }

--- a/internal/im/twitch_adapter_test.go
+++ b/internal/im/twitch_adapter_test.go
@@ -698,6 +698,9 @@ func TestTwitchMentionTokenBoundary(t *testing.T) {
 	if got := stripTwitchMention("ggcodex is broken", "ggcode"); got != "ggcodex is broken" {
 		t.Fatalf("mid-word substring must not be stripped, got %q", got)
 	}
+	if got := stripTwitchMention("@GGCode, fix it", "ggcode"); got != "fix it" {
+		t.Fatalf("#1747: trailing-punctuation mention must be stripped, got %q", got)
+	}
 	if got := stripTwitchMention("@GGCode do X", "ggcode"); got != "do X" {
 		t.Fatalf("case-insensitive mention must be stripped, got %q", got)
 	}


### PR DESCRIPTION
The gate tokenizes with FieldsFunc (any non letter/digit/underscore separates), so `@ggcode,` passed the gate - but the strip's Fields+TrimPrefix kept `ggcode,` and the mention **survived into the agent's prompt** (the most common chat form: comma right after the nick). The strip now tokenizes each word the same way and drops it when any token equals the nick. Trailing-comma case pinned alongside the existing case-insensitivity and mid-word guards.

(The per-connection PRIVMSG limiter deferred by #1565 stays deferred - noted in the issue.)

Isolated worktree (fresh origin/main): im package full PASS (36.1s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)