### PR TITLE
fix(tui,tunnel): whatsapp enable rides configMutationMsg; broker session-info reads locked (#1793 cases 1+2)

### DIFF
--- a/internal/tui/whatsapp_panel.go
+++ b/internal/tui/whatsapp_panel.go
@@ -333,6 +333,10 @@ func (m *Model) bindWAEntry(entry whatsappBindingEntry) tea.Cmd {
 			return whatsappBindResultMsg{err: err}
 		}
 		if err := m.startWAAdapterIfNeeded(entry.Adapter); err != nil {
+			if errors.Is(err, errWAEnableNeeded) {
+				// #1793 case 1: enable on the Update loop, then restart+bind.
+				return m.waEnableMutation(entry.Adapter, nil)
+			}
 			return whatsappBindResultMsg{err: err}
 		}
 		ws := m.currentWorkspacePath()
@@ -419,6 +423,40 @@ func (m *Model) ensureWARuntime() error {
 	return m.ensureStartedCurrentWorkspaceIMRuntime(m.t("panel.whatsapp.error.config_unavailable"), "", true)
 }
 
+// errWAEnableNeeded signals the auto-enable must run on the Update loop
+// via configMutationMsg (#1793 case 1).
+var errWAEnableNeeded = errors.New("whatsapp adapter needs enable-on-update-loop")
+
+// waEnableMutation performs the auto-enable on the Update loop, then
+// restarts the adapter and continues with next.
+func (m *Model) waEnableMutation(name string, next func(m *Model) tea.Msg) tea.Msg {
+	return configMutationMsg{
+		apply: func(m *Model) error {
+			if err := m.config.SetIMAdapterEnabled(name, true); err != nil {
+				return fmt.Errorf("enable %s: %w", name, err)
+			}
+			if m.imManager != nil {
+				_ = m.imManager.EnableBinding(name)
+			}
+			return nil
+		},
+		next: func(m *Model) tea.Cmd {
+			return func() tea.Msg {
+				if err := im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager); err != nil {
+					return whatsappBindResultMsg{err: err}
+				}
+				if next == nil {
+					return nil
+				}
+				return next(m)
+			}
+		},
+		fail: func(err error) tea.Msg {
+			return whatsappBindResultMsg{err: err}
+		},
+	}
+}
+
 func (m *Model) startWAAdapterIfNeeded(name string) error {
 	if m.imManager == nil || m.config == nil {
 		return nil
@@ -438,13 +476,12 @@ func (m *Model) startWAAdapterIfNeeded(name string) error {
 		return fmt.Errorf("adapter %q not configured", name)
 	}
 	if !adapterCfg.Enabled {
-		// Auto-enable when user explicitly tries to bind from panel.
-		if err := m.config.SetIMAdapterEnabled(name, true); err != nil {
-			return fmt.Errorf("enable %s: %w", name, err)
-		}
-		if m.imManager != nil {
-			_ = m.imManager.EnableBinding(name)
-		}
+		// #1793 case 1: ran SetIMAdapterEnabled on the Cmd goroutine -
+		// config map write + disk save racing the panel's 2s tick range of
+		// the same map (concurrent map read/write fatal). The file's own
+		// #1367 comment claims the migration; createWAAdapterCmd got it,
+		// this bind path didn't. Sentinel + mutation, the nostr pattern.
+		return errWAEnableNeeded
 	}
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformWhatsApp)) {
 		return fmt.Errorf("adapter %q is not a WhatsApp adapter", name)

--- a/internal/tunnel/broker.go
+++ b/internal/tunnel/broker.go
@@ -899,7 +899,13 @@ func (b *Broker) sendActiveSession(sessionID string) {
 		return
 	}
 	barrierEventID, barrierOrdinal, projectionHash := b.activeSessionBarrier()
+	// #1793 case 2: this read raced the writer's whole-struct replace
+	// (SendSnapshot reads the same field under RLock - the asymmetry was
+	// an omission, not design). Multi-string torn reads sent corrupted
+	// workspace/provider to the relay; -race flagged it.
+	b.sessionMu.RLock()
 	info := b.cachedSessionInfo
+	b.sessionMu.RUnlock()
 	_ = b.session.SendActiveSessionWithParams(sessionID, b.AuthorityEpoch(), barrierEventID, barrierOrdinal, projectionHash, info.Workspace, info.Provider, info.Model)
 }
 
@@ -908,7 +914,10 @@ func (b *Broker) sendActiveSessionWithMode(sessionID, mode string) {
 		return
 	}
 	barrierEventID, barrierOrdinal, projectionHash := b.activeSessionBarrier()
+	// #1793 case 2: same torn-read fix as SendActiveSessionWithParams.
+	b.sessionMu.RLock()
 	info := b.cachedSessionInfo
+	b.sessionMu.RUnlock()
 	_ = b.session.SendActiveSessionWithMode(sessionID, mode, b.AuthorityEpoch(), barrierEventID, barrierOrdinal, projectionHash, info.Workspace, info.Provider, info.Model)
 }
 


### PR DESCRIPTION
Case 1 (Med-High, #1792 family third instance): the bind path ran `SetIMAdapterEnabled` on the Cmd goroutine - config map write + disk save racing the panel's 2s tick range of the same map (**concurrent map read/write fatal**). The file's own #1367 comment claims the migration; `createWAAdapterCmd` got it, this bind path didn't. Sentinel + `waEnableMutation`, the nostr pattern.

Case 2 (Med, torn reads): two broker reads of `cachedSessionInfo` ran **without the lock** while the writer replaces the whole struct under the write lock (SendSnapshot reads the same field under RLock - the asymmetry was an omission). Multi-string torn reads sent corrupted workspace/provider to the relay. RLock snapshots now (verified `-race`).

Isolated worktree (fresh origin/main): tui PASS (10.2s) + tunnel PASS with -race (29.7s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)