### PR TITLE
fix(agent): undo-blind charter scenario live; checkpoint tail-anchor regression (#1518)

### DIFF
--- a/internal/agent/agent_compact.go
+++ b/internal/agent/agent_compact.go
@@ -57,18 +57,23 @@ func (a *Agent) maybeFallbackCheckpoint() {
 		// #1437-A: the old skip made the safety net 100% DEAD CODE in its
 		// only target scenario - SummaryMsgID is non-empty ONLY after a
 		// successful summarization compaction, so 'summarization keeps
-		// failing' (this function's charter) always skipped. Fall back to
-		// the LAST message ID as the anchor: loadSession replays only what
-		// comes after the anchor, so anchoring at the tail is conservative
-		// and correct (the journal remains the full history).
-		if n := len(msgs); n > 0 {
-			fallbackID = msgs[n-1].ID
-		}
-		debug.Log("checkpoint", "fallback checkpoint: no summary message; anchoring at latest message")
+		// failing' (this function's charter) always skipped.
+		// #1518 case A: the interim fix anchored at the LAST message ID,
+		// but loadSession treats checkpoint_summary_msg_id as a summary
+		// SUBSTITUTE - it REPLACES everything before the anchor with that
+		// single message (store.go: ContextMessages = [summaryMsg]). With a
+		// real summary that one message carries the whole history forward;
+		// with a tail anchor it is one arbitrary message (possibly a bare
+		// tool_result whose paired tool_use is now dropped) and the extras
+		// are empty - resume context collapsed to ~1 message, WORSE than
+		// the no-checkpoint path which restores the last 200. In the exact
+		// scenario this net protects (long session, compaction never
+		// succeeded, crash), skip: no checkpoint -> loadSession takes the
+		// no-checkpoint path and restores the full tail window.
+		debug.Log("checkpoint", "fallback checkpoint: no summary message; skipping (tail anchor would replace history with one message)")
+		return
 	}
-	if fallbackID != "" {
-		fn(fallbackID, "", tokenCount)
-	}
+	fn(fallbackID, "", tokenCount)
 }
 
 // MicrocompactIfOverThreshold is kept as a no-op for API compatibility.

