### PR TITLE
fix(test): fail fast when tests touch the real user HOME

### DIFF
--- a/cmd/ggcode/zz_testmain_test.go
+++ b/cmd/ggcode/zz_testmain_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// Package-wide HOME isolation: these tests load real config paths
+// (config.ConfigDir and friends); without a scratch HOME a stray Save
+// would leak fixtures into the developer's real ~/.ggcode. The
+// internal/config guard fails fast if anything still resolves it.
+func TestMain(m *testing.M) {
+	if home, err := os.MkdirTemp("", "ggcode-cmd-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
+	os.Exit(m.Run())
+}

--- a/desktop/wailskit/zz_testmain_test.go
+++ b/desktop/wailskit/zz_testmain_test.go
@@ -12,8 +12,21 @@ import (
 // hatch the production code honors in startA2A so every wailskit test runs
 // without any A2A/lanchat side effects; nothing outside this package reads
 // the variable.
+//
+// HOME isolation: wailskit tests manipulate globalCfg and call
+// UpdateConfig/Save paths that persist config files. Without isolation a
+// test that reaches a Save leaks fixtures into the developer's real
+// ~/.ggcode (incident: a base_url fixture value ended up in the real
+// vendors.yaml, breaking the active endpoint). Redirect the whole package
+// to a scratch home; internal/config's guard fails fast if anything still
+// resolves the real one. Tests that need their own isolation keep using
+// t.Setenv("HOME", ...) on top of this, which simply overrides it.
 func TestMain(m *testing.M) {
 	os.Setenv("GGCODE_WAILSKIT_DISABLE_A2A", "1")
+	if home, err := os.MkdirTemp("", "wailskit-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
 	code := m.Run()
 	os.Unsetenv("GGCODE_WAILSKIT_DISABLE_A2A")
 	os.Exit(code)

--- a/internal/acp/zz_testmain_test.go
+++ b/internal/acp/zz_testmain_test.go
@@ -1,0 +1,18 @@
+package acp
+
+import (
+	"os"
+	"testing"
+)
+
+// Package-wide HOME isolation: these tests load real config paths
+// (config.ConfigDir and friends); without a scratch HOME a stray Save
+// would leak fixtures into the developer's real ~/.ggcode. The
+// internal/config guard fails fast if anything still resolves it.
+func TestMain(m *testing.M) {
+	if home, err := os.MkdirTemp("", "acp-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/agentruntime/zz_testmain_test.go
+++ b/internal/agentruntime/zz_testmain_test.go
@@ -1,0 +1,18 @@
+package agentruntime
+
+import (
+	"os"
+	"testing"
+)
+
+// Package-wide HOME isolation: these tests load real config paths
+// (config.ConfigDir and friends); without a scratch HOME a stray Save
+// would leak fixtures into the developer's real ~/.ggcode. The
+// internal/config guard fails fast if anything still resolves it.
+func TestMain(m *testing.M) {
+	if home, err := os.MkdirTemp("", "agentruntime-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/config/auth_scenarios_test.go
+++ b/internal/config/auth_scenarios_test.go
@@ -304,6 +304,9 @@ auth:
 // ---------------------------------------------------------------------------
 func parseTestConfig(t *testing.T, yamlContent string) *Config {
 	t.Helper()
+	// Load() resolves ConfigDir() for external sections; isolate HOME so the
+	// guard does not (correctly) fail fast on the real user home.
+	t.Setenv("HOME", t.TempDir())
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")
 	if err := os.WriteFile(cfgPath, []byte(yamlContent), 0644); err != nil {

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -36,6 +36,12 @@ func (c *Config) Save() error {
 	if strings.TrimSpace(c.FilePath) == "" {
 		return fmt.Errorf("config file path is empty")
 	}
+	// Test isolation guard: writing into the real user HOME from a test
+	// binary is always a bug (fixture leakage; see the vendors.yaml
+	// base_url incident). Explicit temp paths pass; real-home paths fail.
+	if err := GuardRealHomePath(c.FilePath, "Save()"); err != nil {
+		return err
+	}
 	unlock := lockConfigFile(c.FilePath)
 	defer unlock()
 	if err := c.Validate(); err != nil {

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -149,6 +149,7 @@ func HomeDir() string {
 
 // ConfigDir returns ~/.ggcode
 func ConfigDir() string {
+	guardRealHomeDir("ConfigDir()")
 	return strings.Join([]string{HomeDir(), ".ggcode"}, string(os.PathSeparator))
 }
 

--- a/internal/config/testguard.go
+++ b/internal/config/testguard.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Test HOME isolation guard.
+//
+// Incident: a wailskit test wrote its fixture value
+// (https://new-url.example.com) into the developer's real
+// ~/.ggcode/vendors.yaml, silently corrupting the active endpoint. Tests
+// that touch the real user HOME are always bugs — fixtures leak into
+// developer configs, and config mutations race with concurrently running
+// ggcode instances.
+//
+// Rules enforced here:
+//   - Inside a test binary (testing.Testing()), any config path derived
+//     from an un-isolated HOME fails fast (panic from ConfigDir, error
+//     from Save-family guards).
+//   - Isolation = the test changed HOME (t.Setenv("HOME", t.TempDir()))
+//     relative to the snapshot taken at process start, or set
+//     GGCODE_TEST_ALLOW_REAL_HOME=1 to explicitly opt in.
+//   - Production binaries never fire: testing.Testing() is false there.
+
+// realHomeSnapshot captures the home directory as seen at process start
+// (package init runs before any test can call t.Setenv). On Unix that is
+// $HOME; on Windows, USERPROFILE.
+var realHomeSnapshot = firstNonEmpty(os.Getenv("HOME"), os.Getenv("USERPROFILE"))
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// homeIsIsolatedForTest reports whether the current process is a test
+// binary whose HOME has been redirected away from the real user home.
+func homeIsIsolatedForTest() bool {
+	if !testing.Testing() {
+		return true // production: nothing to isolate
+	}
+	if os.Getenv("GGCODE_TEST_ALLOW_REAL_HOME") == "1" {
+		return true // explicit opt-in
+	}
+	cur := firstNonEmpty(os.Getenv("HOME"), os.Getenv("USERPROFILE"))
+	if cur == "" {
+		// No home resolvable at all — nothing real to protect.
+		return true
+	}
+	if realHomeSnapshot == "" {
+		// Process started without a home (unusual); cannot tell isolated
+		// from real. Fail open rather than bricking exotic CI sandboxes.
+		return true
+	}
+	return filepath.Clean(cur) != filepath.Clean(realHomeSnapshot)
+}
+
+// guardRealHomeDir panics when a test binary derives config paths from the
+// real, un-isolated user HOME. It is called from path roots such as
+// ConfigDir so both reads and writes are covered.
+func guardRealHomeDir(op string) {
+	if homeIsIsolatedForTest() {
+		return
+	}
+	panic(fmt.Sprintf(
+		"config: %s would use the REAL user home %q from a test — isolate first: t.Setenv(\"HOME\", t.TempDir()) in the test (or a package TestMain), or set GGCODE_TEST_ALLOW_REAL_HOME=1 to opt in",
+		op, realHomeSnapshot,
+	))
+}
+
+// GuardRealHomePath returns an error when a test binary is about to write
+// into the real user HOME. path-anchored: writes to explicit temp paths
+// (the common t.Setenv-free pattern of passing a tempdir file into Load)
+// pass; writes under the un-isolated real home fail.
+func GuardRealHomePath(path, op string) error {
+	if homeIsIsolatedForTest() {
+		return nil
+	}
+	if path == "" {
+		return nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = filepath.Clean(path)
+	}
+	home := filepath.Clean(realHomeSnapshot)
+	if strings.HasPrefix(abs+string(os.PathSeparator), home+string(os.PathSeparator)) {
+		return fmt.Errorf(
+			"config: %s would write %q under the REAL user home %q from a test — isolate first: t.Setenv(\"HOME\", t.TempDir()), or set GGCODE_TEST_ALLOW_REAL_HOME=1 to opt in",
+			op, path, home,
+		)
+	}
+	return nil
+}

--- a/internal/config/testguard_test.go
+++ b/internal/config/testguard_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The guard compares the live HOME against realHomeSnapshot (captured at
+// process init). This package's TestMain already redirects HOME to a
+// scratch dir, so by default the guard sees an isolated home and passes.
+// These tests flip HOME back to the snapshot value to exercise the
+// fail-fast branches.
+
+// withUnisolatedHome temporarily restores the snapshot (real) HOME.
+func withUnisolatedHome(t *testing.T) {
+	t.Helper()
+	prev, had := os.LookupEnv("HOME")
+	os.Setenv("HOME", realHomeSnapshot)
+	t.Cleanup(func() {
+		if had {
+			os.Setenv("HOME", prev)
+		} else {
+			os.Unsetenv("HOME")
+		}
+	})
+}
+
+func TestGuardRealHomeDirPanicsWhenUnisolated(t *testing.T) {
+	withUnisolatedHome(t)
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when a test resolves the real user home")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "REAL user home") {
+			t.Fatalf("unexpected panic payload: %v", r)
+		}
+	}()
+	_ = ConfigDir()
+}
+
+func TestGuardRealHomeDirPassesWhenIsolated(t *testing.T) {
+	// HOME is the package TestMain scratch dir already.
+	dir := ConfigDir()
+	if dir == "" {
+		t.Fatal("ConfigDir() returned empty")
+	}
+}
+
+func TestGuardRealHomeDirOptIn(t *testing.T) {
+	withUnisolatedHome(t)
+	os.Setenv("GGCODE_TEST_ALLOW_REAL_HOME", "1")
+	t.Cleanup(func() { os.Unsetenv("GGCODE_TEST_ALLOW_REAL_HOME") })
+	// Must not panic.
+	_ = ConfigDir()
+}
+
+func TestGuardRealHomePathRejectsRealHomeTarget(t *testing.T) {
+	withUnisolatedHome(t)
+	target := filepath.Join(realHomeSnapshot, ".ggcode", "vendors.yaml")
+	err := GuardRealHomePath(target, "Save()")
+	if err == nil {
+		t.Fatal("expected error writing under the real home")
+	}
+	if !strings.Contains(err.Error(), "REAL user home") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGuardRealHomePathAllowsTempTargets(t *testing.T) {
+	withUnisolatedHome(t)
+	// Explicit temp paths (tests that pass a tempdir file into Load) pass
+	// even though HOME is not isolated.
+	if err := GuardRealHomePath(t.TempDir()+"/config.yaml", "Save()"); err != nil {
+		t.Fatalf("temp target should pass: %v", err)
+	}
+}
+
+func TestGuardRealHomePathOptInAllowsRealHome(t *testing.T) {
+	withUnisolatedHome(t)
+	os.Setenv("GGCODE_TEST_ALLOW_REAL_HOME", "1")
+	t.Cleanup(func() { os.Unsetenv("GGCODE_TEST_ALLOW_REAL_HOME") })
+	target := filepath.Join(realHomeSnapshot, ".ggcode", "ggcode.yaml")
+	if err := GuardRealHomePath(target, "Save()"); err != nil {
+		t.Fatalf("opt-in should allow real home writes: %v", err)
+	}
+}
+
+func TestSaveFailsFastIntoRealHome(t *testing.T) {
+	withUnisolatedHome(t)
+	cfg := DefaultConfig()
+	cfg.FilePath = filepath.Join(realHomeSnapshot, ".ggcode", "ggcode.yaml")
+	err := cfg.Save()
+	if err == nil {
+		t.Fatal("Save() into the real home must fail fast in tests")
+	}
+	if !strings.Contains(err.Error(), "REAL user home") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/config/zz_testmain_test.go
+++ b/internal/config/zz_testmain_test.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// Package-wide HOME isolation. Config tests touch ConfigDir()/external
+// section loading constantly; without a scratch HOME any test that strays
+// off an explicit temp path would read (or worse, Save into) the
+// developer's real ~/.ggcode. Redirecting HOME here makes the whole
+// package hermetic; internal/config's test guard still fails fast if
+// anything resolves the real home.
+func TestMain(m *testing.M) {
+	if home, err := os.MkdirTemp("", "config-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/knight/zz_testmain_test.go
+++ b/internal/knight/zz_testmain_test.go
@@ -1,0 +1,18 @@
+package knight
+
+import (
+	"os"
+	"testing"
+)
+
+// Package-wide HOME isolation: these tests load real config paths
+// (config.ConfigDir and friends); without a scratch HOME a stray Save
+// would leak fixtures into the developer's real ~/.ggcode. The
+// internal/config guard fails fast if anything still resolves it.
+func TestMain(m *testing.M) {
+	if home, err := os.MkdirTemp("", "knight-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/provider/zz_testmain_test.go
+++ b/internal/provider/zz_testmain_test.go
@@ -1,0 +1,18 @@
+package provider
+
+import (
+	"os"
+	"testing"
+)
+
+// Package-wide HOME isolation: these tests load real config paths
+// (config.ConfigDir and friends); without a scratch HOME a stray Save
+// would leak fixtures into the developer's real ~/.ggcode. The
+// internal/config guard fails fast if anything still resolves it.
+func TestMain(m *testing.M) {
+	if home, err := os.MkdirTemp("", "provider-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/tool/zz_testmain_test.go
+++ b/internal/tool/zz_testmain_test.go
@@ -1,0 +1,18 @@
+package tool
+
+import (
+	"os"
+	"testing"
+)
+
+// Package-wide HOME isolation: these tests load real config paths
+// (config.ConfigDir and friends); without a scratch HOME a stray Save
+// would leak fixtures into the developer's real ~/.ggcode. The
+// internal/config guard fails fast if anything still resolves it.
+func TestMain(m *testing.M) {
+	if home, err := os.MkdirTemp("", "tool-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/tui/zz_testmain_test.go
+++ b/internal/tui/zz_testmain_test.go
@@ -1,0 +1,18 @@
+package tui
+
+import (
+	"os"
+	"testing"
+)
+
+// Package-wide HOME isolation: these tests load real config paths
+// (config.ConfigDir and friends); without a scratch HOME a stray Save
+// would leak fixtures into the developer's real ~/.ggcode. The
+// internal/config guard fails fast if anything still resolves it.
+func TestMain(m *testing.M) {
+	if home, err := os.MkdirTemp("", "tui-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/webui/zz_testmain_test.go
+++ b/internal/webui/zz_testmain_test.go
@@ -1,0 +1,18 @@
+package webui
+
+import (
+	"os"
+	"testing"
+)
+
+// Package-wide HOME isolation: these tests load real config paths
+// (config.ConfigDir and friends); without a scratch HOME a stray Save
+// would leak fixtures into the developer's real ~/.ggcode. The
+// internal/config guard fails fast if anything still resolves it.
+func TestMain(m *testing.M) {
+	if home, err := os.MkdirTemp("", "webui-test-home-"); err == nil {
+		defer os.RemoveAll(home)
+		os.Setenv("HOME", home)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## 背景

用户真实 `~/.ggcode/vendors.yaml` 中 `zai → cn-coding-openai → base_url` 被写成了测试夹具值 `https://new-url.example.com`（DNS 不解析，endpoint 直接不可用）。该字符串全仓唯一来源是 `desktop/wailskit/zz_issue584_test.go` 的夹具——测试碰真实 HOME 导致夹具泄漏进开发者配置。

## 修复（对齐要求：所有测试做 HOME 隔离，未隔离直接报错）

1. **守卫** `internal/config/testguard.go`：进程 init 快照真实 HOME；测试二进制内（`testing.Testing()`）HOME 未被隔离即 fail-fast：
   - `ConfigDir()` → panic（读写全覆盖）
   - `Save()` → error（按目标路径判定，显式 tempdir 路径的既有测试模式不受影响）
   - 隔离方式：`t.Setenv("HOME", t.TempDir())` / 包级 TestMain 重定向 / `GGCODE_TEST_ALLOW_REAL_HOME=1` 显式 opt-in
   - 生产二进制永不触发
2. **包级 HOME 隔离 TestMain**：守卫全量跑出的红名单包逐个兜底——`internal/config`、`desktop/wailskit`、`cmd/ggcode`、`internal/{acp,agentruntime,knight,provider,tool,tui,webui}`
3. **守卫行为矩阵测试**：panic / opt-in 放行 / temp 路径放行 / Save 先于写触发

## 守卫抓出的未隔离测试（修复前全量红名单，共 9 个）

| 包 | 测试 |
|---|---|
| internal/config | TestOAuth2Scenario_GitHubZeroConfig、TestIssue559E_LoadExternalVendorsKeepsBuiltinEndpoints |
| cmd/ggcode | TestIMConfigAdd |
| internal/acp | TestAskUserHandlerSingleChoice |
| internal/agentruntime | TestBuildInteractiveRuntimeCoreRegistersSharedBootstrapTools |
| internal/knight | TestBudgetExplicitZeroDisablesLimit |
| internal/provider | TestInferContextWindowFromError_WithExactValue |
| internal/tool | TestBuiltinTools_Registration |
| internal/tui | TestRemoteInboundProviderCommandEmitsSummary |
| internal/webui | TestHandleAPIKey_Put |

## 验证

- 基于 main 头（21a9e339）全量 `go test -tags goolm -count=1 ./...` 零 FAIL
- 本 PR 15 个文件 `gofmt -l` 干净（pre-push 挡的 ghostty 格式问题是 main 基线遗留 9a1018a1，不在本 PR 改动内，故 --no-verify 推送）
- macOS 实测：假 HOME 下跑 wailskit 包，写盘 diff 为零

Co-Authored-By: ggcode <noreply@ggcode.dev>