### PR TITLE
fix(agent): goto-label reachability; two-line uintptr round-trip; non-destructive unused-param hint (#1520)

### DIFF
--- a/internal/agent/checks_1520_test.go
+++ b/internal/agent/checks_1520_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1520 case B pin: a goto target label after a goto must not be reported
+// unreachable - `goto done; done: cleanup()` is reachable via the jump.
+func Test1520GotoLabelNotUnreachable(t *testing.T) {
+	newContent := `package p
+func f(err error) {
+	if err != nil {
+		goto done
+	}
+	println("ok")
+	return
+	done:
+	println("cleanup")
+}
+`
+	warnings := checkUnreachableCode("t.go", "", newContent)
+	for _, w := range warnings {
+		if contains := len(w) > 0; contains {
+			t.Fatalf("goto-target code must not be flagged unreachable: %q", w)
+		}
+	}
+}
+
+// #1520 case C pin: the classic two-line uintptr round-trip must be caught.
+func Test1520TwoLineUintptrRoundTrip(t *testing.T) {
+	src := `package p
+import "unsafe"
+func g(p *byte, q *byte) {
+	off := uintptr(unsafe.Pointer(p)) + 16
+	*q = *(*byte)(unsafe.Pointer(off))
+}
+`
+	warnings := checkUnsafeUsage("t.go", "", src)
+	if len(warnings) == 0 {
+		t.Fatal("two-line uintptr(unsafe.Pointer(p))+16 -> unsafe.Pointer(off) round trip must be detected (vet-unsafeptr parity)")
+	}
+}
+
+// #1520 case D pin: the unused-parameter hint must not list deletion first.
+func Test1520UnusedParamHintNonDestructive(t *testing.T) {
+	src := `package p
+type handler struct{}
+func (h *handler) Shutdown(ctx string) error { return nil }
+`
+	warnings := checkUnusedParam("t.go", "", src)
+	for _, w := range warnings {
+		if len(w) > 0 && w[0] == 'X' {
+			t.Fatal("unreachable")
+		}
+		if strings.Contains(w, "consider removing it or renaming") {
+			t.Fatalf("hint must not offer deletion as an option (interface contracts break): %q", w)
+		}
+	}
+}

--- a/internal/agent/unreachable_code_check.go
+++ b/internal/agent/unreachable_code_check.go
@@ -49,6 +49,7 @@ func checkUnreachableCode(filePath, oldContent, newContent string) []string {
 	}
 
 	var warnings []string
+	var gotoTargetLabels map[string]bool
 
 	ast.Inspect(goAST, func(n ast.Node) bool {
 		blk, ok := n.(*ast.BlockStmt)
@@ -64,6 +65,21 @@ func checkUnreachableCode(filePath, oldContent, newContent string) []string {
 		deadStmts := blk.List[termIdx+1:]
 		if len(deadStmts) == 0 {
 			return true
+		}
+
+		// #1520 case B: `goto done; done: cleanup()` - the label target and
+		// everything after it ARE reachable via the goto, yet BranchStmt
+		// (any position, tok included) was treated as a hard terminator.
+		// Conservative zero-FP rule: if any "dead" statement is a label
+		// targeted by ANY goto in the file, skip the report for this block
+		// (no control-flow analysis - we cannot soundly rank reachability).
+		if gotoTargetLabels == nil {
+			gotoTargetLabels = collectGotoLabels(goAST)
+		}
+		for _, ds := range deadStmts {
+			if ls, ok := ds.(*ast.LabeledStmt); ok && gotoTargetLabels[ls.Label.Name] {
+				return true
+			}
 		}
 
 		pos := fset.Position(deadStmts[0].Pos())
@@ -135,6 +151,19 @@ func renderNode(fset *token.FileSet, node ast.Node) string {
 		return ""
 	}
 	return buf.String()
+}
+
+// collectGotoLabels returns the set of labels targeted by goto statements
+// anywhere in the file (#1520 case B).
+func collectGotoLabels(file *ast.File) map[string]bool {
+	targets := map[string]bool{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		if bs, ok := n.(*ast.BranchStmt); ok && bs.Tok == token.GOTO && bs.Label != nil {
+			targets[bs.Label.Name] = true
+		}
+		return true
+	})
+	return targets
 }
 
 // findTerminatingStmt returns the index of the first statement in the list that

--- a/internal/agent/unsafe_usage_check.go
+++ b/internal/agent/unsafe_usage_check.go
@@ -149,19 +149,59 @@ func findUnsafeIssues(src string) []unsafeInstance {
 	})
 
 	// Pattern 3: stored uintptr from unsafe.Pointer (requires assignment context).
+	uintptrIdents := map[string]bool{}
 	ast.Inspect(file, func(node ast.Node) bool {
 		as, ok := node.(*ast.AssignStmt)
 		if !ok {
 			return true
 		}
 		for _, rhs := range as.Rhs {
-			if isUintptrOfUnsafePointer(rhs) {
+			stored := isUintptrOfUnsafePointer(rhs)
+			if !stored {
+				// #1520 case C first half: `off := uintptr(unsafe.Pointer(p)) + 16`
+				// stores a DERIVED uintptr - the bare-conversion check missed
+				// the arithmetic wrapper entirely.
+				stored = containsUintptrOfUnsafePointer(rhs)
+			}
+			if stored {
 				instances = append(instances, unsafeInstance{
 					category: unsafeCatStoredUint,
 					detail:   unsafeDetailStored,
 					line:     fset.Position(as.Pos()).Line,
 				})
+				// #1520 case C: track the LHS ident - the classic two-line
+				// idiom stores the (possibly arithmetic) uintptr in a
+				// variable and reconverts it lines later:
+				//   off := uintptr(unsafe.Pointer(p)) + 16
+				//   q  := unsafe.Pointer(off)
+				// Pattern 2 below requires the arithmetic INLINE, so the
+				// reconversion half was invisible. Remember derived-uintptr
+				// idents so unsafe.Pointer(<ident>) can be flagged.
+				if len(as.Lhs) == 1 {
+					if id, ok := as.Lhs[0].(*ast.Ident); ok {
+						uintptrIdents[id.Name] = true
+					}
+				}
 			}
+		}
+		return true
+	})
+
+	// #1520 case C second half: unsafe.Pointer(<ident>) where <ident> was
+	// assigned (possibly with arithmetic) from uintptr(unsafe.Pointer(...)).
+	// This is exactly the vet-unsafeptr pattern the header claims parity
+	// with; the inline-arithmetic-only check missed the two-line form.
+	ast.Inspect(file, func(node ast.Node) bool {
+		ce, ok := node.(*ast.CallExpr)
+		if !ok || !isUnsafePointerCall(ce) || len(ce.Args) == 0 {
+			return true
+		}
+		if id, ok := ce.Args[0].(*ast.Ident); ok && uintptrIdents[id.Name] {
+			instances = append(instances, unsafeInstance{
+				category: unsafeCatPtrArith,
+				detail:   unsafeDetailPtrArith,
+				line:     fset.Position(ce.Pos()).Line,
+			})
 		}
 		return true
 	})
@@ -237,6 +277,32 @@ func isUintptrCall(expr ast.Expr) bool {
 	}
 	ident, ok := ce.Fun.(*ast.Ident)
 	return ok && ident.Name == "uintptr"
+}
+
+// containsUintptrOfUnsafePointer reports whether expr anywhere contains a
+// uintptr(unsafe.Pointer(...)) conversion (e.g. as an arithmetic operand).
+func containsUintptrOfUnsafePointer(expr ast.Expr) bool {
+	if expr == nil {
+		return false
+	}
+	if isUintptrOfUnsafePointer(expr) {
+		return true
+	}
+	switch e := expr.(type) {
+	case *ast.BinaryExpr:
+		return containsUintptrOfUnsafePointer(e.X) || containsUintptrOfUnsafePointer(e.Y)
+	case *ast.ParenExpr:
+		return containsUintptrOfUnsafePointer(e.X)
+	case *ast.UnaryExpr:
+		return containsUintptrOfUnsafePointer(e.X)
+	case *ast.CallExpr:
+		for _, a := range e.Args {
+			if containsUintptrOfUnsafePointer(a) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // isUintptrOfUnsafePointer returns true if expr is uintptr(unsafe.Pointer(...)).

--- a/internal/agent/unused_param_check.go
+++ b/internal/agent/unused_param_check.go
@@ -80,7 +80,7 @@ func checkUnusedParam(filePath, oldContent, src string) []string {
 		}
 		warnings = append(warnings, fmt.Sprintf(
 			"%s: parameter '%s' is never used in function '%s' "+
-				"-- consider removing it or renaming to '_'",
+				"-- if the signature is not an interface/callback contract, consider renaming it to '_' (never delete a parameter: implementations of Shutdown(ctx)/ServeHTTP/handler-adapter contracts fail to compile without it)",
 			upFormatPos(is.pos), is.param, is.funcName))
 	}
 	return warnings


### PR DESCRIPTION
## Summary
Closes #1520 (cases B/C/D; case A already landed via parallel fix).

- **Case B (Med)**: goto-target labels after a goto are no longer reported unreachable (`goto done; done: cleanup()`) — conservative suppression when any "dead" statement is a goto-target label.
- **Case C (Med)**: the classic two-line uintptr round-trip (`off := uintptr(unsafe.Pointer(p)) + 16; q := unsafe.Pointer(off)`) is now detected on both halves — derived-conversion tracking + ident-following reconversion scan, matching the vet-unsafeptr parity the header claims.
- **Case D (Med)**: unused-parameter hint no longer offers deletion first — leads with the non-destructive '_' rename and warns contract implementations break on deletion.

## Verification evidence (review)
Isolated worktree on latest main: internal/agent **22.2s PASS** (p=1). Pins for all three cases.

Per team convention: merge only after this PR's CI is green.

Closes #1520

Generated with [ggcode](https://github.com/topcheer/ggcode)
