### PR TITLE
fix(agentruntime): StartShare stops the previous share; upgradeMgr read stays locked (#1787)

### DIFF
--- a/internal/agentruntime/tunnel_host.go
+++ b/internal/agentruntime/tunnel_host.go
@@ -252,9 +252,31 @@ func (h *TunnelHost) StartShare(cfg ShareConfig) (*ShareResult, error) {
 
 	// 7. Store ref for cleanup + create P2P upgrade manager.
 	h.mu.Lock()
+	// #1787 case 1: a second StartShare used to overwrite the old
+	// activeShare/upgradeMgr references WITHOUT stopping them - the old
+	// manager's PeerConnections and negotiation goroutines leaked for the
+	// process lifetime (#1501 documented exactly this for the Close path;
+	// the StartShare overwrite path never got the fix). Stop the previous
+	// share first, mirroring StopShare's teardown order.
+	if oldRef := h.activeShare; oldRef != nil {
+		h.activeShare = nil
+		oldMgr := h.upgradeMgr
+		h.upgradeMgr = nil
+		h.mu.Unlock()
+		if oldMgr != nil {
+			oldMgr.Stop()
+		}
+		if oldRef.broker != nil {
+			oldRef.broker.Stop()
+		}
+		h.DetachOnlineBroker()
+		h.mu.Lock()
+	}
 	h.activeShare = &tunnelSessionRef{session: sess, broker: broker}
+	var p2pMgr *tunnel.UpgradeManager
 	if h.p2pFactory != nil && h.p2pConfig.Enabled {
-		h.upgradeMgr = tunnel.NewUpgradeManager(broker, h.p2pFactory, h.p2pConfig)
+		p2pMgr = tunnel.NewUpgradeManager(broker, h.p2pFactory, h.p2pConfig)
+		h.upgradeMgr = p2pMgr // #1787 case 2: keep the read INSIDE the lock
 	}
 	h.mu.Unlock()
 
@@ -263,7 +285,6 @@ func (h *TunnelHost) StartShare(cfg ShareConfig) (*ShareResult, error) {
 	// Starting the upgrade before the mobile client has joined means the
 	// SDP offer is sent to an empty relay room and silently discarded.
 	onConnected := cfg.OnConnected
-	p2pMgr := h.upgradeMgr
 	broker.OnRelayConnected(func(info tunnel.RelayConnectedState) {
 		if onConnected != nil {
 			onConnected(info)


### PR DESCRIPTION
Case 1 (Med, #1501 same shape): a second StartShare overwrote the old `activeShare`/`upgradeMgr` references **without stopping them** - the old manager's PeerConnections and negotiation goroutines leaked for the process lifetime. #1501 documented exactly this for the Close path; the StartShare overwrite path never got the fix (another half-covered fix). The previous share now stops first, mirroring StopShare's teardown order.

Case 2 (Low-Med): `p2pMgr` was read **outside the lock** right after it - a concurrent StopShare/Close (which nils under the lock) raced it; reading nil silently disabled P2P upgrade. The local now carries out of the critical section.

Isolated worktree (fresh origin/main): agentruntime package full PASS (13.0s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)