### PR TITLE
fix(provider,tunnel): calibration guard before the remote call; per-token salt (#1795 cases 1-4)

### DIFF
--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -564,6 +564,22 @@ func (p *AnthropicProvider) CountTokens(ctx context.Context, messages []Message)
 	if isFirst {
 		calCtx, cancel := context.WithTimeout(ctx, calibrateFirstTimeout)
 		defer cancel()
+		// #1795 case 1: the guard sat AFTER the remote call - the skip
+		// branch neither applied the result nor recorded a failure, so
+		// lastCalibrate stayed zero, shouldCalibrate was ALWAYS true, and
+		// every CountTokens made a synchronous 2s remote call (competing
+		// with the main API for rate limit) whose precise value was then
+		// DISCARDED for the local estimate. Guard first; when skipping,
+		// mark the calibration as done so the cadence holds.
+		// #1618-A: skip asymmetric samples - the local estimator counts
+		// only text, but image/tool_result-attachment/thinking blocks all
+		// land in the remote count. Feeding such a sample pinned the
+		// ratio at the 3.0 clamp for the whole visual session.
+		if messagesContainNonTextBlocks(messages) {
+			debug.Log("provider-calibrator", "first calibration skipped: non-text blocks (image/thinking) make the sample asymmetric")
+			p.calibrator.recordSkip()
+			return estimated, nil
+		}
 		realTokens, err := p.remoteCountTokens(calCtx, messages)
 		if err != nil {
 			debug.Log("provider-calibrator", "first calibration failed: %v", err)
@@ -571,16 +587,6 @@ func (p *AnthropicProvider) CountTokens(ctx context.Context, messages []Message)
 			// a synchronous remote attempt on every call (#708); permanent
 			// 404/403 errors disable inside remoteCountTokens.
 			p.calibrator.recordFailure()
-			return estimated, nil
-		}
-		// #1618-A: skip asymmetric samples - the local estimator counts
-		// only text, but image/tool_result-attachment/thinking blocks all
-		// land in the remote count. Feeding such a sample pinned the
-		// ratio at the 3.0 clamp for the whole visual session (every
-		// subsequent estimate x3 -> premature compaction), and it could
-		// never converge because images stay in context.
-		if messagesContainNonTextBlocks(messages) {
-			debug.Log("provider-calibrator", "first calibration skipped: non-text blocks (image/thinking) make the sample asymmetric")
 			return estimated, nil
 		}
 		p.calibrator.applyResult(estimated, realTokens)
@@ -594,15 +600,17 @@ func (p *AnthropicProvider) CountTokens(ctx context.Context, messages []Message)
 	safego.Go("provider.calibrateTokens", func() {
 		calCtx, cancel := context.WithTimeout(context.Background(), calibrateAsyncTimeout)
 		defer cancel()
+		// #1795 case 1: same reordering as the first-calibration path -
+		// guard BEFORE paying for the remote call.
+		if messagesContainNonTextBlocks(messages) {
+			debug.Log("provider-calibrator", "async calibration skipped: non-text blocks (image/thinking) make the sample asymmetric")
+			p.calibrator.recordSkip()
+			return
+		}
 		realTokens, err := p.remoteCountTokens(calCtx, messages)
 		if err != nil {
 			debug.Log("provider-calibrator", "async calibration failed: %v", err)
 			p.calibrator.recordFailure() // transient errors back off, don't disable (#708)
-			return
-		}
-		// #1618-A: same asymmetry guard as the first-calibration path.
-		if messagesContainNonTextBlocks(messages) {
-			debug.Log("provider-calibrator", "async calibration skipped: non-text blocks (image/thinking) make the sample asymmetric")
 			return
 		}
 		p.calibrator.applyResult(estimated, realTokens)
@@ -619,7 +627,15 @@ func messagesContainNonTextBlocks(messages []Message) bool {
 	for _, m := range messages {
 		for _, b := range m.Content {
 			switch b.Type {
-			case "image", "tool_result", "thinking", "redacted_thinking":
+			// #1795 case 2: tool_result was filtered WHOLESALE, but the
+			// local estimator already counts its Output text (symmetric) -
+			// only its EMBEDDED IMAGES are asymmetric. Agent sessions
+			// ALWAYS carry tool_result from the first tool call on, so the
+			// async calibration never ran for any real agent session and
+			// the ratio froze on the first pure-text sample. Images and
+			// thinking blocks remain asymmetric (counted remotely,
+			// invisible locally).
+			case "image", "thinking", "redacted_thinking":
 				return true
 			}
 		}

--- a/internal/provider/token_calibrator.go
+++ b/internal/provider/token_calibrator.go
@@ -136,6 +136,20 @@ func (c *tokenCountCalibrator) applyResult(estimated, realTokens int) {
 		estimated, realTokens, observedRatio, c.ratio)
 }
 
+// recordSkip marks a calibration attempt as performed-but-skipped (an
+// asymmetric sample, #1795 case 1): the cadence clock advances without
+// counting a failure or disabling - the OLD code left lastCalibrate zero
+// on every skip, so shouldCalibrate stayed true and each CountTokens paid
+// a synchronous remote call whose result was then discarded.
+func (c *tokenCountCalibrator) recordSkip() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.enabled {
+		return
+	}
+	c.lastCalibrate = time.Now()
+}
+
 // recordFailure records a failed calibration attempt (429/5xx/network) and
 // starts (or extends) the exponential backoff window (#708). After
 // calibrateMaxConsecutiveFailures consecutive failures the calibrator is

--- a/internal/provider/token_calibrator_test.go
+++ b/internal/provider/token_calibrator_test.go
@@ -9,10 +9,19 @@ func TestMessagesContainNonTextBlocks(t *testing.T) {
 	if messagesContainNonTextBlocks(pure) {
 		t.Fatal("text-only messages must not flag")
 	}
-	for _, typ := range []string{"image", "tool_result", "thinking", "redacted_thinking"} {
+	// #1795 case 2: tool_result WITHOUT embedded images is symmetric (the
+	// local estimator counts its Output text) and must NOT flag - agent
+	// sessions carry tool_result from the first tool call on, and the old
+	// wholesale filter froze the calibration ratio on the first pure-text
+	// sample for virtually every real agent session.
+	for _, typ := range []string{"image", "thinking", "redacted_thinking"} {
 		with := []Message{{Role: "user", Content: []ContentBlock{{Type: "text", Text: "hi"}, {Type: typ}}}}
 		if !messagesContainNonTextBlocks(with) {
 			t.Fatalf("%s block must flag the message set", typ)
 		}
+	}
+	withResult := []Message{{Role: "user", Content: []ContentBlock{{Type: "text", Text: "hi"}, {Type: "tool_result", Output: "done"}}}}
+	if messagesContainNonTextBlocks(withResult) {
+		t.Fatal("plain tool_result (no embedded images) is symmetric - must not flag (#1795 case 2)")
 	}
 }

--- a/internal/tunnel/crypto.go
+++ b/internal/tunnel/crypto.go
@@ -4,10 +4,12 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
-
 	"golang.org/x/crypto/argon2"
+	"strings"
 )
 
 // Crypto provides AES-GCM encryption/decryption using the token as key.
@@ -25,6 +27,12 @@ type Crypto struct {
 // Length policy: <16 bytes -> argon2id-derived 32-byte key; 16/24/32 -> used
 // directly; >32 -> truncated to 32 (intermediate lengths 17-31 also truncate).
 func NewCrypto(tokenHex string) (*Crypto, error) {
+	// #1795 case 4: an empty token shared a deterministic key anyone
+	// could recompute offline - the sibling relay_client.go rejects this
+	// explicitly; the public constructor must too.
+	if strings.TrimSpace(tokenHex) == "" {
+		return nil, errors.New("crypto: empty session token")
+	}
 	// Decode hex token to get key bytes
 	key := []byte(tokenHex)
 	// If key is too short for AES, derive via argon2id
@@ -33,9 +41,13 @@ func NewCrypto(tokenHex string) (*Crypto, error) {
 	// But AES only supports 16, 24, or 32 byte keys.
 	// For simplicity: if len < 16, derive; if 16/24/32, use directly; else truncate to 32.
 	if len(key) < 16 {
-		// Derive 32-byte key via argon2id
-		var salt [16]byte
-		derived := argon2.IDKey(key, salt[:], 1, 64*1024, 4, 32)
+		// Derive 32-byte key via argon2id. #1795 case 3: the salt was a
+		// FIXED all-zero array - precomputable across every installation
+		// (rainbow-able for low-entropy tokens). Salt from the key material
+		// itself: deterministic per token (relays must derive the same key
+		// without a shared salt channel) but no longer globally constant.
+		salt := sha256.Sum256(append([]byte("ggcode-tunnel-salt-v1"), key...))
+		derived := argon2.IDKey(key, salt[:16], 1, 64*1024, 4, 32)
 		key = derived
 	} else if len(key) > 32 {
 		key = key[:32]


### PR DESCRIPTION
Case 1 (High): the asymmetry guard sat **after** `remoteCountTokens` - the skip branch neither applied the result nor recorded a failure, so `lastCalibrate` stayed zero, `shouldCalibrate` was ALWAYS true, and every CountTokens paid a synchronous 2s remote call (competing with the main API for rate limit) **whose precise value was then discarded** for the local estimate. Guards now run before the call; skips advance the cadence clock via `recordSkip` (no failure, no disable - #708's backoff semantics preserved).

Case 2 (Med): `tool_result` was filtered wholesale, but the local estimator already counts its Output text - only **embedded images** are asymmetric. Agent sessions carry tool_result from the first tool call on, so the async calibration **never ran for any real agent session**; the ratio froze on the first pure-text sample. Pin synced to the new semantics.

Case 3 (Med-Low): argon2id salt was a **fixed all-zero array** - precomputable across installations. Now derived from the key material (deterministic per token - relays must match - but not globally constant).

Case 4 (Med): `NewCrypto("")` rejected (the sibling caller already did; the public constructor must too).

Isolated worktree (fresh origin/main): provider full PASS (4.2s) + tunnel full PASS (13.5s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)