--- a/internal/agent/agent_memory.go
+++ b/internal/agent/agent_memory.go
@@ -124,6 +124,13 @@ func projectMemoryPathKey(key string) bool {
 	switch key {
 	case "path", "file_path", "file", "filename", "directory":
 		return true
+	case "files":
+		// #1518 case C: batch_replace's files[] is a BARE string array -
+		// with "files" rejected here every element was dropped and the
+		// whitelist entry for batch_replace was effectively dead (no project
+		// memory injection ever fired for it). Object-shaped files[] (multi_*
+		// tools) are unaffected - their nested "path" keys already qualify.
+		return true
 	default:
 		return false
 	}

--- a/internal/agent/unchecked_assert_check.go
+++ b/internal/agent/unchecked_assert_check.go
@@ -217,7 +217,12 @@ func assertExprAt(file *ast.File, pos token.Pos) string {
 
 // assertFingerprint returns a content-based key for delta comparison.
 // Uses the expression text so the same assertion at different line numbers
-// is recognized as the same issue.
+// is recognized as the same issue (pinned by
+// TestCheckUncheckedTypeAssert_LineShiftNotReflagged). #1518 case D1
+// proposed adding the line (two identical assertions in one function
+// share a fingerprint, so fix-one-add-another nets to zero), but that
+// directly contradicts the deliberate line-shift-stability design - kept
+// as a documented trade-off, not changed.
 func assertFingerprint(a uncheckedAssertInfo) string {
 	return a.expr
 }

--- a/internal/agent/undo_blind.go
+++ b/internal/agent/undo_blind.go
@@ -97,10 +97,20 @@ func (s *undoBlindState) recordToolCall(toolName string, argsJSON []byte) string
 		if fp != "" {
 			s.pendingUndoFiles[fp] = true
 		} else {
-			// For git operations without a specific file, we can't track precisely.
-			// Mark a generic sentinel. For git_reset/git_stash without file args,
-			// we track via a wildcard since we don't know which files changed.
-			if toolName == "git_reset" || toolName == "git_stash" || toolName == "git_checkout" {
+			// For git operations without a specific file, we can't track
+			// precisely. Mark a generic sentinel. For git_reset/git_stash/
+			// git_checkout/git_revert without file args, and for undo_edit
+			// (whose args carry only action/checkpoint_id/description - no path
+			// fields - so extraction is ALWAYS empty), we track via a wildcard
+			// since we can't know which files changed (#1518 case B: undo_edit
+			// is the charter's #1 scenario "undo_edit(file.go) ->
+			// edit_file(file.go) // BLIND" and was 100% dead: zero marks, zero
+			// warnings. git_revert joins the wildcard group too - bare revert
+			// has no path arg, and with a path arg it names a repo object, never
+			// a working-tree file, so it never matched file-level tracking
+			// either way).
+			if toolName == "git_reset" || toolName == "git_stash" || toolName == "git_checkout" ||
+				toolName == "git_revert" || toolName == "undo_edit" {
 				// Check if args contain specific file paths
 				if !undoBlindArgsHasFilePath(argsJSON) {
 					// Whole-tree revert — set a wildcard
@@ -117,8 +127,16 @@ func (s *undoBlindState) recordToolCall(toolName string, argsJSON []byte) string
 		if fp != "" {
 			delete(s.pendingUndoFiles, fp)
 		}
-		// For wildcard, any read clears it (conservative)
-		delete(s.pendingUndoFiles, "*")
+		// #1518 case D2: the wildcard used to be cleared by ANY read -
+		// including git_show/git_diff with no path arg (fp==""). The
+		// comment called that "conservative" but it is the opposite: an
+		// unrelated read silently disarmed the whole-tree guard, and the
+		// next blind edit went unwarned. Only a read that actually carries
+		// a file path (i.e. a real re-grounding of a specific file) clears
+		// the wildcard; the mutation-side warning still consumes it.
+		if fp != "" {
+			delete(s.pendingUndoFiles, "*")
+		}
 		return ""
 	}
 

--- a/internal/agent/undo_blind_1518_test.go
+++ b/internal/agent/undo_blind_1518_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import "testing"
+
+// #1518: pins for all four cases.
+func Test1518UndoBlindCharterScenario(t *testing.T) {
+	// Case B: undo_edit (pathless args) must set the wildcard; a following
+	// blind edit must fire the tree-wide warning.
+	s := newUndoBlindState()
+	if msg := s.recordToolCall("undo_edit", []byte(`{"action":"undo","checkpoint_id":"cp-1"}`)); msg != "" {
+		t.Fatalf("undo op must not warn: %q", msg)
+	}
+	if !s.pendingUndoFiles["*"] {
+		t.Fatal("undo_edit did not set the wildcard (charter scenario was 100% dead)")
+	}
+	msg := s.recordToolCall("edit_file", []byte(`{"file_path":"/w/a.go","old_text":"a","new_text":"b"}`))
+	if msg == "" {
+		t.Fatal("blind edit after undo_edit must warn")
+	}
+
+	// Case B2: git_revert (bare) joins the wildcard group.
+	s2 := newUndoBlindState()
+	s2.recordToolCall("git_revert", []byte(`{"revision":"abc123"}`))
+	if !s2.pendingUndoFiles["*"] {
+		t.Fatal("bare git_revert must set the wildcard")
+	}
+
+	// Case D2: an unrelated pathless read (git_show without path) must NOT
+	// disarm the wildcard.
+	s3 := newUndoBlindState()
+	s3.recordToolCall("undo_edit", []byte(`{"action":"undo"}`))
+	s3.recordToolCall("git_show", []byte(`{"revision":"HEAD"}`))
+	if !s3.pendingUndoFiles["*"] {
+		t.Fatal("pathless git_show must not clear the wildcard")
+	}
+	// But a real file-bearing read does.
+	s3.recordToolCall("read_file", []byte(`{"path":"/w/a.go"}`))
+	if s3.pendingUndoFiles["*"] {
+		t.Fatal("file-bearing read must clear the wildcard")
+	}
+}
+
+// #1518 case C: batch_replace's bare-string files[] must produce targets.
+func Test1518BatchReplaceBareFiles(t *testing.T) {
+	targets := projectMemoryTargetsForTool("batch_replace",
+		[]byte(`{"files":["/w/internal/x/a.go","/w/internal/y/b.go"],"pattern":"a","replacement":"b"}`))
+	found := map[string]bool{}
+	for _, tg := range targets {
+		found[tg] = true
+	}
+	if !found["/w/internal/x/a.go"] || !found["/w/internal/y/b.go"] {
+		t.Fatalf("bare files[] not collected: %v", targets)
+	}
+}
+
+// #1518 case D1: REJECTED after checking - the line-inclusion fix
+// contradicts the deliberate line-shift-stability design pinned by
+// TestCheckUncheckedTypeAssert_LineShiftNotReflagged. Documented as a
+// trade-off at the function; this pin asserts the kept behavior so the
+// decision is visible in tests.
+func Test1518AssertFingerprintLineStableByDesign(t *testing.T) {
+	a := uncheckedAssertInfo{line: 10, expr: "x.(string)"}
+	b := uncheckedAssertInfo{line: 30, expr: "x.(string)"}
+	if assertFingerprint(a) != assertFingerprint(b) {
+		t.Fatal("line-shift-stability is the deliberate design (see LineShiftNotReflagged)")
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1518 (A/B/C/D2 fixed; D1 rejected with evidence).

- **A (High)**: no-summary fallback no longer anchors at the tail message — loadSession treats the anchor as a summary SUBSTITUTE (context collapsed to ~1 message on resume, worse than the no-checkpoint path's 200). Skip instead.
- **B (High)**: undo_blind's #1 charter scenario (undo_edit → blind edit) was 100% dead — undo_edit joins the wildcard group (git_revert too, dead both ways).
- **C (Med)**: batch_replace's whitelist entry was dead — bare-string files[] now collected ("files" path-key added).
- **D2 (Low)**: pathless reads (git_show/git_diff) no longer disarm the wildcard — only file-bearing reads do.
- **D1**: rejected — the line-inclusion fix contradicts the deliberate line-shift-stability design pinned by `TestCheckUncheckedTypeAssert_LineShiftNotReflagged` (found when the existing pin failed). Documented trade-off + assert-pin instead.

## Verification evidence (review)
Isolated worktree: internal/agent **22.5s** + session 3.1s PASS (p=1). Pins: charter scenario end-to-end, bare revert wildcard, wildcard clear/clear-not semantics, batch_replace bare files[], kept fingerprint design.

Closes #1518

Generated with [ggcode](https://github.com/topcheer/ggcode)
