### PR TITLE
fix(plugin): MCP-disabled cold write path no longer caches failure as truth (#1782 cases 1+2)

### DIFF
--- a/internal/plugin/coverage_test.go
+++ b/internal/plugin/coverage_test.go
@@ -8,6 +8,13 @@ import (
 )
 
 func TestSetMCPDisabled(t *testing.T) {
+	// #1782 case 2: same isolation as the race test - never touch the
+	// developer's real ~/.ggcode.
+	t.Setenv("HOME", t.TempDir())
+	mcpDisabledMu.Lock()
+	mcpDisabledCache = nil
+	mcpDisabledCacheOK = false
+	mcpDisabledMu.Unlock()
 	// Should not panic; #1740 case 2 also returns nil error on success.
 	if err := SetMCPDisabled("test-server", true); err != nil {
 		t.Fatalf("disable should succeed: %v", err)

--- a/internal/plugin/mcp_disabled.go
+++ b/internal/plugin/mcp_disabled.go
@@ -90,20 +90,41 @@ func SetMCPDisabled(name string, disabled bool) error {
 		// Cold cache: hydrate from disk (lock already held; mirror the
 		// load path's decode without re-locking).
 		cached = map[string]bool{}
+		// #1782 case 1: the load path treats a read/decode failure as
+		// NOT cacheable (#781 - corrupt JSON is not truth), but this cold
+		// WRITE path unconditionally cached the empty map - the first
+		// touch after startup being a toggle under a failed read wrote
+		// the EMPTY set + the toggle to disk, silently reviving every
+		// previously disabled server on restart. Mirror the load path:
+		// only a missing file hydrates as legitimately empty; anything
+		// else leaves the cache un-OK so the next reader retries.
+		readFailed := false
 		if path, err := mcpDisabledPath(); err == nil {
-			if data, rerr := os.ReadFile(path); rerr == nil {
+			data, rerr := os.ReadFile(path)
+			switch {
+			case rerr == nil:
 				var names []string
 				if jerr := json.Unmarshal(data, &names); jerr == nil {
-					// #781: corrupt JSON is not cacheable as truth.
 					cached = make(map[string]bool, len(names))
 					for _, n := range names {
 						cached[n] = true
 					}
+				} else {
+					readFailed = true // corrupt JSON is not truth (#781)
 				}
+			case os.IsNotExist(rerr):
+				// Legitimately empty - cacheable.
+			default:
+				readFailed = true
 			}
 		}
 		mcpDisabledCache = cached
-		mcpDisabledCacheOK = true
+		if !readFailed {
+			mcpDisabledCacheOK = true
+		}
+		// On readFailed we proceed with the toggle-only in-memory delta
+		// below but the cache stays cold; the toggle STILL persists (see
+		// the names slice below seeded from `cached`).
 	} else {
 		// Warm cache: copy before mutating - readers index the cached
 		// map pointer outside their RLock (MCPDisabled), so in-place

--- a/internal/plugin/mcp_disabled_race_test.go
+++ b/internal/plugin/mcp_disabled_race_test.go
@@ -7,6 +7,14 @@ import (
 )
 
 func TestMCPDisabledConcurrentReadWrite(t *testing.T) {
+	// #1782 case 2: without this the 500 concurrent toggles below wrote
+	// the developer's REAL ~/.ggcode/disabled_mcp.json (a random subset as
+	// the final state) and leaked the package-global cache to other tests.
+	t.Setenv("HOME", t.TempDir())
+	mcpDisabledMu.Lock()
+	mcpDisabledCache = nil
+	mcpDisabledCacheOK = false
+	mcpDisabledMu.Unlock()
 	var wg sync.WaitGroup
 	// Concurrent readers
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
Case 1 (Med, #781 revival): the cold WRITE path unconditionally cached the empty map - the first touch after startup being a toggle under a failed read (IO error or corrupt JSON) wrote **EMPTY+toggle to disk, silently reviving every previously disabled server on restart**. The load path already refused to cache failure (#781); the cold write path now mirrors it - only a missing file hydrates as legitimately empty; IO/decode failure leaves the cache cold and persists only the toggle delta.

Case 2 (Med, test hygiene): the race test's 500 concurrent toggles wrote the **developer's real ~/.ggcode/disabled_mcp.json** (random subset as the final state) and leaked the package-global cache to other tests - both it and `TestSetMCPDisabled` now run under `HOME=t.TempDir()` with a reset cache. Verified with `-race`.

(#1783's write-side swallow is verified already-fixed by #1740 case 2.)

Isolated worktree (fresh origin/main): plugin package PASS + -race PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)