### PR TITLE
fix(agent): real copylock body-scan revert; claim-level ack proximity + revision supersede (#1536)

### DIFF
--- a/internal/agent/contradiction_track.go
+++ b/internal/agent/contradiction_track.go
@@ -75,6 +75,18 @@ type contradictionClaim struct {
 	entity    string // normalized claimed location/cause
 	excerpt   string
 	iteration int
+	// acknowledged marks a claim that sits right after an ack phrase
+	// (#1536 case C): it enters history but skips pairing this iteration.
+	acknowledged bool
+	// superseded marks a claim retired by an acknowledged revision
+	// (#1536 case D): kept in history for audit, excluded from pairing.
+	superseded bool
+	// revision marks a claim following a STRONG revision phrase ("I was
+	// wrong", "correction:", ...). A revision retires the superseded
+	// prior claims (#1536 case D) so a later restatement of the corrected
+	// assertion cannot pair against the stale one. Weak openers like
+	// "actually, i" acknowledge without retiring anything.
+	revision bool
 }
 
 // contradictionInstance represents a detected cross-turn reversal.
@@ -194,11 +206,45 @@ func extractClaims(text string, iteration int) []contradictionClaim {
 	// 'without acknowledging' charter. Skip texts that explicitly
 	// acknowledge the revision.
 	lower := strings.ToLower(text)
+	// #1447-A + #1536 C/D: an ACKNOWLEDGED revision is not a contradiction -
+	// but the old whole-text exemption ("return nil") blinded the detector
+	// to every OTHER claim in the same message and dropped the corrected
+	// claims from history ("actually, i" is an extremely common opener:
+	// "Actually, I already ran the tests. The bug is in handler.go" washed
+	// out the handler.go root-cause migration entirely). Claim-level
+	// proximity instead: a claim is 'acknowledged' only when an ack phrase
+	// sits within a window before it; acknowledged claims are recorded in
+	// history (fixing the stale-pairing false positive when the corrected
+	// assertion is later restated) but skip contradiction pairing this
+	// iteration.
+	ackPositions := []int{}
+	revisionPositions := []int{}
 	for _, ack := range []string{"i was wrong", "i was mistaken", "i misread", "earlier i thought", "i previously thought", "let me correct", "correction:", "on second thought", "actually, i", "to correct myself"} {
-		if strings.Contains(lower, ack) {
-			return nil
+		strong := ack != "actually, i" // weak opener: acknowledges, does not retire
+		for start := 0; start < len(lower); {
+			idx := strings.Index(lower[start:], ack)
+			if idx < 0 {
+				break
+			}
+			ackPositions = append(ackPositions, start+idx)
+			if strong {
+				revisionPositions = append(revisionPositions, start+idx)
+			}
+			start += idx + len(ack)
 		}
 	}
+	nearAny := func(positions []int, entityStart int) bool {
+		// An ack phrase within 150 chars before the claim entity
+		// acknowledges THAT claim, not one three paragraphs later.
+		for _, pos := range positions {
+			if pos <= entityStart && entityStart-pos <= 150 {
+				return true
+			}
+		}
+		return false
+	}
+	nearAck := func(entityStart int) bool { return nearAny(ackPositions, entityStart) }
+	nearRevision := func(entityStart int) bool { return nearAny(revisionPositions, entityStart) }
 
 	for _, pat := range contradictionClaimPatterns {
 		locs := pat.FindAllStringSubmatchIndex(text, -1)
@@ -219,9 +265,11 @@ func extractClaims(text string, iteration int) []contradictionClaim {
 
 			excerpt := extractContradictionExcerpt(text, loc[0], loc[1])
 			claims = append(claims, contradictionClaim{
-				entity:    entity,
-				excerpt:   excerpt,
-				iteration: iteration,
+				entity:       entity,
+				excerpt:      excerpt,
+				iteration:    iteration,
+				acknowledged: nearAck(entityStart),
+				revision:     nearRevision(entityStart),
 			})
 		}
 	}
@@ -235,8 +283,39 @@ func (s *contradictionState) recordContradictionClaims(text string, iteration in
 	newClaims := extractClaims(text, iteration)
 
 	// Check new claims against prior claims for contradictions.
+	// #1536 case C: only non-acknowledged claims pair; acknowledged ones
+	// still enter history below (case D) so a later restatement of the
+	// corrected assertion pairs against the CURRENT belief instead of the
+	// superseded one.
+	hasRevision := false
 	for _, nc := range newClaims {
+		if nc.revision {
+			hasRevision = true
+		}
+	}
+	if hasRevision {
+		// #1536 case D: a strong revision retires prior claims not
+		// re-asserted in the revision message - the agent's standing
+		// belief moved; later restatements of the corrected assertion
+		// must pair against the CURRENT belief, not the stale one.
+		reasserted := make(map[string]bool, len(newClaims))
+		for _, nc := range newClaims {
+			reasserted[nc.entity] = true
+		}
+		for i := range s.claims {
+			if s.claims[i].iteration < iteration && !reasserted[s.claims[i].entity] {
+				s.claims[i].superseded = true
+			}
+		}
+	}
+	for _, nc := range newClaims {
+		if nc.acknowledged {
+			continue
+		}
 		for _, pc := range s.claims {
+			if pc.superseded {
+				continue // retired by an acknowledged revision
+			}
 			// A contradiction occurs when the new entity differs from a prior
 			// entity AND they aren't substrings of each other (e.g. "auth" vs
 			// "auth.go" are the same root, not a contradiction).

--- a/internal/agent/copylock_check.go
+++ b/internal/agent/copylock_check.go
@@ -159,52 +159,17 @@ func findCopylockIssues(fset *token.FileSet, file *ast.File) []copylockIssue {
 				issue.funcName = fn.Name.Name // delta key component (#213)
 				issues = append(issues, issue)
 			}
-			// #1447-B: the header's category 4 ("Assignments and function
-			// call arguments that copy a sync type") was never implemented -
-			// only signatures were scanned, while the CLASSIC copylocks
-			// shapes (range value copies, `snapshot := *lockedPtr`, value
-			// passing at call sites) all live in the function BODY.
-			if fn.Body != nil {
-				ast.Inspect(fn.Body, func(n ast.Node) bool {
-					switch stmt := n.(type) {
-					case *ast.AssignStmt:
-						for _, rhs := range stmt.Rhs {
-							if u, ok := rhs.(*ast.UnaryExpr); ok && u.Op == token.MUL {
-								if typeName := syncOrLockStruct(u.X, lockStructs); typeName != "" {
-									issues = append(issues, copylockIssue{
-										pos:     fset.Position(stmt.Pos()),
-										message: fmt.Sprintf("assignment copies lock value: copying *%s", typeName),
-									})
-								}
-							}
-						}
-					case *ast.RangeStmt:
-						if stmt.Value != nil {
-							if typeName := syncOrLockStruct(stmt.Value, lockStructs); typeName != "" {
-								if id, ok := stmt.Value.(*ast.Ident); ok {
-									issues = append(issues, copylockIssue{
-										pos:     fset.Position(stmt.Pos()),
-										message: fmt.Sprintf("range var %s copies lock value: %s (contains sync field)", id.Name, typeName),
-									})
-								}
-							}
-						}
-					case *ast.CallExpr:
-						for i, arg := range stmt.Args {
-							if _, isStar := arg.(*ast.StarExpr); isStar {
-								continue // explicit deref of a pointer arg: pointer, not copy
-							}
-							if typeName := syncOrLockStruct(arg, lockStructs); typeName != "" {
-								issues = append(issues, copylockIssue{
-									pos:     fset.Position(stmt.Pos()),
-									message: fmt.Sprintf("call argument %d copies lock value: %s (contains sync field)", i+1, typeName),
-								})
-							}
-						}
-					}
-					return true
-				})
-			}
+			// #1536 case A: the body-level scan added in 5bd1ab3d (range
+			// value copies, deref assignments, call-arg copies) was "reverted"
+			// by 9c6bb693 as comment-only - the code kept running with no test
+			// coverage while the header went back to claiming bodies are not
+			// analyzed. Its name-based type matching (syncOrLockStruct resolves
+			// the variable NAME, not the TYPE) made exactly the false positives
+			// the revert message predicted: `for _, Cache := range caches`
+			// (caches []*Cache - pointer copy, legal) hit lockStructs["Cache"]
+			// and fired on every Go file write. This is the real revert: the
+			// scan is deleted, matching the header comment and the zero-test
+			// reality. Signature-path scanning (above) keeps its #213 delta keys.
 		}
 	}
 

--- a/internal/agent/copylock_check_1536_test.go
+++ b/internal/agent/copylock_check_1536_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// #1536 case A pin: the body-level scan must stay deleted - a range over a
+// pointer slice with a loop variable NAMED like a lock struct type is legal
+// (copies a pointer) and must not fire. The 5bd1ab3d scan hit exactly this
+// shape via name-based type matching.
+func Test1536BodyScanStaysDeleted(t *testing.T) {
+	src := `package p
+type Cache struct{ mu syncMutexAlias }
+type syncMutexAlias = fakeMutex
+type fakeMutex struct{ x int }
+
+func f(caches []*Cache) {
+	for _, Cache := range caches {
+		_ = Cache
+	}
+	snapshot := *caches[0]
+	_ = snapshot
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "t.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cache has no real sync field here (alias to plain struct) so even the
+	// struct collector should not flag; the point of this pin is that NO
+	// body-derived issue ("range var ... copies lock value" /
+	// "assignment copies lock value") is ever produced.
+	for _, iss := range findCopylockIssues(fset, file) {
+		if iss.funcName == "" {
+			t.Fatalf("signature-path issues must carry funcName (#213); got %+v", iss)
+		}
+	}
+}
+
+// #1536 case C pin: an ack phrase in one paragraph must not blind the
+// detector to unrelated claims elsewhere in the same message.
+func Test1536AckProximityNotWholeText(t *testing.T) {
+	s := newContradictionState()
+	// iter1: claim handler.go (will be contradicted later)
+	s.recordContradictionClaims("the root cause is in auth.go", 1)
+	// iter2: acknowledged revision near auth.go + a NEW unrelated claim far away
+	s.recordContradictionClaims("On second thought, I was wrong about auth.go being the cause. Separately, after full re-checking I now believe the real bug is in handler.go.", 2)
+	if n := len(s.contradictions); n != 0 {
+		t.Fatalf("acknowledged revision must not pair (got %d contradictions)", n)
+	}
+	// iter3: restating the corrected claim must NOT pair against the stale
+	// auth.go claim (the correction was recorded in history - case D).
+	s.recordContradictionClaims("I still believe the bug is in handler.go", 3)
+	if n := len(s.contradictions); n != 0 {
+		t.Fatalf("restating the corrected claim must not pair against the superseded one (got %d)", n)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1536 (all four cases).

- **Case A (Med-High)**: 9c6bb693's "revert" of the 5bd1ab3d body scan was comment-only — the name-based scan (variable NAME ≠ TYPE) kept firing the predicted FPs (`for _, Cache := range caches` over []*Cache) on every Go file write, uncovered. Real revert: scan deleted, header now true, signature path untouched.
- **Case B (Med)**: dies with the scan (body issues carried no funcName, collapsing the #213 delta key to bare message).
- **Case C (Med)**: whole-text ack exemption (`return nil`) → claim-level 150-char proximity; "actually, i" opener no longer washes out unrelated root-cause claims in the same message.
- **Case D (Low-Med)**: acknowledged claims enter history; strong revision phrases retire superseded priors (excluded from pairing, kept for audit) — restating the corrected assertion no longer pairs against the stale claim. Weak openers acknowledge without retiring.

## Verification evidence (review)
Isolated worktree on latest main: internal/agent **34.3s PASS** (p=1) — includes the 13 pre-existing signature-form tests and the #1447 contradiction pins. New pins: body scan stays deleted; ack proximity not whole-text; corrected restatement does not pair against the superseded claim.

Per team convention: merge only after this PR's CI is green.

Closes #1536

Generated with [ggcode](https://github.com/topcheer/ggcode)
