### PR TITLE
fix(tui): slack auto-enable rides configMutationMsg; knight spinner tick kept (#1758 cases 1+2)

### DIFF
--- a/internal/tui/commands_slash_admin.go
+++ b/internal/tui/commands_slash_admin.go
@@ -795,12 +795,15 @@ func (m *Model) handleKnightCommand(parts []string) tea.Cmd {
 		}
 		m.chatWriteSystem(nextSystemID(), fmt.Sprintf("🌙 Knight running: %s", goal))
 		m.setLoading(true)
-		m.spinner.Start("Knight task")
+		// #1758 case 2: spinner.Start returns the FIRST tick Cmd - dropping
+		// it left the animation frozen on frame one until Stop (the elapsed
+		// timer kept running). Batch it with the task Cmd.
+		tick := m.spinner.Start("Knight task")
 		m.statusActivity = "Knight task"
 		m.statusToolName = "knight"
 		m.statusToolArg = util.Truncate(goal, 80)
 		m.statusToolCount = 1
-		return func() tea.Msg {
+		return tea.Batch(tick, func() tea.Msg {
 			// #1364: cancellable at shutdown instead of context.Background.
 			taskCtx, handle := m.registerKnightTask()
 			defer m.releaseKnightTask(handle)
@@ -810,7 +813,7 @@ func (m *Model) handleKnightCommand(parts []string) tea.Cmd {
 				Result: result,
 				Err:    err,
 			}
-		}
+		})
 	case "propose":
 		if len(parts) < 3 {
 			m.chatWriteSystem(nextSystemID(), "Usage: /knight propose <project-improvement-goal>")
@@ -823,12 +826,12 @@ func (m *Model) handleKnightCommand(parts []string) tea.Cmd {
 		}
 		m.chatWriteSystem(nextSystemID(), fmt.Sprintf("📝 Knight drafting project proposal: %s", goal))
 		m.setLoading(true)
-		m.spinner.Start("Knight proposal")
+		tick := m.spinner.Start("Knight proposal") // #1758 case 2: keep the tick
 		m.statusActivity = "Knight proposal"
 		m.statusToolName = "knight"
 		m.statusToolArg = util.Truncate(goal, 80)
 		m.statusToolCount = 1
-		return func() tea.Msg {
+		return tea.Batch(tick, func() tea.Msg {
 			// #1364: cancellable at shutdown instead of context.Background.
 			taskCtx, handle := m.registerKnightTask()
 			defer m.releaseKnightTask(handle)
@@ -839,7 +842,7 @@ func (m *Model) handleKnightCommand(parts []string) tea.Cmd {
 				Result:   result,
 				Err:      err,
 			}
-		}
+		})
 	case "proposals":
 		if len(parts) >= 4 {
 			action := strings.ToLower(parts[2])

--- a/internal/tui/slack_panel.go
+++ b/internal/tui/slack_panel.go
@@ -378,6 +378,10 @@ func (m *Model) createSlackAdapterCmd(spec string) tea.Cmd {
 						return rollback(err)
 					}
 					if err := m.startSlackAdapterIfNeeded(name); err != nil {
+						if errors.Is(err, errSlackEnableNeeded) {
+							// #1758 case 1: enable on the Update loop, then retry.
+							return m.slackEnableMutation(name, nil)
+						}
 						return rollback(err)
 					}
 					return slackBindResultMsg{message: m.t("panel.slack.message.added_bot", name)}
@@ -387,6 +391,40 @@ func (m *Model) createSlackAdapterCmd(spec string) tea.Cmd {
 				return slackBindResultMsg{err: err}
 			},
 		}
+	}
+}
+
+// errSlackEnableNeeded signals the auto-enable must run on the Update
+// loop via configMutationMsg (#1758 case 1).
+var errSlackEnableNeeded = errors.New("slack adapter needs enable-on-update-loop")
+
+// slackEnableMutation performs the auto-enable on the Update loop, then
+// restarts the adapter and continues with next.
+func (m *Model) slackEnableMutation(name string, next func(m *Model) tea.Msg) tea.Msg {
+	return configMutationMsg{
+		apply: func(m *Model) error {
+			if err := m.config.SetIMAdapterEnabled(name, true); err != nil {
+				return fmt.Errorf("enable %s: %w", name, err)
+			}
+			if m.imManager != nil {
+				_ = m.imManager.EnableBinding(name)
+			}
+			return nil
+		},
+		next: func(m *Model) tea.Cmd {
+			return func() tea.Msg {
+				if err := im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager); err != nil {
+					return slackBindResultMsg{err: err}
+				}
+				if next == nil {
+					return nil
+				}
+				return next(m)
+			}
+		},
+		fail: func(err error) tea.Msg {
+			return slackBindResultMsg{err: err}
+		},
 	}
 }
 
@@ -409,13 +447,11 @@ func (m *Model) startSlackAdapterIfNeeded(name string) error {
 		return errors.New(m.t("panel.slack.error.not_configured", name))
 	}
 	if !adapterCfg.Enabled {
-		// Auto-enable when user explicitly tries to bind from panel.
-		if err := m.config.SetIMAdapterEnabled(name, true); err != nil {
-			return fmt.Errorf("enable %s: %w", name, err)
-		}
-		if m.imManager != nil {
-			_ = m.imManager.EnableBinding(name)
-		}
+		// #1758 case 1: the auto-enable wrote the config map RIGHT HERE on
+		// the Cmd goroutine (the #1367 family - irc/matrix/mattermost all
+		// migrated; slack only moved AddIMAdapter and missed this). Signal
+		// the caller to route the enable through configMutationMsg.
+		return errSlackEnableNeeded
 	}
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformSlack)) {
 		return errors.New(m.t("panel.slack.error.not_slack_adapter", name))


### PR DESCRIPTION
Case 1 (Med): slack's `startSlackAdapterIfNeeded` auto-enable called `SetIMAdapterEnabled` (config map write + disk save) on the Cmd goroutine - the #1367 family's **last panel**: irc/matrix/mattermost all migrated (and slack itself moved `AddIMAdapter`) but missed this call. Sentinel + `slackEnableMutation`, the nostr/dingtalk pattern.

Case 2 (Med-Low): `/knight run|propose` discarded `spinner.Start`'s returned tick Cmd - the generation++ chain never armed and the frame char **froze on frame one** until Stop (elapsed timing kept running). Both sites now `tea.Batch` the tick with the task Cmd.

Isolated worktree (fresh origin/main): tui package full PASS (11.3s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)