### PR TITLE
fix(tool): exit_worktree branch-delete gate; worktree-name path-component rejection; dirty-probe fail-safe; CJK scoring note (#1710)

### DIFF
--- a/internal/tool/web_search_quality.go
+++ b/internal/tool/web_search_quality.go
@@ -199,7 +199,13 @@ func isAlphaNumByte(b byte) bool {
 
 func scoreResult(queryTerms []string, res searchResult) int {
 	if len(queryTerms) == 0 {
-		return 50 // neutral score when no query terms
+		// #1710 case 4: a CJK query (or any non-[a-z0-9+#.] script) yields
+		// ZERO tokens here - every result scores a flat 50 and the sort
+		// degenerates to the upstream (DDG) order. That is still a sane
+		// fallback (the upstream ranker saw the full query we cannot
+		// tokenize), so keep 50, but log it once per call site via the
+		// caller's debug path - silent degeneration hid the gap for months.
+		return 50 // neutral score when no query terms (incl. CJK queries)
 	}
 
 	titleLower := strings.ToLower(res.Title)

--- a/internal/tool/worktree_tools.go
+++ b/internal/tool/worktree_tools.go
@@ -8,8 +8,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/topcheer/ggcode/internal/debug"
 )
 
 // EnterWorktree creates a new git worktree for isolated work.
@@ -62,6 +65,12 @@ func (t EnterWorktree) Execute(ctx context.Context, input json.RawMessage) (Resu
 		if !isWorktreeNameChar(c) {
 			return Result{IsError: true, Content: fmt.Sprintf("invalid worktree name %q: only letters, digits, dots, underscores, and dashes allowed", name)}, nil
 		}
+	}
+	// #1710 case 5: "."/".." pass the character check (dot allowed) but are
+	// path components - filepath.Join(worktreesDir, "..") escapes the
+	// worktrees directory.
+	if !isSafeWorktreeName(name) {
+		return Result{IsError: true, Content: fmt.Sprintf("invalid worktree name %q: must not be a path component ('.', '..') or contain separators", name)}, nil
 	}
 
 	// Find git root
@@ -230,10 +239,37 @@ func (t ExitWorktree) Execute(ctx context.Context, input json.RawMessage) (Resul
 
 	// Optionally delete the branch
 	if branchName != "" && branchName != "main" && branchName != "master" {
-		delCmd := exec.CommandContext(ctx, "git", "branch", "-D", branchName)
-		delCmd.Dir = mainRepoRoot
-		delCmd.Env = append(os.Environ(), "GIT_PAGER=cat")
-		_ = delCmd.Run() // best effort
+		// #1710 case 1: gate the force-delete on unmerged/unpushed commits.
+		// The old code ran `git branch -D` unconditionally and swallowed the
+		// error, so committed-but-unpushed work was destroyed with ZERO gate -
+		// strictly weaker protection than the dirty-files gate above, for data
+		// that is worth strictly more.
+		unmergedCmd := exec.CommandContext(ctx, "git", "rev-list", "--count", branchName, "--not", "HEAD")
+		unpushedCmd := exec.CommandContext(ctx, "git", "rev-list", "--count", branchName, "--not", "--remotes")
+		unmergedCmd.Dir = mainRepoRoot
+		unpushedCmd.Dir = mainRepoRoot
+		unmergedCmd.Env = append(os.Environ(), "GIT_PAGER=cat")
+		unpushedCmd.Env = append(os.Environ(), "GIT_PAGER=cat")
+		unmergedOut, uerr1 := unmergedCmd.Output()
+		unpushedOut, uerr2 := unpushedCmd.Output()
+		unmerged, _ := strconv.Atoi(strings.TrimSpace(string(unmergedOut)))
+		unpushed, _ := strconv.Atoi(strings.TrimSpace(string(unpushedOut)))
+		// If the safety probes themselves fail, do NOT force-delete (fail
+		// closed); keep the branch and tell the user.
+		if uerr1 == nil && uerr2 == nil && (unmerged > 0 || unpushed > 0) && !args.DiscardChanges {
+			return Result{
+				Content:             fmt.Sprintf("worktree removed, but branch %s has %d unmerged and %d unpushed commit(s); branch kept. Set discard_changes=true to delete the branch too, or push/merge it first (recoverable via reflog for ~30 days after -D).", branchName, unmerged, unpushed),
+				SuggestedWorkingDir: mainRepoRoot,
+			}, nil
+		}
+		if uerr1 != nil || uerr2 != nil {
+			debug.Log("tool.worktree", "branch safety probe failed for %s (unmerged err=%v unpushed err=%v); keeping branch", branchName, uerr1, uerr2)
+		} else {
+			delCmd := exec.CommandContext(ctx, "git", "branch", "-D", branchName)
+			delCmd.Dir = mainRepoRoot
+			delCmd.Env = append(os.Environ(), "GIT_PAGER=cat")
+			_ = delCmd.Run() // best effort
+		}
 	}
 
 	return Result{
@@ -245,6 +281,16 @@ func (t ExitWorktree) Execute(ctx context.Context, input json.RawMessage) (Resul
 // isWorktreeNameChar returns true for characters allowed in worktree names.
 func isWorktreeNameChar(c rune) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.'
+}
+
+// isSafeWorktreeName rejects names that are themselves path components
+// (#1710 case 5): "." and ".." pass isWorktreeNameChar (dot allowed) and
+// then escape the worktrees directory through filepath.Join.
+func isSafeWorktreeName(name string) bool {
+	if name == "." || name == ".." || strings.Contains(name, "/") || strings.Contains(name, string(os.PathSeparator)) {
+		return false
+	}
+	return true
 }
 
 // findGitRoot finds the git repository root from a directory.
@@ -423,6 +469,13 @@ func checkWorktreeDirty(ctx context.Context, entries []worktreeEntry) {
 		stCmd.Env = append(os.Environ(), "GIT_PAGER=cat")
 		stOut, stErr := stCmd.Output()
 		if stErr == nil && len(strings.TrimSpace(string(stOut))) > 0 {
+			entries[i].Dirty = true
+		}
+		// #1710 case 5: a failed probe used to leave Dirty=false - a
+		// worktree whose status could not be read rendered "clean". Fail
+		// safe: mark dirty (unknown state must not look safe).
+		if stErr != nil {
+			debug.Log("tool.worktree", "dirty probe failed for %s: %v; marking dirty (fail-safe)", entries[i].Path, stErr)
 			entries[i].Dirty = true
 		}
 	}

--- a/internal/tool/worktree_tools_test.go
+++ b/internal/tool/worktree_tools_test.go
@@ -622,3 +622,19 @@ func TestExitWorktreeRejectsInvalidAction(t *testing.T) {
 		}
 	}
 }
+
+// #1710 case 5: "." and ".." pass the per-character check (dot allowed) but
+// are path components - they must be rejected by the name gate, not left to
+// git's illegal-branch-name error as the only backstop.
+func Test1710WorktreeNameRejectsPathComponents(t *testing.T) {
+	for _, bad := range []string{".", ".."} {
+		if isSafeWorktreeName(bad) {
+			t.Errorf("name %q must be rejected as a path component", bad)
+		}
+	}
+	for _, ok := range []string{"fix-1710", "wt_dotted.name", "a"} {
+		if !isSafeWorktreeName(ok) {
+			t.Errorf("name %q should be accepted", ok)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1710 (remaining cases 1, 4, 5; cases 2+3 already landed by parallel fixes).

- **Case 1 (Med)**: exit_worktree(remove) gated  behind two rev-list probes (unmerged into HEAD / unpushed vs --remotes) + discard_changes; probe failure fails closed (branch kept). Unpushed commits previously had ZERO gate — weaker than the dirty-files gate for data worth more.
- **Case 5 (Low)**: worktree names "."/".." rejected at the gate (path-component escape via filepath.Join); checkWorktreeDirty marks unknown state dirty (fail-safe) instead of rendering "clean".
- **Case 4 (Low)**: CJK zero-token flat-50 degeneration documented at the neutral-score return.

## Verification evidence (review)
Isolated worktree on latest main: internal/tool **54.4s PASS** (p=1). Pin: ./.. rejected by isSafeWorktreeName, dotted names still accepted.

Per team convention: merge only after this PR's CI is green.

Closes #1710

Generated with [ggcode](https://github.com/topcheer/ggcode)