### PR TITLE
fix(agent): wire session token budget consumption; silent-error resource-key model (#1494)

### DIFF
--- a/ggcode.example.yaml
+++ b/ggcode.example.yaml
@@ -527,7 +527,7 @@ im:
 max_iterations: 0
 
 # Maximum total tokens (input + output) per agent run (0 = unlimited)
-# Progressive warnings at 75% and 90%, hard stop at 100%.
+# Progressive warnings at 80% and 95%, hard stop at 100%.
 # session_token_budget: 0
 
 # Maximum total tool calls per agent run (0 = auto-derive from max_iterations)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1548,6 +1548,10 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 	a.editAbandon.reset()
 	a.toolCallBudget.reset()
 	a.toolCallBudget.SetDefaultBudget(deriveDefaultBudget(a.maxIter))
+	// #1494 case A: per-run accumulation reset - without it the 80/95/100
+	// tier flags stay latched from the previous run (stopGiven=true makes
+	// Record permanently silent for every later run in this process).
+	a.resetSessionTokenUsage()
 
 	// Reset the unread-file edit tracker so each run starts fresh.
 	a.unreadEdit.reset()
@@ -2137,6 +2141,22 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 		a.maybeSetAutopilotGoalFromLLMOutput(textBuf)
 		a.syncContextManagerUsage(resp.Usage)
 		a.emitUsage(resp.Usage)
+		// #1494 case A: session token budget consumption - setter/getter/
+		// check existed since #543 but the usage-accumulation site was never
+		// wired, so the whole feature was a no-op (10x over-budget ran with
+		// zero warnings or stop). Record here; guidance mirrors the cache-
+		// efficiency injection path.
+		if msg, stop := a.RecordSessionTokenUsage(int64(resp.Usage.InputTokens), int64(resp.Usage.OutputTokens)); msg != "" {
+			a.crossDetectorConsensus.recordFiring("Session Token Budget", i+1)
+			a.injectGuidance(msg)
+			debug.Log("session-token-budget", "threshold crossed at iteration %d stop=%v", i+1, stop)
+			if stop {
+				onEvent(provider.StreamEvent{
+					Type: provider.StreamEventSystem,
+					Text: "[Session token budget fully consumed — winding down. Summarize the state so the user can resume with a fresh budget.] ",
+				})
+			}
+		}
 		// Context Engineering: monitor cache efficiency and forecast context
 		// window pressure after each LLM call. Both are zero-LLM-cost
 		// deterministic analysis. Guidance is injected into the context

--- a/internal/agent/checks_1494_test.go
+++ b/internal/agent/checks_1494_test.go
@@ -1,0 +1,68 @@
+package agent
+
+import "testing"
+
+// #1494 case A pin: Record + reset wiring exists and tiers fire.
+func Test1494SessionBudgetTiers(t *testing.T) {
+	a := &Agent{}
+	a.SetSessionTokenBudget(1000)
+	a.resetSessionTokenUsage()
+	if _, stop := a.RecordSessionTokenUsage(900, 0); stop {
+		t.Fatal("80% must be guidance, not stop")
+	}
+	msg, stop := a.RecordSessionTokenUsage(60, 0) // 96%
+	if stop || msg == "" {
+		t.Fatalf("95%% must warn: stop=%v msg=%q", stop, msg)
+	}
+	_, stop = a.RecordSessionTokenUsage(100, 0) // 106%
+	if !stop {
+		t.Fatal("100%+ must stop")
+	}
+	// Reset clears the latched stop (per-run freshness).
+	a.resetSessionTokenUsage()
+	if _, stop := a.RecordSessionTokenUsage(10, 0); stop {
+		t.Fatal("after reset the budget must re-arm")
+	}
+}
+
+// #1494 case C pin: editing a source file addresses a command-class error.
+func Test1494EditAddressesCommandError(t *testing.T) {
+	st := newSilentErrorStateFor1494()
+	st.recordToolError("run_command", "go build ./...", "exit status 1", 1)
+	if !st.actionAddressesError("/src/foo.go", "edit_file") {
+		t.Fatal("file edit must address a command-class error (textbook fix flow)")
+	}
+}
+
+// #1494 case D pin: uncovered-tool successes are not advancement.
+func Test1494UncoveredToolNoAdvancement(t *testing.T) {
+	st := newSilentErrorStateFor1494()
+	st.recordToolError("edit_file", "/a/foo.go", "anchor not found", 1)
+	for i := 0; i < 8; i++ {
+		if msg := st.recordToolAction("lsp_diagnostics", ""); msg != "" {
+			t.Fatalf("uncovered tool must be silent, got %q", msg)
+		}
+	}
+}
+
+// #1494 case E pins: empty-key errors survive unrelated clears; sibling
+// paths do not cross-clear.
+func Test1494ClearBoundaryAndEmptyKey(t *testing.T) {
+	st := newSilentErrorStateFor1494()
+	st.recordToolError("web_search", "", "boom", 1)
+	st.recordToolError("edit_file", "/a/foo.go", "anchor", 2)
+	st.clearAddressedErrors("/a/foo.go")
+	if len(st.unresolvedErrors) != 1 {
+		t.Fatalf("empty-key error must survive an unrelated clear, got %d", len(st.unresolvedErrors))
+	}
+	st2 := newSilentErrorStateFor1494()
+	st2.recordToolError("edit_file", "/a/foo.go", "anchor", 1)
+	st2.clearAddressedErrors("/a/foobar.go")
+	if len(st2.unresolvedErrors) != 1 {
+		t.Fatal("/a/foobar.go must not clear /a/foo.go (byte-prefix, not path-prefix)")
+	}
+}
+
+func newSilentErrorStateFor1494() *silentErrorState {
+	return &silentErrorState{}
+}

--- a/internal/agent/silent_error.go
+++ b/internal/agent/silent_error.go
@@ -46,6 +46,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/topcheer/ggcode/internal/debug"
@@ -124,8 +125,20 @@ func (s *silentErrorState) recordToolAction(toolName, resourceKey string) string
 		return ""
 	}
 
