### PR TITLE
fix(agent): claim-verify window covers tail; fail:0 exempted; read_file culled (#1780 cases 1+2+3)

### DIFF
--- a/internal/agent/tool_claim_verify.go
+++ b/internal/agent/tool_claim_verify.go
@@ -27,6 +27,7 @@ package agent
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -73,11 +74,14 @@ var claimVerifyCommandTools = map[string]bool{
 // successful grep whose first matched line merely mentions the phrase (the
 // false-positive case) has match lines before/around it and will not match.
 var claimVerifyContentTools = map[string]bool{
-	"grep":            true,
-	"search_files":    true,
-	"glob":            true,
-	"read_file":       true,
-	"multi_file_read": true,
+	"grep":         true,
+	"search_files": true,
+	"glob":         true,
+	// #1780 case 3: read_file/multi_file_read REMOVED - their Content is
+	// ARBITRARY FILE DATA, and the meta-status prefixes ("no matches
+	// found"...) are emitted only by grep/search_files/glob. A file whose
+	// first line reads that text triggered a pure false positive (#1506
+	// widened the table without culling this side).
 	"code_search":     true,
 	"lsp_definition":  true,
 	"lsp_references":  true,
@@ -133,6 +137,30 @@ type claimVerifyPattern struct {
 	msg     string
 }
 
+// claimVerifyReCache compiles the "re:"-prefixed patterns once.
+var claimVerifyReCache = func() map[string]*regexp.Regexp {
+	m := make(map[string]*regexp.Regexp)
+	for _, cvp := range claimVerifyPatterns {
+		if strings.HasPrefix(cvp.pattern, "re:") {
+			if re, err := regexp.Compile(strings.TrimPrefix(cvp.pattern, "re:")); err == nil {
+				m[cvp.pattern] = re
+			}
+		}
+	}
+	return m
+}()
+
+// claimVerifyMatch dispatches plain-Contains vs "re:" regex patterns.
+func claimVerifyMatch(lower, pattern string) bool {
+	if strings.HasPrefix(pattern, "re:") {
+		if re := claimVerifyReCache[pattern]; re != nil {
+			return re.MatchString(lower)
+		}
+		return false
+	}
+	return strings.Contains(lower, pattern)
+}
+
 var claimVerifyPatterns = []claimVerifyPattern{
 	// Exit code failure masked in non-error output
 	{"exit code: 1", "Command exited with code 1 (failure). Do not claim this command succeeded."},
@@ -145,7 +173,13 @@ var claimVerifyPatterns = []claimVerifyPattern{
 	// Build/test failures
 	{"build failed", "Build failed. Do not claim the build passed."},
 	{"compilation failed", "Compilation failed. Do not claim compilation succeeded."},
-	{"fail:", "Test output contains FAIL. Do not claim all tests passed."},
+	// #1780 case 2: 'fail:' bare Contains hit COUNT lines like
+	// 'pass:120 fail:0' - a zero-failure summary was condemned as a
+	// failure (semantic reversal). The "re:" prefix marks regex patterns:
+	// require a non-zero digit after the colon/tab.
+	{"--- fail:", "Test output contains FAIL. Do not claim all tests passed."},
+	{"re:fail:[1-9]", "Test output contains FAIL. Do not claim all tests passed."},
+	{"re:fail\t[1-9]", "Test output contains FAIL. Do not claim all tests passed."},
 	{"fail\t", "Test output contains FAIL. Do not claim all tests passed."},
 	// File not found
 	{"no such file or directory", "File/path does not exist. Do not claim you accessed it."},
@@ -335,13 +369,18 @@ func (c *claimVerifyState) check(toolName, content string, isError bool, cmd str
 
 	// Command-execution tools: scan the command output for status patterns.
 	lower := strings.ToLower(content)
-	// Only scan the first 4000 chars to keep cost low on huge outputs.
-	if len(lower) > 4000 {
-		lower = lower[:4000]
+	// #1780 case 1: go test prints its FAIL summary at the END - a
+	// head-only window scrolled the failure signal out for exit-0-but-FAIL
+	// masking cases ('|| true', truncated pipes). Head AND tail, 4000 each.
+	if len(lower) > 8000 {
+		lower = lower[:4000] + "\n" + lower[len(lower)-4000:]
 	}
 
 	for _, cvp := range claimVerifyPatterns {
-		if strings.Contains(lower, cvp.pattern) {
+		// #1780 case 2: dispatch plain Contains vs "re:" regex patterns -
+		// 'fail:' bare Contains condemned count lines like 'pass:120
+		// fail:0'; the regex form requires a non-zero digit.
+		if claimVerifyMatch(lower, cvp.pattern) {
 			c.injections++
 			debug.Log("claim_verify", "misinterpretation risk detected: tool=%s pattern=%q", toolName, cvp.pattern)
 			return fmt.Sprintf("[Verify] %s Re-read the tool output carefully before proceeding.", cvp.msg)

--- a/internal/agent/tool_claim_verify_test.go
+++ b/internal/agent/tool_claim_verify_test.go
@@ -258,3 +258,30 @@ func TestClaimVerifyZeroResultPrefixVariants(t *testing.T) {
 		t.Errorf("mid-text mention must not trigger: %q", got)
 	}
 }
+
+// TestClaimVerifyWindowAndPatterns pins #1780 cases 1+2: the scan window
+// covers head AND tail (go test FAIL summaries live at the end), and
+// 'fail:0' count lines no longer trigger the failure-reversal note.
+func TestClaimVerifyWindowAndPatterns(t *testing.T) {
+	tail := strings.Repeat("x", 9000) + "--- FAIL: TestX"
+	if !claimVerifyMatch(strings.ToLower(tail), "--- fail:") {
+		t.Fatal("canonical form must still match")
+	}
+	if claimVerifyMatch("pass:120 fail:0 skipped:0", "re:fail:[1-9]") {
+		t.Fatal("fail:0 must NOT match the non-zero regex")
+	}
+	if !claimVerifyMatch("pass:12 fail:3 skipped:0", "re:fail:[1-9]") {
+		t.Fatal("fail:3 must match")
+	}
+	// THROUGH check() itself (#2035 review): the production path must see
+	// a tail-window failure and must not see a zero-count line.
+	s := newClaimVerifyState()
+	bigTail := strings.Repeat("x", 9000) + "\npass:12 fail:3 skipped:0"
+	if g := s.check("run_command", bigTail, false, "go test ./..."); g == "" {
+		t.Fatal("check() must fire on a tail-window fail count (head-only window would scroll it out)")
+	}
+	s2 := newClaimVerifyState()
+	if g := s2.check("run_command", "ok all\npass:120 fail:0 skipped:0", false, "go test ./..."); g != "" {
+		t.Fatalf("check() must NOT fire on fail:0, got %q", g)
+	}
+}


### PR DESCRIPTION
Case 1: go test prints its FAIL summary at the END - the head-only 4000-char window scrolled it out for exit-0-but-FAIL masking cases (`|| true`, truncated pipes). **Head+tail 4000 each**.

Case 2: `fail:` bare Contains hit COUNT lines like `pass:120 fail:0` - a zero-failure summary condemned as failure (semantic reversal). New `re:` regex pattern form requires a non-zero digit; the go-test canonical `--- FAIL:` form kept verbatim (#739 pin re-verified).

Case 3: `read_file`/`multi_file_read` leave the content-tools set - their Content is arbitrary file data and the meta-status prefixes are only ever emitted by grep/search_files/glob; a file whose first line reads 'No matches found.' triggered a pure false positive (#1506 widened without culling).

(Case 4 - git global-flag adjacency - verified already-fixed by #1695 case 2.)

Isolated worktree (fresh origin/main): agent package full PASS (24.5s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)