### PR TITLE
fix(agent): compound-127 amnesty; oracle fence unwrap; batch_replace path extraction (#1522)

### DIFF
--- a/internal/agent/checks_1522_test.go
+++ b/internal/agent/checks_1522_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// #1522 case B pin: exit 127 from a compound command is a REAL failure.
+func Test1522Compound127IsFailure(t *testing.T) {
+	if isNonFailureExit("go test ./... || npm run build", 127) {
+		t.Fatal("compound-command 127 must not get the not-found amnesty (fallback leg 127 swallowed a real test failure)")
+	}
+	if !isNonFailureExit("cargo build", 127) {
+		t.Fatal("simple missing-binary 127 keeps the amnesty")
+	}
+}
+
+// #1522 case C pin: fenced oracle output must be unwrapped.
+func Test1522StripCodeFence(t *testing.T) {
+	for in, want := range map[string]string{
+		"```go\ngo test ./...\n```":         "go test ./...",
+		"```bash\nnpm test\n```":            "npm test",
+		"go vet ./...":                      "go vet ./...",
+		"```sh\ngo build ./...\n\nextra```": "go build ./...",
+	} {
+		if got := stripCodeFence(in); got != want {
+			t.Errorf("stripCodeFence(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// #1522 case D pin: batch_replace's bare []string files must yield paths.
+func Test1522BatchReplaceFilesExtracted(t *testing.T) {
+	args := json.RawMessage(`{"pattern":"x","replacement":"y","files":["/a/foo.go","/b/bar.go"]}`)
+	if got := extractFilePathFromArgs("batch_replace", args); got != "/a/foo.go" {
+		t.Fatalf("batch_replace first path not extracted: %q", got)
+	}
+}

--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -364,7 +364,7 @@ func (a *Agent) llmDecideVerifyCommand(ctx context.Context, changedFiles []strin
 	}
 	a.emitUsageWithSource(resp.Usage, "verify")
 
-	cmd := strings.TrimSpace(extractText(resp.Message))
+	cmd := stripCodeFence(strings.TrimSpace(extractText(resp.Message)))
 	if strings.EqualFold(cmd, "SKIP") || cmd == "" {
 		return ""
 	}
@@ -380,6 +380,30 @@ func (a *Agent) llmDecideVerifyCommand(ctx context.Context, changedFiles []strin
 	}
 
 	return cmd
+}
+
+// stripCodeFence removes a markdown code fence wrapper the LLM may add
+// despite the "output only the command" instruction (#1522 case C): a
+// fenced command reached the pre-flight LookPath as a 3-backtick prefix,
+// failed, and came back Passed=true "verification skipped" - a silent
+// false green for every fenced oracle answer.
+func stripCodeFence(s string) string {
+	t := strings.TrimSpace(s)
+	for _, fence := range []string{"```go", "```bash", "```sh", "```shell", "```"} {
+		if strings.HasPrefix(t, fence) {
+			t = strings.TrimPrefix(t, fence)
+			t = strings.TrimSpace(t)
+			break
+		}
+	}
+	if idx := strings.LastIndex(t, "```"); idx >= 0 {
+		t = strings.TrimSpace(t[:idx])
+	}
+	// Single line only - the oracle is asked for ONE command.
+	if nl := strings.IndexByte(t, '\n'); nl >= 0 {
+		t = t[:nl]
+	}
+	return strings.TrimSpace(t)
 }
 
 // executeVerifyCommand runs the command and returns the result.
@@ -460,7 +484,17 @@ func (a *Agent) executeVerifyCommand(ctx context.Context, command string) *Verif
 // that simply lack tests or the toolchain.
 func isNonFailureExit(command string, code int) bool {
 	if code == 127 {
-		return true // command not found
+		// Command not found. #1522 case B: only a MISSING LEADING binary is
+		// "nothing to verify" - `go test ./... || npm run build` with npm
+		// absent exits 127 from the FALLBACK side while the real test run
+		// already failed; blanket 127 amnesty turned that into Passed=true
+		// ("verification passed") with a genuine test failure swallowed.
+		// Compound commands (||, &&, ;) lose the amnesty: we cannot tell
+		// which leg exited 127 without shell semantics.
+		if strings.ContainsAny(command, "||;&&") {
+			return false
+		}
+		return true
 	}
 	// pytest exit 5: no tests were collected - not a code defect.
 	return code == 5 && strings.Contains(command, "pytest")

--- a/internal/agent/verify_hint.go
+++ b/internal/agent/verify_hint.go
@@ -505,6 +505,21 @@ func extractFilePathFromArgs(toolName string, args json.RawMessage) string {
 					}
 				}
 			}
+		} else {
+			// #1522 case D: batch_replace's files[] is a bare []string - the
+			// map-only unmarshal above failed silently, so the first path
+			// was never extracted and postEditVerify's sourceEditsSinceHint
+			// under-counted (plus searchInvalidation/stalledConvergence
+			// missed those files). The sibling extractors (#737/#738)
+			// already handle both shapes; this was the third copy, unfixed.
+			var list []string
+			if json.Unmarshal(filesRaw, &list) == nil {
+				for _, s := range list {
+					if s != "" {
+						return s
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
Closes #1522 (cases B/C/D; case A already landed via parallel fix).

- **Case B (Med)**: exit-127 amnesty no longer applies to compound commands — `go test ./... || npm run build` with npm absent exits 127 from the fallback leg and was reported Passed=true, swallowing a real test failure. Simple missing-binary commands keep the amnesty.
- **Case C (Low-Med)**: verify-oracle LLM output is unwrapped from markdown fences — fenced commands previously failed the pre-flight LookPath (backtick prefix) and every fenced answer became Passed=true "verification skipped".
- **Case D (Low-Med)**: extractFilePathFromArgs handles batch_replace's bare []string files[] — the map-only unmarshal failed silently, under-counting postEditVerify's sourceEditsSinceHint and missing files for searchInvalidation/stalledConvergence (third-copy gap; #737/#738 siblings already handled both shapes).

## Verification evidence (review)
Isolated worktree on latest main: internal/agent **22.7s PASS** (p=1). Pins: compound 127 is failure / simple 127 keeps amnesty; fence unwrap table; batch_replace first path.

Per team convention: merge only after this PR's CI is green.

Closes #1522

Generated with [ggcode](https://github.com/topcheer/ggcode)
