### PR TITLE
fix(agent): write-integrity reads the file back from disk (#1786 case 2)

### DIFF
--- a/internal/agent/write_integrity.go
+++ b/internal/agent/write_integrity.go
@@ -5,6 +5,7 @@ import (
 	"go/parser"
 	"go/scanner"
 	"go/token"
+	"os"
 	"strings"
 
 	"github.com/topcheer/ggcode/internal/debug"
@@ -34,9 +35,30 @@ const (
 // checkWriteIntegrity validates the content of a file after a write/edit.
 // Delegates to the Check Registry for parallel, language-aware execution.
 func checkWriteIntegrity(filePath, oldContent, newContent string) string {
+	// #1786 case 2: the "Post-write integrity check: validate file
+	// content" comments promised a DISK read-back; the checks validated
+	// the intended strings only - a partial write, a failed atomic
+	// rename, or a post-write gofmt reformat never surfaced. Read the
+	// file back once and compare.
+	if disk, rerr := osReadFileForIntegrity(filePath); rerr == nil {
+		if string(disk) != newContent {
+			trimmed := string(disk)
+			if len(trimmed) > 120 {
+				trimmed = trimmed[:120] + "..."
+			}
+			return fmt.Sprintf("post-write mismatch: file on disk differs from what was written (starts %q) - the write may be partial, or something (formatter/other agent) rewrote it immediately; re-read before further edits", trimmed)
+		}
+	}
 	ctx := newCheckContext(filePath, oldContent, newContent)
 	warnings := runChecksParallel(ctx)
 	return formatWarnings(warnings)
+}
+
+// osReadFileForIntegrity isolates the disk read for the mismatch check
+// (kept separate so tests can reason about failure semantics: an
+// unreadable file skips the read-back rather than failing the tool).
+func osReadFileForIntegrity(path string) ([]byte, error) {
+	return os.ReadFile(path)
 }
 
 // registerAllChecks registers all post-write integrity checks with their

--- a/internal/agent/write_integrity_test.go
+++ b/internal/agent/write_integrity_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -222,5 +224,28 @@ func (a *AnotherImpl) Method() {}
 	// detector is loaded by checking it doesn't crash
 	if strings.Contains(warning, "internal error") {
 		t.Fatalf("interface-design check caused internal error (may not be properly registered): %s", warning)
+	}
+}
+
+// TestCheckWriteIntegrityReadBack pins #1786 case 2: the promised disk
+// read-back actually happens - a file whose on-disk content differs from
+// what was written (partial write / immediate rewrite) surfaces a mismatch
+// warning; a matching file does not.
+func TestCheckWriteIntegrityReadBack(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(p, []byte("actual-on-disk"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if w := checkWriteIntegrity(p, "old", "intended-new"); w == "" {
+		t.Fatal("disk != written must surface a mismatch warning")
+	}
+	if err := os.WriteFile(p, []byte("intended-new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Matching file: no mismatch warning (other checks may still fire; for
+	// plain text they don't).
+	if w := checkWriteIntegrity(p, "old", "intended-new"); w != "" {
+		t.Fatalf("matching disk content must not warn, got %q", w)
 	}
 }


### PR DESCRIPTION
The 'Post-write integrity check: validate file content' comments promised a **disk read-back**; the checks validated the intended strings only - a partial write, a failed atomic rename, or a post-write gofmt reformat never surfaced. One `ReadFile`+compare now runs before the static checks; a mismatch names the divergence and tells the agent to re-read before further edits.

(Case 3 - sse transport normalization - is verified already-fixed by #1659 case 2; case 1, the diffConfirm TOCTOU baseline, stays for a dedicated pass.)

Isolated worktree (fresh origin/main): agent package full PASS (23.3s) + read-back pin (mismatch warns, match silent), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)