### PR TITLE
fix(agent): CJK bare-word narrowing; redirection opener semantics; failed-run verification (#1521)

### DIFF
--- a/internal/agent/ambiguity_point.go
+++ b/internal/agent/ambiguity_point.go
@@ -171,14 +171,24 @@ var ambiguityPatterns = []struct {
 	{"优化一下", ambDirectionVague, "improve toward what goal -- performance, readability, security?"},
 	{"优化这个", ambDirectionVague, "improve toward what goal -- performance, readability, security?"},
 	{"去掉重复", ambScopeVague, "which duplicates exactly, and dedupe by what key"},
-	{"去重", ambScopeVague, "which duplicates exactly, and dedupe by what key"},
+	{"去重一下", ambScopeVague, "which duplicates exactly, and dedupe by what key"},
+	{"帮我去重", ambScopeVague, "which duplicates exactly, and dedupe by what key"},
 	{"排个序", ambSortOrder, "ascending or descending, and by which key"},
-	{"排序", ambSortOrder, "ascending or descending, and by which key"},
-	{"重命名", ambNamingVague, "the new name convention and whether to update all references"},
-	{"改名", ambNamingVague, "the new name convention and whether to update all references"},
-	{"最新的", ambQuantityVague, "how many of the latest items, and by what cutoff"},
-	{"随便", ambScopeVague, "which specific item or criteria"},
-	{"大概", ambQuantityVague, "the exact count or selection criteria"},
+	// #1521 case B: the bare CJK forms were pure substrings - isWordByte is
+	// ASCII-only, so beforeOK/afterOK are ALWAYS true for CJK and
+	// "修复排序不稳定的 bug" (stability explicitly discussed) still hit
+	// bare 排序; "大概是上个月引入的" (time adverb) hit bare 大概 with a
+	// COUNT suggestion. Narrowed to imperative/count-question shapes, the
+	// same discipline #1438-A applied to the English table.
+	{"排序一下", ambSortOrder, "ascending or descending, and by which key"},
+	{"帮我排序", ambSortOrder, "ascending or descending, and by which key"},
+	{"重命名一下", ambNamingVague, "the new name convention and whether to update all references"},
+	{"改个名", ambNamingVague, "the new name convention and whether to update all references"},
+	{"最新的几个", ambQuantityVague, "how many of the latest items, and by what cutoff"},
+	{"大概几个", ambQuantityVague, "the exact count or selection criteria"},
+	{"大概多少", ambQuantityVague, "the exact count or selection criteria"},
+	{"随便挑", ambScopeVague, "which specific item or criteria"},
+	{"随便选", ambScopeVague, "which specific item or criteria"},
 }
 
 // phrases that indicate this is a quick, unambiguous task -- skip detection

--- a/internal/agent/ambiguity_point_test.go
+++ b/internal/agent/ambiguity_point_test.go
@@ -226,7 +226,7 @@ func TestAmbiguityQuickTaskSkip(t *testing.T) {
 func TestAmbiguityPointCJKAndGate(t *testing.T) {
 	// fired is once-per-run: a FRESH state per prompt (the initial version
 	// reused one Agent and the 2nd+ prompts silently skipped).
-	for _, cjk := range []string{"请优化一下这个函数的性能", "把这个列表去重", "帮我排个序", "把这个函数改名"} {
+	for _, cjk := range []string{"请优化一下这个函数的性能", "帮我把这个列表去重一下", "帮我排个序", "帮我把这个函数改个名"} {
 		a := &Agent{ambiguityPoint: newAmbiguityPointState()}
 		if msg := a.checkAmbiguityPoints(cjk); msg == "" {
 			t.Fatalf("CJK prompt %q not detected", cjk)

--- a/internal/agent/checks_1521_test.go
+++ b/internal/agent/checks_1521_test.go
@@ -1,0 +1,59 @@
+package agent
+
+import "testing"
+
+// #1521 case B pins: bare CJK substrings must NOT fire.
+func Test1521CJKBareFormsNotFlagged(t *testing.T) {
+	mkAgent := func() *Agent { return &Agent{ambiguityPoint: newAmbiguityPointState()} }
+	for _, msg := range []string{
+		"修复排序不稳定的 bug",
+		"大概是上个月引入的",
+		"最近的改动导致回归",
+		"用最新的 API 重写这一段",
+		"去重逻辑有问题，key 不对",
+	} {
+		if w := mkAgent().checkAmbiguityPoints(msg); len(w) > 0 {
+			t.Errorf("bare CJK substring falsely flagged %q: %v", msg, w)
+		}
+	}
+	for _, msg := range []string{"排序一下", "帮我排序", "改个名", "最新的几个", "大概几个", "随便挑一个"} {
+		if w := mkAgent().checkAmbiguityPoints(msg); len(w) == 0 {
+			t.Errorf("phrase shape should flag %q", msg)
+		}
+	}
+}
+
+// #1521 case C pin: long redirection messages must still classify.
+func Test1521LongRedirectionDetected(t *testing.T) {
+	long := "Actually, I meant the opposite - " + makeStr('x', 150)
+	mid := makeStr('y', 120) + " the wrong approach might actually be right if we consider edge cases"
+	if c := detectNegativeFeedback(mid); c != "" {
+		t.Fatalf("mid-sentence actually in a long reflective message must NOT classify, got %q", c)
+	}
+	if c := detectNegativeFeedback(long); c != "redirection" {
+		t.Fatalf("long redirection must fire regardless of length, got %q", c)
+	}
+}
+
+// #1521 case D pin: a failed test run must not satisfy verification.
+func Test1521FailedRunNotVerification(t *testing.T) {
+	rs := &RunStats{
+		CommandsRun: []string{"go test ./..."},
+		Errors:      []string{"go test ./... : exit status 1 --- FAIL"},
+	}
+	if hasVerificationCommands(rs) {
+		t.Fatal("failed test run must not count as verification")
+	}
+	rsOK := &RunStats{CommandsRun: []string{"go test ./..."}}
+	if !hasVerificationCommands(rsOK) {
+		t.Fatal("successful test run must count as verification")
+	}
+}
+
+func makeStr(b byte, n int) string {
+	s := make([]byte, n)
+	for i := range s {
+		s[i] = b
+	}
+	return string(s)
+}

--- a/internal/agent/unverified_claim.go
+++ b/internal/agent/unverified_claim.go
@@ -231,6 +231,40 @@ func hasVerificationCommands(runStats *RunStats) bool {
 	for _, cmd := range runStats.CommandsRun {
 		lower := strings.ToLower(stripCommandComment(cmd))
 		if isBuildTestCommand(lower) {
+			// #1521 case D: a FAILED test run is not verification - the
+			// target scenario is exactly "ran the tests (they failed) and
+			// still declared them passing". Existence-only checking made
+			// the failed run satisfy the exemption. The command string is
+			// cross-checked against the run's collected error text: a
+			// build/test command whose failure signature appears there
+			// does not count.
+			if commandFailed(runStats, cmd) {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// commandFailed reports whether the run's collected Errors mention this
+// build/test command failing (exit-status/non-zero markers near the
+// command text, or FAIL/exit status lines referencing it).
+func commandFailed(runStats *RunStats, cmd string) bool {
+	if len(runStats.Errors) == 0 {
+		return false
+	}
+	base := strings.TrimSpace(stripCommandComment(cmd))
+	if base == "" {
+		return false
+	}
+	// Use the first token (the binary) as the anchor - error lines usually
+	// quote the command or its failure output, not the full arg list.
+	fields := strings.Fields(base)
+	anchor := fields[0]
+	for _, e := range runStats.Errors {
+		el := strings.ToLower(e)
+		if strings.Contains(el, strings.ToLower(anchor)) && (strings.Contains(el, "fail") || strings.Contains(el, "exit status") || strings.Contains(el, "non-zero") || strings.Contains(el, "error")) {
 			return true
 		}
 	}

--- a/internal/agent/user_sentiment.go
+++ b/internal/agent/user_sentiment.go
@@ -192,8 +192,22 @@ func detectNegativeFeedback(message string) string {
 				// false positives in detailed technical messages. A long
 				// message with "actually" mid-sentence is context, not
 				// a course-correction signal.
+				//
+				// #1521 case C: redirection fires on long messages too (the
+				// header heuristic #2 promises "regardless of length"), but
+				// only as an OPENER - the first 40 chars. The old isShort
+				// gate swallowed a 150-char "Actually, I meant X" opener,
+				// which also reset consecutiveNegatives (two detailed
+				// corrections in a row restarted from the level-1 nudge);
+				// while firing on a mid-sentence "actually" in a long
+				// reflective message was the exact FP the gate existed for.
 				if isShort {
 					return group.category
+				}
+				if group.category == negCatRedirection {
+					if idx := strings.Index(scanText, pat); idx >= 0 && idx < 40 {
+						return group.category
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
Closes #1521 (cases B/C/D; case A already landed via parallel fix).

- **Case B (Med-High)**: CJK bare substrings (排序/改名/最新的/大概/随便/去重) narrowed to imperative/count-question phrase shapes — word-boundary checks are no-ops for CJK (isWordByte is ASCII-only), so the exact FP class #1438-A killed for English was live in Chinese.
- **Case C (Med-Low)**: redirection fires on long messages as an OPENER (first 40 chars) — long "Actually, I meant X" course-corrections no longer reset consecutiveNegatives, while mid-sentence "actually" in reflective messages stays ignored (legacy pin retained).
- **Case D (Med)**: hasVerificationCommands cross-checks the command against run Errors — a failed test run no longer satisfies the "tests pass" verification exemption.

## Verification evidence (review)
Isolated worktree on latest main: internal/agent **22.5s PASS** (p=1). Pins for all three cases; legacy CJK/rejection tests updated to the narrowed shapes with intent preserved.

Per team convention: merge only after this PR's CI is green.

Closes #1521

Generated with [ggcode](https://github.com/topcheer/ggcode)
