### PR TITLE
fix(agent): spawn/warp mutation channels join mixed-batch pre-exec guard (#1829)

### DIFF
--- a/internal/agent/parallel_guard_1829_test.go
+++ b/internal/agent/parallel_guard_1829_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/topcheer/ggcode/internal/provider"
+	"github.com/topcheer/ggcode/internal/tool"
+)
+
+// #1829: async/spawn mutation channels must skip pre-execution in mixed
+// batches - same stale-read guard family as #1590-A/#1607-A/#1649.
+func Test1829SpawnFamilySkipsPreExec(t *testing.T) {
+	a := &Agent{
+		tools:      tool.NewRegistry(),
+		speculator: newSpeculator(),
+	}
+	for _, name := range []string{
+		"spawn_agent", "teammate_spawn", "send_message", "swarm_task_create",
+		"a2a_send_task", "a2a_remote", "warp",
+	} {
+		calls := []provider.ToolCallDelta{
+			{ID: "1", Name: "read_file", Arguments: []byte(`{"path":"/tmp/test"}`)},
+			{ID: "2", Name: name, Arguments: []byte(`{}`)},
+		}
+		if got := a.preExecuteReadOnlyTools(context.Background(), calls); got != nil {
+			t.Errorf("%s in a mixed batch must skip pre-execution, got %d results", name, len(got))
+		}
+	}
+	// Pure read-only batches are unaffected by the new guards.
+	pure := []provider.ToolCallDelta{
+		{ID: "1", Name: "read_file", Arguments: []byte(`{"path":"/tmp/a"}`)},
+		{ID: "2", Name: "grep", Arguments: []byte(`{"pattern":"x"}`)},
+	}
+	// (Result count is environment-dependent; the invariant is no panic and
+	// the guard not firing on reads alone - a nil result is fine here.)
+	_ = a.preExecuteReadOnlyTools(context.Background(), pure)
+}

--- a/internal/agent/parallel_tools.go
+++ b/internal/agent/parallel_tools.go
@@ -126,6 +126,28 @@ func (a *Agent) preExecuteReadOnlyTools(ctx context.Context, toolCalls []provide
 		if tc.Name == "delegate" {
 			return nil
 		}
+		// #1829 case 1: spawn_agent/teammate_spawn (and their task-delivery
+		// companions send_message/swarm_task_create on tm-* targets) leak
+		// async tree mutations past every guard: the spawned agent inherits
+		// the parent WorkingDir with edit tools enabled, and can rewrite the
+		// tree while pre-executed reads sit unconsumed. Weaker than #1649's
+		// deterministic delegate (the first sub-agent edit needs an LLM
+		// round-trip, so the race window opens in seconds, not ms) but the
+		// failure shape is identical: stale pre-read content delivered
+		// unlabeled. FN = High-severity stale read / FP = lost parallelism
+		// - the guard's own asymmetry says block.
+		if tc.Name == "spawn_agent" || tc.Name == "teammate_spawn" ||
+			tc.Name == "send_message" || tc.Name == "swarm_task_create" ||
+			tc.Name == "a2a_send_task" || tc.Name == "a2a_remote" {
+			return nil
+		}
+		// #1829 case 2: warp's input/new_tab surfaces execute arbitrary shell
+		// (executeInput(args.Command)+send_key enter) in one call - a
+		// run_command-equivalent mutation channel the shell guard never
+		// covered. Narrow trigger (macOS + Warp), but same stale-read shape.
+		if tc.Name == "warp" {
+			return nil
+		}
 	}
 	for i, tc := range toolCalls {
 		if !speculativeSafeTools[tc.Name] {


### PR DESCRIPTION
## Summary
Closes #1829 (both cases).

1. **Case 1 (Med)**: spawn_agent/teammate_spawn + task-delivery companions (send_message/swarm_task_create/a2a_send_task/a2a_remote) join the mixed-batch pre-execution skip list — async tree mutations no longer race pre-executed reads.
2. **Case 2 (Low)**: warp joins the skip list (its input/new_tab surfaces execute arbitrary shell in one call).

Pure read-only and pure spawn batches are unaffected (guard fires only on MIXED batches).

## Verification evidence (review)
Isolated worktree: internal/agent **25.1s PASS** (p=1). Pins: all seven names return nil in a mixed batch; the six existing PreExecuteReadOnly family tests pass unchanged.

Closes #1829

Generated with [ggcode](https://github.com/topcheer/ggcode)
