### PR TITLE
fix(agent): cross-process lock + unique tmp for trajectory learnings persistence (#1512 case C)

### DIFF
--- a/internal/agent/traj_intel.go
+++ b/internal/agent/traj_intel.go
@@ -267,6 +267,12 @@ func (s *trajIntelState) persistLocked() error {
 		return fmt.Errorf("mkdir: %w", err)
 	}
 
+	unlock, lockErr := lockTrajFile(s.filePath + ".lock")
+	if lockErr != nil {
+		return fmt.Errorf("lock: %w", lockErr)
+	}
+	defer unlock()
+
 	// Read existing entries to maintain rolling window.
 	existing, loadErr := s.loadFromFile()
 	if loadErr != nil && !os.IsNotExist(loadErr) {
@@ -281,11 +287,20 @@ func (s *trajIntelState) persistLocked() error {
 	}
 
 	// Write atomically.
-	tmpPath := s.filePath + ".tmp"
-	f, err := os.Create(tmpPath)
+	// #1512 case C: the whole load→append→rewrite must run under a
+	// cross-PROCESS file lock — s.mu is per-Agent-instance, but the file
+	// is workspace-shared: two concurrently finishing agents each loaded
+	// the same baseline, appended their own learnings, and the LAST
+	// rename won, silently erasing the other's entries (a lost update
+	// directly against the "accumulated self-improvement" purpose). The
+	// tmp name is also unique now: two writers sharing the fixed
+	// ".tmp" path interleaved content into one file.
+	tmpF, err := os.CreateTemp(filepath.Dir(s.filePath), ".traj-*.tmp")
 	if err != nil {
 		return fmt.Errorf("create tmp: %w", err)
 	}
+	tmpPath := tmpF.Name()
+	f := tmpF
 	enc := json.NewEncoder(f)
 	for _, l := range all {
 		if encErr := enc.Encode(l); encErr != nil {

--- a/internal/agent/traj_intel_1512_test.go
+++ b/internal/agent/traj_intel_1512_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// #1512 case C pin: concurrent persistLocked from two states (simulating
+// two Agent instances on one workspace) must not lose entries.
+func Test1512TrajConcurrentPersistNoLostUpdate(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trajectory-learnings.jsonl")
+
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			s := &trajIntelState{filePath: path}
+			s.learnings = []trajectoryLearning{{Insight: "learning"}}
+			if err := s.persistLocked(); err != nil {
+				t.Errorf("worker %d persist: %v", w, err)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := 0
+	for _, b := range data {
+		if b == '\n' {
+			lines++
+		}
+	}
+	if lines != 4 {
+		t.Fatalf("lost update: 4 concurrent persists must yield 4 entries, got %d", lines)
+	}
+	// No residual tmp files from interleaved writers.
+	ents, _ := os.ReadDir(dir)
+	for _, e := range ents {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Fatalf("residual tmp file leaked: %s", e.Name())
+		}
+	}
+}

--- a/internal/agent/traj_intel_lock_unix.go
+++ b/internal/agent/traj_intel_lock_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package agent
+
+import (
+	"os"
+	"syscall"
+)
+
+// lockTrajFile takes an exclusive cross-process flock on lockPath,
+// creating it if needed. The returned unlock func must be called
+// (defer). #1512 case C: the trajectory JSONL is workspace-shared
+// across Agent instances and processes; the in-memory s.mu cannot
+// serialize them.
+func lockTrajFile(lockPath string) (func(), error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return func() {
+		syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		f.Close()
+	}, nil
+}

--- a/internal/agent/traj_intel_lock_windows.go
+++ b/internal/agent/traj_intel_lock_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package agent
+
+import (
+	"os"
+	"time"
+)
+
+// lockTrajFile is the Windows counterpart: an exclusive-create lock
+// file with bounded retry (flock semantics are unavailable without
+// LockFileEx plumbing; the O_EXCL marker is sufficient for the
+// lost-update window here and self-heals on process exit via the
+// stale-age sweep).
+func lockTrajFile(lockPath string) (func(), error) {
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			return func() { f.Close(); os.Remove(lockPath) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		// Stale sweep: a lock older than 30s is from a crashed holder.
+		if fi, statErr := os.Stat(lockPath); statErr == nil && time.Since(fi.ModTime()) > 30*time.Second {
+			os.Remove(lockPath)
+			continue
+		}
+		if time.Now().After(deadline) {
+			return nil, os.ErrDeadlineExceeded
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #1512 (case C; cases A/B were fixed by 47a0abb3 and the trailing-whitespace checker has since been removed entirely by #1704).

- **Case C (Low-Med, lost update)**: trajectory-learnings persistence now runs under a cross-process file lock — `s.mu` is per-Agent-instance but the JSONL is workspace-shared; two concurrently finishing agents each loaded the same baseline and the last rename silently erased the other's entries. Unix: flock on `<path>.lock`; Windows: O_EXCL marker with bounded retry + 30s stale sweep. The fixed `.tmp` path is replaced by `os.CreateTemp` unique names (interleaved-writer corruption).

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **23.4s PASS** (p=1). Pin: 4 concurrent persists yield 4 entries (no lost update), no residual tmp files.

Per team convention: merge only after this PR's CI is green.

Closes #1512

Generated with [ggcode](https://github.com/topcheer/ggcode)
