### PR TITLE
fix(provider,tui): probe single-flight; stale probe results dropped (#1789 cases 1+2)

### DIFF
--- a/internal/provider/context_probe.go
+++ b/internal/provider/context_probe.go
@@ -33,6 +33,12 @@ var probeTiers = []int{
 }
 
 // ProbeResult is delivered asynchronously after a probe completes.
+// probeInflight tracks running background probes by key (#1789 case 1).
+var (
+	probeInflightMu sync.Mutex
+	probeInflight   = map[string]bool{}
+)
+
 type ProbeResult struct {
 	Key           string // "vendor|baseURL|model"
 	ContextWindow int    // discovered value, 0 if probe failed
@@ -443,10 +449,28 @@ func ProbeContextWindow(ctx context.Context, p Provider, vendor, baseURL, model 
 		return
 	}
 
+	// #1789 case 1: five trigger points can fire while a tiered probe is
+	// still in flight (minutes for the 1M tier - ~2MB padding per request)
+	// - each miss launched ANOTHER full paid tier sequence, doubling real
+	// billing. Single-flight per key: a running probe suppresses new ones.
+	probeInflightMu.Lock()
+	if probeInflight[key] {
+		probeInflightMu.Unlock()
+		debug.Log("probe", "in-flight probe for key=%s suppressed duplicate launch", key)
+		return
+	}
+	probeInflight[key] = true
+	probeInflightMu.Unlock()
+
 	debug.Log("probe", "cache MISS: key=%s — launching background goroutine", key)
 
 	// Phase 2: fire background probe
 	safego.Go("provider.contextProbe", func() {
+		defer func() {
+			probeInflightMu.Lock()
+			delete(probeInflight, key)
+			probeInflightMu.Unlock()
+		}()
 		start := time.Now()
 		window := probeInBackground(ctx, p, key)
 		elapsed := time.Since(start)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -781,6 +781,17 @@ func (m *Model) SetProgram(p *tea.Program) {
 // provider+model and applies the result to the agent's ContextManager.
 // Completely invisible to the user — no UI feedback at all.
 // Safe to call at any time; no-ops if agent/provider/config are not ready.
+// currentProbeKey rebuilds the probe key for the CURRENT provider
+// combination (#1789 case 2): a stale probe completing after a provider
+// switch must not write the old window onto the new session.
+func (m *Model) currentProbeKey() (string, bool) {
+	res, err := m.config.ResolveActiveEndpoint()
+	if err != nil || res.VendorID == "" || res.Model == "" {
+		return "", false
+	}
+	return provider.MakeProbeKey(res.VendorID, res.BaseURL, res.Model), true
+}
+
 func (m *Model) startContextProbe() {
 	if m.config == nil || !m.config.ProbeContext {
 		return
@@ -832,6 +843,15 @@ func (m *Model) startContextProbe() {
 	provider.ProbeContextWindow(context.Background(), prov,
 		resolved.VendorID, resolved.BaseURL, resolved.Model,
 		func(r provider.ProbeResult) {
+			// #1789 case 2: a probe started for model A completes after the
+			// user switched to model B - applying it wrote A's window onto
+			// the B session (persisted; the L809 guard then blocked a
+			// correct re-probe). Drop results whose key no longer matches
+			// the CURRENT combination.
+			if cur, ok := m.currentProbeKey(); ok && cur != r.Key {
+				debug.Log("probe", "dropping stale probe result key=%s (now %s)", r.Key, cur)
+				return
+			}
 			if r.ContextWindow > 0 {
 				debug.Log("probe", "applying context_window=%d fromCache=%v to agent",
 					r.ContextWindow, r.FromCache)


### PR DESCRIPTION
Case 1 (Med, **doubled billing**): five trigger points can fire while a tiered probe is still in flight (minutes for the 1M tier, ~2MB padding per request) - each miss launched **another full paid tier sequence**. In-flight markers per key now suppress duplicate launches (cleared on completion/failure).

Case 2 (Med, **cross-model pollution**): a probe started for model A completes after the user switched to model B - the callback unconditionally applied A's window onto the B session (**persisted to disk**; the existing guard then blocked a correct re-probe). The callback now drops results whose `MakeProbeKey` no longer matches the current combination.

Isolated worktree (fresh origin/main): provider+tui packages full PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)