### PR TITLE
fix(agent): windowed reads no longer mark a file fully read (#1782)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3271,13 +3271,23 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 				// false 'over-mining' hit. The hint fires once per call on
 				// the LAST path only.
 				readPathsLen := len(extractReadFilePaths(tc.Name, tc.Arguments))
+				// #1782 case 3: a windowed read (read_file with offset/limit)
+				// must not mark the file FULLY read. recordRead had no window
+				// notion, so `read_file {offset:2000, limit:50}` set
+				// filesRead=true and a follow-up edit outside the window
+				// passed the unread guard silently (#463 fixed the redundant
+				// read side only - the fix that reached exactly one consumer).
+				// The other three recorders below are disk-based (they stat or
+				// hash the file itself, not the returned slice), so a windowed
+				// read is equivalent to a full read for them - unchanged.
+				hasWindow := readArgsHaveWindow(tc.Arguments)
 				for pi, p := range extractReadFilePaths(tc.Name, tc.Arguments) {
-					a.unreadEdit.recordRead(p)
+					a.unreadEdit.recordReadWindow(p, hasWindow)
 					a.tunnelVision.recordFile(p)
 					a.editFailRecovery.recordRead(p)
 					a.fileFreshness.recordRead(p)
 					a.readHash.recordReadHash(p)
-					if hint := a.redundantRead.checkRedundantRead(p, readArgsHaveWindow(tc.Arguments)); hint != "" {
+					if hint := a.redundantRead.checkRedundantRead(p, hasWindow); hint != "" {
 						a.appendGuidance(&result, hint)
 					}
 					if pi == readPathsLen-1 {

--- a/internal/agent/unread_edit_guard.go
+++ b/internal/agent/unread_edit_guard.go
@@ -106,11 +106,24 @@ func (s *unreadEditState) normalize(path string) string {
 // recordRead marks a file as read. Called after successful read_file/multi_file_read.
 // Also captures the file's modification time for stale-read detection.
 func (s *unreadEditState) recordRead(path string) {
+	s.recordReadWindow(path, false)
+}
+
+// recordReadWindow records a read; when windowed (read_file with
+// offset/limit), the file is NOT marked fully read (#1782 case 3:
+// `read_file {offset:2000, limit:50}` used to set filesRead=true and a
+// follow-up edit_file outside the window passed the unread guard
+// silently). A windowed read still refreshes the staleness baseline and
+// mtime - the agent did look at the file, so the stale/mtime sentinels
+// keep their semantics; only the fully-read flag is withheld.
+func (s *unreadEditState) recordReadWindow(path string, windowed bool) {
 	if path == "" {
 		return
 	}
 	n := s.normalize(path)
-	s.filesRead[n] = true
+	if !windowed {
+		s.filesRead[n] = true
+	}
 	// Re-reading the file refreshes the staleness baseline: any future
 	// external modification after this read must be able to re-warn, so
 	// clear the stale warning key (fix #162 — the key was never cleared,

--- a/internal/agent/unread_edit_guard_1782_test.go
+++ b/internal/agent/unread_edit_guard_1782_test.go
@@ -1,0 +1,25 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #1782 case 3: a windowed read (offset/limit) must not mark the file fully
+// read - an edit outside the window must still trip the unread guard.
+func Test1782WindowedReadNotFullyRead(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "x.go")
+	os.WriteFile(p, []byte("package main\n"), 0644)
+
+	s := newUnreadEditState()
+	s.recordReadWindow(p, true) // windowed
+	if s.checkUnreadEdit(p) == "" {
+		t.Fatal("windowed read must NOT satisfy the unread guard (edit outside the window would pass silently)")
+	}
+	s.recordReadWindow(p, false) // full read
+	if s.checkUnreadEdit(p) != "" {
+		t.Fatal("full read must satisfy the unread guard")
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1782 (remaining case 3; cases 1/2/4 landed via parallel fixes).

- **Case 3 (Med)**: read_file with offset/limit no longer sets filesRead — an edit outside the window now trips the unread guard instead of passing silently. recordReadWindow withholds only the fully-read flag (staleness baseline/mtime semantics preserved); the three disk-based recorders stay unchanged with the rationale documented at the call site.

## Verification evidence (review)
Isolated worktree on latest main: internal/agent **23.1s** + internal/plugin **4.8s** PASS (p=1). Pin: windowed read must NOT satisfy the unread guard; full read must.

Per team convention: merge only after this PR's CI is green.

Closes #1782

Generated with [ggcode](https://github.com/topcheer/ggcode)