+	// #1494 case D: tools whose resource model is "" (lsp_diagnostics,
+	// git_diff, code_execution, todo_write, batch_replace, file_ops,
+	// web_search, ...) must not count as silent advancement. The error
+	// side stores empty-key errors, but the action side's early return
+	// made EVERY uncovered-tool success an advancement++ - the standard
+	// recovery trio (lsp_diagnostics + git_diff + todo_write after a
+	// failed edit) triggered the "fix before continuing" indictment.
+	// Symmetric skip: no key, no signal either way.
+	if resourceKey == "" {
+		return ""
+	}
+
 	// Check if this action addresses an unresolved error.
-	if s.actionAddressesError(resourceKey) {
+	if s.actionAddressesError(resourceKey, toolName) {
 		// The agent is revisiting the error â clear matched errors.
 		s.clearAddressedErrors(resourceKey)
 		s.lastErrorResource = ""
@@ -148,7 +161,7 @@ func (s *silentErrorState) recordToolAction(toolName, resourceKey string) string
 // actionAddressesError checks if the current tool action targets the same
 // resource as an unresolved error (e.g., retrying the same edit, reading the
 // error file, running the same command with fixes).
-func (s *silentErrorState) actionAddressesError(resourceKey string) bool {
+func (s *silentErrorState) actionAddressesError(resourceKey string, toolName string) bool {
 	if resourceKey == "" {
 		return false
 	}
@@ -157,6 +170,15 @@ func (s *silentErrorState) actionAddressesError(resourceKey string) bool {
 		ueKey := normalizeResourceKey(ue.resourceKey)
 		if ueKey == "" {
 			continue
+		}
+		// #1494 case C: command-class errors (2-token keys like "go
+		// build") are canonically fixed by editing SOURCE FILES - a
+		// different resource. The same-key assumption turned the textbook
+		// "build fails -> edit source -> retest" flow into an
+		// unaddressed-error indictment. Any file-editing action addresses
+		// a command-class error.
+		if isCommandKey(ueKey) && isEditTool(toolName) {
+			return true
 		}
 		// Same resource key = directly addressing the error.
 		if resourceKey == ueKey {
@@ -177,14 +199,53 @@ func (s *silentErrorState) clearAddressedErrors(resourceKey string) {
 	filtered := s.unresolvedErrors[:0]
 	for _, ue := range s.unresolvedErrors {
 		ueKey := normalizeResourceKey(ue.resourceKey)
+		// #1494 case E(a): an empty stored key must never match -
+		// HasPrefix(k, "") is always true, so ONE legitimately addressed
+		// error cleared ALL empty-key errors in the same sweep.
+		if ueKey == "" {
+			filtered = append(filtered, ue)
+			continue
+		}
 		if ueKey == resourceKey ||
-			strings.HasPrefix(resourceKey, ueKey) ||
-			strings.HasPrefix(ueKey, resourceKey) {
+			pathPrefixMatch(resourceKey, ueKey) ||
+			pathPrefixMatch(ueKey, resourceKey) {
 			continue // Remove addressed error
 		}
 		filtered = append(filtered, ue)
 	}
 	s.unresolvedErrors = filtered
+}
+
+// pathPrefixMatch reports whether longer starts with shorter as a
+// filesystem-path prefix (separator boundary), not a byte prefix:
+// /a/foo.go must NOT match /a/foobar.go (#1494 case E(b)).
+func pathPrefixMatch(longer, shorter string) bool {
+	if !strings.HasPrefix(longer, shorter) {
+		return false
+	}
+	if len(longer) == len(shorter) {
+		return true
+	}
+	// Boundary: next char must be a separator (or the shorter endswith one).
+	if strings.HasSuffix(shorter, "/") {
+		return true
+	}
+	return len(longer) > len(shorter) && (longer[len(shorter)] == '/' || longer[len(shorter)] == filepath.Separator)
+}
+
+// isCommandKey reports whether a resource key is command-shaped (the
+// 2-token form normalizeResourceKey produces for go/npm/cargo/python
+// commands) rather than a file path or pattern.
+func isCommandKey(key string) bool {
+	fields := strings.Fields(key)
+	if len(fields) != 2 {
+		return false
+	}
+	switch fields[0] {
+	case "go", "npm", "cargo", "python", "python3", "yarn", "pnpm", "make", "pytest":
+		return true
+	}
+	return false
 }
 
 func (s *silentErrorState) buildGuidance() string {


### PR DESCRIPTION
## Summary
Closes #1494 (cases A/C/D/E; case B already landed via parallel fix in ApplySessionTokenBudget).

- **Case A (High)**: session token budget was end-to-end no-op — consumption never wired. RecordSessionTokenUsage now fires after each LLM call's usage emission (guidance injected; system event at hard stop), resetSessionTokenUsage joins the run-start reset block (stopGiven no longer latches across runs). example.yaml thresholds aligned (80/95, not 75/90).
- **Case C (Med)**: command-class errors ("go build") are addressed by any file-editing action — the same-key assumption indicted the textbook "build fails → edit source → retest" flow.
- **Case D (Med)**: tools with no resource model (lsp_diagnostics/git_diff/todo_write/...) no longer count as silent advancement — the recovery trio after a failed edit no longer trips "fix before continuing".
- **Case E (Low x2)**: empty-key errors survive unrelated clears; prefix matching is path-boundary-aware (/a/foo.go vs /a/foobar.go).

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **30.4s PASS** (p=1). Pins: budget tier firing + re-arm after reset; edit addresses command error; uncovered-tool silence; empty-key survival + sibling-path isolation.

Per team convention: merge only after this PR's CI is green.

Closes #1494

Generated with [ggcode](https://github.com/topcheer/ggcode)
