### PR TITLE
fix(agent): regex-loop alias imports; multiset delta for same-pattern growth (#1488 case C)

### DIFF
--- a/internal/agent/checks_1488_test.go
+++ b/internal/agent/checks_1488_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import "testing"
+
+// #1488 case C(a) pin: alias-imported regexp compiles in loops must be detected.
+func Test1488RegexAliasImportDetected(t *testing.T) {
+	src := `package p
+import r "regexp"
+func f(items []string) bool {
+	for _, s := range items {
+		re := r.MustCompile("^a")
+		if re.MatchString(s) { return true }
+	}
+	return false
+}
+`
+	warns := findRegexInLoops("alias.go", src)
+	if len(warns) == 0 {
+		t.Fatal("alias import (import r \"regexp\") compile-in-loop undetected")
+	}
+	// Canonical name recorded.
+	if warns[0].funcName != "regexp.MustCompile" {
+		t.Fatalf("funcName should be canonical, got %q", warns[0].funcName)
+	}
+}
+
+// #1488 case C(b) pin: growing 1 -> 2 instances of the same pattern must flag the surplus.
+func Test1488RegexSamePatternGrowth(t *testing.T) {
+	one := `package p
+import "regexp"
+func f(xs, ys []string) {
+	for _, s := range xs {
+		_ = regexp.MustCompile("^a").MatchString(s)
+	}
+}
+`
+	two := `package p
+import "regexp"
+func f(xs, ys []string) {
+	for _, s := range xs {
+		_ = regexp.MustCompile("^a").MatchString(s)
+	}
+	for _, s := range ys {
+		_ = regexp.MustCompile("^a").MatchString(s)
+	}
+}
+`
+	if w := checkRegexLoop("g.go", one, two); len(w) == 0 {
+		t.Fatal("added second instance of an existing pattern must be flagged (set-delta suppressed it)")
+	}
+	// Unchanged file stays silent.
+	if w := checkRegexLoop("g.go", one, one); len(w) != 0 {
+		t.Fatalf("no-delta edit must stay silent, got %v", w)
+	}
+}

--- a/internal/agent/regex_loop_check.go
+++ b/internal/agent/regex_loop_check.go
@@ -96,16 +96,25 @@ func checkRegexLoop(filePath, oldContent, newContent string) []string {
 	// introduced patterns pass silently) and over-reports (an added instance
 	// makes untouched old instances count as "new") (#1017).
 	if strings.TrimSpace(oldContent) != "" {
-		oldFPs := make(map[string]bool)
+		// #1488 case C(b): MULTISET delta, not set difference. The set form
+		// suppressed an ADDED instance of an already-present pattern (same
+		// pattern in a second loop stayed unflagged after an edit grew 1
+		// occurrence to 2) - #1017 fixed count-comparison, but the set
+		// difference reintroduced the under-report for the same-fingerprint
+		// growth case. Decrement per match: only the surplus occurrences
+		// count as newly introduced.
+		oldFPs := make(map[string]int)
 		for _, oi := range findRegexInLoops(filePath, oldContent) {
-			oldFPs[oi.fingerprint()] = true
+			oldFPs[oi.fingerprint()]++
 		}
 		if len(oldFPs) > 0 {
 			fresh := newIssues[:0]
 			for _, ni := range newIssues {
-				if !oldFPs[ni.fingerprint()] {
-					fresh = append(fresh, ni)
+				if oldFPs[ni.fingerprint()] > 0 {
+					oldFPs[ni.fingerprint()]--
+					continue
 				}
+				fresh = append(fresh, ni)
 			}
 			newIssues = fresh
 			if len(newIssues) == 0 {
@@ -158,6 +167,34 @@ func findRegexInLoops(filename, src string) []regexLoopIssue {
 
 	var results []regexLoopIssue
 
+	// #1488 case C(a): resolve import aliases to canonical package names -
+	// `import r "regexp"` yields the call name "r.MustCompile", which the
+	// regexCompileFuncs table (canonical "regexp.*" keys) never matched:
+	// alias-importing files were completely undetected. Map every local
+	// alias of "regexp" back to the canonical prefix.
+	alias := make(map[string]string) // local name -> canonical pkg
+	for _, imp := range file.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if path != "regexp" {
+			continue
+		}
+		local := "regexp"
+		if imp.Name != nil {
+			local = imp.Name.Name
+		}
+		if local != "." && local != "_" {
+			alias[local] = "regexp"
+		}
+	}
+	canonical := func(name string) string {
+		if i := strings.IndexByte(name, '.'); i > 0 {
+			if base, ok := alias[name[:i]]; ok {
+				return base + name[i:]
+			}
+		}
+		return name
+	}
+
 	// The outer Inspect visits nested loop statements after already scanning
 	// them as part of the enclosing loop body, so the same call is reached
 	// twice with the same position — dedup by pos (#1017).
@@ -185,7 +222,7 @@ func findRegexInLoops(filename, src string) []regexLoopIssue {
 			if !ok {
 				return true
 			}
-			name := callFuncName(call)
+			name := canonical(callFuncName(call))
 			if regexCompileFuncs[name] {
 				if seenPos[call.Pos()] {
 					return true


### PR DESCRIPTION
## Summary
Closes #1488 (case C; cases A/B already landed via parallel fixes — reproRan filter at the observeText call site, ownershipTransferred struct-field/channel extensions).

- **Case C(a) (Low)**: alias imports (`import r "regexp"`) now resolve to the canonical package before the compile-func table lookup — alias-importing files were completely undetected before.
- **Case C(b) (Low)**: the delta is now a multiset comparison — an edit growing the same pattern from 1 loop to 2 is flagged as surplus; untouched files stay silent (the #1017 set-difference had reintroduced the under-report for same-fingerprint growth).

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **109.8s PASS** (p=1). Pins: alias import detected with canonical funcName; 1→2 same-pattern growth flagged, no-delta edit silent.

Per team convention: merge only after this PR's CI is green.

Closes #1488

Generated with [ggcode](https://github.com/topcheer/ggcode)
