### PR TITLE
fix(agent): token-waste family joins the guidance budget; metering tracks post-shrink length (#1819)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2525,26 +2525,14 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// predictor of agent success.
 			if raHint := a.maybeWarnReasonAction(assistantText, toolCalls); raHint != "" {
 				debug.Log("agent", "Iteration %d: reasoning-action alignment verifier triggered", i+1)
-				a.contextManager.Add(provider.Message{
-					Role: "user",
-					Content: []provider.ContentBlock{{
-						Type: "text",
-						Text: raHint,
-					}},
-				})
+				a.injectGuidance(raHint)
 			}
 			// Mindless action detector: tracks consecutive tool-call steps
 			// with minimal reasoning text. When 4+ consecutive mindless steps
 			// occur, inject guidance to pause and reflect before continuing.
 			if a.mindlessAction.recordStep(len(assistantText), len(toolCalls) > 0) {
 				debug.Log("agent", "Iteration %d: mindless action detector triggered (streak=%d)", i+1, a.mindlessAction.streak)
-				a.contextManager.Add(provider.Message{
-					Role: "user",
-					Content: []provider.ContentBlock{{
-						Type: "text",
-						Text: mindlessActionWarning(a.mindlessAction.streak),
-					}},
-				})
+				a.injectGuidance(mindlessActionWarning(a.mindlessAction.streak))
 			}
 			// Trajectory health synthesizer (metacognitive layer): record
 			// per-iteration tool activity stats for composite health scoring.
@@ -2557,25 +2545,13 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// inject holistic guidance about accumulating risk.
 			if healthHint := a.maybeWarnTrajectoryHealth(); healthHint != "" {
 				debug.Log("agent", "Iteration %d: trajectory health synthesizer detected composite degradation", i+1)
-				a.contextManager.Add(provider.Message{
-					Role: "user",
-					Content: []provider.ContentBlock{{
-						Type: "text",
-						Text: healthHint,
-					}},
-				})
+				a.injectGuidance(healthHint)
 			}
 			// Token waste budget warning (AgentDiet arXiv:2509.23586):
 			// when aggregate waste ratio exceeds 40%, inject guidance.
 			if wasteHint := a.maybeWarnTokenWaste(); wasteHint != "" {
 				debug.Log("agent", "Iteration %d: token waste budget exceeded 40%% threshold", i+1)
-				a.contextManager.Add(provider.Message{
-					Role: "user",
-					Content: []provider.ContentBlock{{
-						Type: "text",
-						Text: wasteHint,
-					}},
-				})
+				a.injectGuidance(wasteHint)
 			}
 			// Foresight calibration (WorldEvolver arXiv:2606.30639): record
 			// the agent's predictions about upcoming tool outcomes BEFORE
@@ -2586,13 +2562,7 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// drifted from the original user request keywords (arXiv:2505.02709).
 			if gdHint := a.goalDriftCtx.checkDrift(i + 1); gdHint != "" {
 				debug.Log("agent", "Iteration %d: context-length goal drift detected", i+1)
-				a.contextManager.Add(provider.Message{
-					Role: "user",
-					Content: []provider.ContentBlock{{
-						Type: "text",
-						Text: gdHint,
-					}},
-				})
+				a.injectGuidance(gdHint)
 			}
 			if a.injectPendingInterruptions() {
 				continue
@@ -3792,7 +3762,9 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// metering the polluted string double-counts guidance tokens in both the
 			// waste numerator and denominator (#553 residual: the old capture point
 			// sat after the chain, so an original 1-token result was recorded as 19).
-			originalContentLen := len(result.Content)
+			// #1819 case 2: metering now uses measuredLen captured post-shrink /
+			// pre-hint at the applyToolResultGuidance call site; nothing needs the
+			// pre-detector-chain length anymore.
 			// Error classifier: immediate type-specific guidance on the first
 			// occurrence of each error category (AgentDebug-inspired).
 			// Fires before error-streak so the agent gets targeted feedback
@@ -4407,6 +4379,14 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// Both vision and non-vision paths share the same hint assembly logic.
 			// originalContentLen was captured BEFORE the detector chain above (#952,
 			// #553 residual) so detector guidance never inflates waste metering.
+			// #1819 case 2: capture the POST-shrink length here — compress/
+			// guardToolOutput may have rewritten Content between the original
+			// capture and this point, and metering must reflect what actually
+			// enters the context (the #952 "real context cost" intent cuts both
+			// ways: a 60KB→6KB compressed error log metered at 60KB inflates the
+			// waste ratio past the 40% threshold early; a truncated large read
+			// metered at full size dilutes it).
+			measuredLen := len(result.Content)
 			a.applyToolResultGuidance(&result, loopGuidance, searchParamHint, redundancyHint, equivHint, undoBlindHint)
 			if len(result.Images) > 0 && a.SupportsVision() {
 				imgs := make([]provider.ContentImage, len(result.Images))
@@ -4435,7 +4415,10 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			}
 			isRedundant := redundancyHint != ""
 			if a.tokenWasteBudget != nil {
-				a.tokenWasteBudget.recordToolResultLen(tc.Name, result.Content, originalContentLen, result.IsError, isRedundant, pathsRead)
+				// #1819 case 2: measuredLen (post-compress/guard, pre-hint) is the
+				// real context cost; originalContentLen stays available upstream for
+				// anything that needs the pre-shrink size.
+				a.tokenWasteBudget.recordToolResultLen(tc.Name, result.Content, measuredLen, result.IsError, isRedundant, pathsRead)
 			}
 			if err := ctx.Err(); err != nil {
 				// Context cancelled after completing some tools. Fill "cancelled"

--- a/internal/agent/guidance_budget_1819_test.go
+++ b/internal/agent/guidance_budget_1819_test.go
@@ -1,0 +1,51 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1819 case 1: the five detector hints route through injectGuidance so
+// the guidance budget's per-turn cap covers them. Source-level pin via
+// build + the behavioral test in guidance_budget_test.go; here we pin the
+// budget actually suppresses when exhausted (the property the direct-Add
+// path bypassed).
+func Test1819GuidanceRoutedThroughBudget(t *testing.T) {
+	// Pin the budget property the direct contextManager.Add path bypassed:
+	// after the advisory slots are drained, a further detector guidance
+	// (e.g. a [token-waste] warning) must be suppressed by allow().
+	var g guidanceBudget
+	g.reset()
+	sent := 0
+	for i := 0; i < guidanceBudgetPerTurn+2; i++ {
+		if g.allow("filler advisory message to drain the budget slot") {
+			sent++
+		}
+	}
+	if sent != guidanceBudgetPerTurn {
+		t.Fatalf("expected exactly %d advisories to pass, got %d", guidanceBudgetPerTurn, sent)
+	}
+	if g.allow("[token-waste] budget-exceeded message") {
+		t.Fatal("detector guidance after budget exhaustion must be suppressed")
+	}
+	if g.suppressed == 0 {
+		t.Fatal("suppression counter must advance")
+	}
+}
+
+func Test1819MeteringUsesPostShrinkLen(t *testing.T) {
+	shrunk := 6 * 1024
+	// The fix passes measuredLen (== len of shrunk content) as the
+	// override, so metered tokens must equal tokens of the shrunk length.
+	shrunkTokens := estimateTokensLen(strings.Repeat("a", shrunk), -1)
+	viaOverride := estimateTokensLen(strings.Repeat("a", shrunk), shrunk)
+	if viaOverride != shrunkTokens {
+		t.Fatalf("override with actual length must equal plain estimate: %d vs %d", viaOverride, shrunkTokens)
+	}
+	// Sanity: a stale pre-shrink override would meter 10x the real cost -
+	// exactly the inflation the fix removes.
+	stale := estimateTokensLen(strings.Repeat("a", shrunk), 60*1024)
+	if stale <= shrunkTokens {
+		t.Fatalf("stale override should meter higher: %d vs %d", stale, shrunkTokens)
+	}
+}

--- a/internal/agent/issue951_952_953_test.go
+++ b/internal/agent/issue951_952_953_test.go
@@ -204,24 +204,27 @@ func TestTokenWasteBudgetOriginalLenDrivesMetering(t *testing.T) {
 	}
 }
 
-// TestAgentGoOriginalContentLenCapturedBeforeDetectorChain pins the #952-1 fix
-// point: the capture must precede the first detector call in the chain, so
-// appended guidance never lands in the metering window.
+// TestAgentGoOriginalContentLenCapturedBeforeDetectorChain pins the
+// #952/#1819-case-2 metering capture contract: the length metered into
+// token-waste must be taken AFTER output shrink (compress/guard) and
+// BEFORE guidance hints are appended, so metering reflects the real
+// context cost in both directions (#553 inflation and #1819 shrink).
 func TestAgentGoOriginalContentLenCapturedBeforeDetectorChain(t *testing.T) {
 	src, err := os.ReadFile("agent.go")
 	if err != nil {
 		t.Fatalf("read agent.go: %v", err)
 	}
-	captureIdx := strings.Index(string(src), "originalContentLen := len(result.Content)")
-	classifierIdx := strings.Index(string(src), "a.errorClassifier.classifyToolError(tc.Name, result.Content)")
+	captureIdx := strings.Index(string(src), "measuredLen := len(result.Content)")
+	applyIdx := strings.Index(string(src), "a.applyToolResultGuidance(")
+	shrinkIdx := strings.LastIndex(string(src), "guardToolOutput(result.Content")
 	if captureIdx < 0 {
-		t.Fatal("originalContentLen capture not found in agent.go")
+		t.Fatal("measuredLen capture not found in agent.go")
 	}
-	if classifierIdx < 0 {
-		t.Fatal("detector-chain entry point (errorClassifier) not found in agent.go")
+	if applyIdx < 0 || captureIdx > applyIdx {
+		t.Fatalf("measuredLen capture (%d) must precede applyToolResultGuidance (%d)", captureIdx, applyIdx)
 	}
-	if captureIdx > classifierIdx {
-		t.Fatalf("originalContentLen capture (%d) must precede the detector chain entry (%d) — #553/#952 regression", captureIdx, classifierIdx)
+	if shrinkIdx < 0 || captureIdx < shrinkIdx {
+		t.Fatalf("measuredLen capture (%d) must follow the last shrink site (%d) - #1819 case 2", captureIdx, shrinkIdx)
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes #1819 (both cases).

1. **Case 1**: five detector hints (reason-action, mindless-action, trajectory-health, token-waste, goal-drift) that called contextManager.Add directly now route through injectGuidance — the #677/#1206 "ALL detectors" per-turn cap and byte-pool promises hold again.
2. **Case 2**: token-waste metering now uses measuredLen captured after compress/guard and before hint append — post-shrink real context cost, fixing both the 60KB→6KB inflation false-positive and the truncated-read dilution false-negative.

## Verification evidence (review)
Isolated worktree, rebased on latest main (770b54c1): internal/agent **25.4s PASS** (p=1). Pins: budget suppression property the direct-Add path bypassed; measuredLen == actual content estimate; stale 10x override sanity; the #952 source pin updated to assert the new capture contract (after last shrink, before hint apply).

Per team convention: merge only after this PR's CI is green.

Closes #1819

Generated with [ggcode](https://github.com/topcheer/ggcode)