### PR TITLE
fix(lsp): unsupported rename kinds surface to the agent (#1769)

### DIFF
--- a/internal/lsp/coverage_test.go
+++ b/internal/lsp/coverage_test.go
@@ -164,3 +164,24 @@ func TestServerLaunchEnv(t *testing.T) {
 		t.Error("expected non-nil env")
 	}
 }
+
+// TestParseWorkspaceEditUnsupportedKindNote pins #1769: a rename-kind
+// documentChange (no edits, top-level oldUri/newUri) drops into the
+// unsupported note WITH the file it involves, and the note is retrievable.
+func TestParseWorkspaceEditUnsupportedKindNote(t *testing.T) {
+	raw := []byte(`{"documentChanges":[{"kind":"rename","oldUri":"file:///a/old.go","newUri":"file:///a/new.go"}]}`)
+	edits := parseWorkspaceEdit(raw)
+	if len(edits) != 0 {
+		t.Fatalf("rename-kind change must not produce edits, got %d", len(edits))
+	}
+	note := TakeUnsupportedNote()
+	if note == "" {
+		t.Fatal("unsupported note must be recorded")
+	}
+	if !strings.Contains(note, "rename") || !strings.Contains(note, "new.go") {
+		t.Fatalf("note must name kind+uri, got %q", note)
+	}
+	if again := TakeUnsupportedNote(); again != "" {
+		t.Fatalf("note must clear on read, got %q", again)
+	}
+}

--- a/internal/lsp/operations.go
+++ b/internal/lsp/operations.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/topcheer/ggcode/internal/debug"
 )
@@ -52,7 +53,13 @@ type rawWorkspaceEdit struct {
 		TextDocument struct {
 			URI string `json:"uri"`
 		} `json:"textDocument"`
-		Edits []rawTextEdit `json:"edits"`
+		// #1769: rename/create/delete carry the TARGET uri at the TOP level
+		// (LSP WorkspaceEdit_structure) - without these the unsupported-kind
+		// note could not say which file was involved.
+		URI    string        `json:"uri"`
+		OldURI string        `json:"oldUri"`
+		NewURI string        `json:"newUri"`
+		Edits  []rawTextEdit `json:"edits"`
 	} `json:"documentChanges"`
 }
 
@@ -175,8 +182,11 @@ func parseWorkspaceEdit(raw json.RawMessage) []FileEdit {
 		// them so callers can report the unsupported change form instead
 		// of a bare "no edits returned".
 		if change.Kind != "" && change.Kind != "edit" && len(change.Edits) == 0 {
+			// #1769: prefer the top-level uri fields (rename uses oldUri/newUri,
+			// create/delete use uri) - TextDocument.URI is absent for these kinds.
+			target := firstNonEmptyStr(change.NewURI, change.OldURI, change.URI, change.TextDocument.URI)
 			unsupportedWorkspaceChangeKinds = append(unsupportedWorkspaceChangeKinds,
-				fmt.Sprintf("%s %s", change.Kind, uriToPath(change.TextDocument.URI)))
+				fmt.Sprintf("%s %s", change.Kind, uriToPath(target)))
 			continue
 		}
 		path := uriToPath(change.TextDocument.URI)
@@ -196,13 +206,38 @@ func parseWorkspaceEdit(raw json.RawMessage) []FileEdit {
 	for _, path := range paths {
 		out = append(out, FileEdit{Path: path, Edits: grouped[path]})
 	}
-	// #1588-B: make unsupported documentChanges kinds observable instead
-	// of the old silent skip (callers saw only "no edits returned").
+	// #1588-B/#1769: make unsupported documentChanges kinds observable.
+	// debug.Log alone was invisible to the agent (ring buffer; /debug only)
+	// - the TypeScript Move-to-file case still got the misleading bare
+	// "no edits returned". RenameEdits now surfaces the note to the caller.
 	if len(unsupportedWorkspaceChangeKinds) > 0 {
+		lastUnsupportedNote.Store(strings.Join(unsupportedWorkspaceChangeKinds, ", "))
 		debug.Log("lsp", "workspace edit dropped unsupported documentChanges kinds: %s",
 			strings.Join(unsupportedWorkspaceChangeKinds, ", "))
 	}
 	return out
+}
+
+// lastUnsupportedNote carries the most recent unsupported-kind note from
+// parseWorkspaceEdit to RenameEdits' caller (#1769) - single-flight per
+// call sequence, cleared on read.
+var lastUnsupportedNote atomic.Value
+
+// TakeUnsupportedNote returns and clears the note about unsupported
+// documentChanges kinds dropped by the last workspace-edit parse.
+func TakeUnsupportedNote() string {
+	v, _ := lastUnsupportedNote.Load().(string)
+	lastUnsupportedNote.Store("")
+	return v
+}
+
+func firstNonEmptyStr(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // editKey builds a dedup key for a TextEdit: range start/end positions plus

--- a/internal/tool/lsp.go
+++ b/internal/tool/lsp.go
@@ -726,6 +726,13 @@ func NewLSPTools(workingDir string, readSandbox, writeSandbox AllowedPathChecker
 					return "", err
 				}
 				if len(edits) == 0 {
+					// #1769: distinguish "server returned nothing" from
+					// "server returned an unsupported change form" (e.g.
+					// TypeScript Move-to-file) - the latter used to hide
+					// behind the same bare message.
+					if note := lsp.TakeUnsupportedNote(); note != "" {
+						return fmt.Sprintf("No rename edits returned - the server replied with an unsupported change form (%s). Manual refactoring or a different rename strategy is needed.", note), nil
+					}
 					return "No rename edits returned.", nil
 				}
 				return applyLSPFileEdits(edits, writeSandbox)


### PR DESCRIPTION
#1588's 'callers can report the unsupported change form' had no code behind it - a debug.Log into the ring buffer only, invisible unless the user opened /debug. The TypeScript Move-to-file case still got the misleading bare `No rename edits returned.`

- The note now carries the **top-level uri fields** (rename uses oldUri/newUri, create/delete use uri - TextDocument.URI is absent for these kinds, so even the log line named no file)
- `RenameEdits` distinguishes 'server returned nothing' from 'unsupported change form (<kind> <file>)'
- Pinned by `TestParseWorkspaceEditUnsupportedKindNote` (kind+uri in note, clear-on-read)

Isolated worktree (fresh origin/main): lsp package full PASS (6.5s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)