### PR TITLE
fix(tui): wecom enable rides configMutationMsg; wechat poll re-arm paced (#1792 cases 3+2)

### DIFF
--- a/internal/tui/model_update.go
+++ b/internal/tui/model_update.go
@@ -767,6 +767,13 @@ func (m Model) Update(msg tea.Msg) (model tea.Model, cmd tea.Cmd) {
 		return m.handleTunnelThemeChangeMsg(msg)
 	case wechatQRCodeMsg:
 		return m.handleWechatQRCodeMsg(msg)
+	case wechatPollDueMsg:
+		// #1792 case 2: the paced re-poll fired - run the real poll.
+		if m.wechatPanel != nil {
+			return m, m.pollWechatQRStatus(msg.token)
+		}
+		return m, nil
+
 	case wechatQRPollMsg:
 		return m.handleWechatQRPollMsg(msg)
 

--- a/internal/tui/wechat_panel.go
+++ b/internal/tui/wechat_panel.go
@@ -292,6 +292,21 @@ func (m *Model) requestWechatQRCode() tea.Cmd {
 }
 
 // pollWechatQRStatus polls the QR code scan status directly (no adapter needed).
+// wechatPollTick delays a re-poll re-arm (#1792 case 2): #1398-A capped
+// the FAILURE streak, but the healthy wait-loop re-polled at network RTT
+// (~10 req/s) for as long as the QR sat unscanned.
+func wechatPollTick(qrcodeToken string) tea.Cmd {
+	return tea.Tick(1500*time.Millisecond, func(time.Time) tea.Msg {
+		// The tick fires as a bare Msg; wrap so the handler sees a poll
+		// request. Reuse the poll command lazily by returning a marker the
+		// existing command path handles: simplest is to schedule the real
+		// poll command here.
+		return wechatPollDueMsg{token: qrcodeToken}
+	})
+}
+
+type wechatPollDueMsg struct{ token string }
+
 func (m *Model) pollWechatQRStatus(qrcodeToken string) tea.Cmd {
 	return func() tea.Msg {
 		// #1398-A: an empty token produced a guaranteed-failing request on
@@ -375,11 +390,11 @@ func (m *Model) handleWechatQRPollMsg(msg wechatQRPollMsg) (Model, tea.Cmd) {
 	case "scanned":
 		panel.authPhase = "polling"
 		panel.message = m.t("panel.wechat.scanned")
-		return *m, m.pollWechatQRStatus(panel.qrcodeToken)
+		return *m, wechatPollTick(panel.qrcodeToken) // #1792 case 2: paced
 	case "wait", "":
 		panel.authPhase = "polling"
-		panel.pollFailures = 0 // #1398-A: healthy poll resets the streak
-		return *m, m.pollWechatQRStatus(panel.qrcodeToken)
+		panel.pollFailures = 0                       // #1398-A: healthy poll resets the streak
+		return *m, wechatPollTick(panel.qrcodeToken) // #1792 case 2: paced
 	default:
 		if msg.err != nil {
 			panel.message = fmt.Sprintf("Poll error: %v", msg.err)

--- a/internal/tui/wecom_panel.go
+++ b/internal/tui/wecom_panel.go
@@ -330,6 +330,10 @@ func (m *Model) createWeComAdapterCmd(spec string) tea.Cmd {
 						return wecomBindResultMsg{err: err}
 					}
 					if err := m.startWeComAdapterIfNeeded(name); err != nil {
+						if errors.Is(err, errWecomEnableNeeded) {
+							// #1792 case 3: enable on the Update loop, then restart.
+							return m.wecomEnableMutation(name, nil)
+						}
 						return wecomBindResultMsg{err: err}
 					}
 					return wecomBindResultMsg{message: m.t("panel.wecom.message.added_bot", name)}
@@ -339,6 +343,40 @@ func (m *Model) createWeComAdapterCmd(spec string) tea.Cmd {
 				return wecomBindResultMsg{err: err}
 			},
 		}
+	}
+}
+
+// errWecomEnableNeeded signals the auto-enable must run on the Update
+// loop via configMutationMsg (#1792 case 3).
+var errWecomEnableNeeded = errors.New("wecom adapter needs enable-on-update-loop")
+
+// wecomEnableMutation performs the auto-enable on the Update loop, then
+// restarts the adapter and continues with next.
+func (m *Model) wecomEnableMutation(name string, next func(m *Model) tea.Msg) tea.Msg {
+	return configMutationMsg{
+		apply: func(m *Model) error {
+			if err := m.config.SetIMAdapterEnabled(name, true); err != nil {
+				return fmt.Errorf("enable %s: %w", name, err)
+			}
+			if m.imManager != nil {
+				_ = m.imManager.EnableBinding(name)
+			}
+			return nil
+		},
+		next: func(m *Model) tea.Cmd {
+			return func() tea.Msg {
+				if err := im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager); err != nil {
+					return wecomBindResultMsg{err: err}
+				}
+				if next == nil {
+					return nil
+				}
+				return next(m)
+			}
+		},
+		fail: func(err error) tea.Msg {
+			return wecomBindResultMsg{err: err}
+		},
 	}
 }
 
@@ -361,13 +399,12 @@ func (m *Model) startWeComAdapterIfNeeded(name string) error {
 		return fmt.Errorf(m.t("panel.wecom.error.not_configured"), name)
 	}
 	if !adapterCfg.Enabled {
-		// Auto-enable when user explicitly tries to bind from panel.
-		if err := m.config.SetIMAdapterEnabled(name, true); err != nil {
-			return fmt.Errorf("enable %s: %w", name, err)
-		}
-		if m.imManager != nil {
-			_ = m.imManager.EnableBinding(name)
-		}
+		// #1792 case 3: this ran SetIMAdapterEnabled on the Cmd goroutine -
+		// config map write + disk save racing the View thread's per-frame
+		// iteration of the same map (concurrent map read/write fatal). The
+		// #1367 family comment above claims the migration; this call missed
+		// it. Signal the caller to route through configMutationMsg.
+		return errWecomEnableNeeded
 	}
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformWeCom)) {
 		return fmt.Errorf(m.t("panel.wecom.error.not_wecom_adapter"), name)


### PR DESCRIPTION
Case 3 (High, **fatal**): `startWeComAdapterIfNeeded` ran `SetIMAdapterEnabled` on the Cmd goroutine - config map write + disk save racing the View thread's per-frame iteration of the same map (**concurrent map read/write fatal**). The #1367 family comment claims the migration; this call missed it. Sentinel + `wecomEnableMutation` (the nostr/slack pattern, persistence kept).

Case 2 (Med, **storm**): #1398-A capped the FAILURE streak, but the healthy wait-loop re-polled at network RTT (**~10 req/s**) for as long as the QR sat unscanned. The wait/scanned re-arms now pace through a 1.5s tick; the error path keeps its streak-capped immediate retry.

(Case 1 - the expired-QR silent stall - is a state-machine UX change and stays for a dedicated pass.)

Isolated worktree (fresh origin/main): tui package full PASS (10.2s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)