### PR TITLE
style(desktop): gofmt notifications_1504_test.go (main Format red)

### DIFF
--- a/desktop/ggcode-desktop-wails/notifications_1504_test.go
+++ b/desktop/ggcode-desktop-wails/notifications_1504_test.go
@@ -30,9 +30,9 @@ func Test1504DeliverUnixBounded(t *testing.T) {
 // deliverUnix bound above is the behavioral one.)
 func Test1504SourceContracts(t *testing.T) {
 	srcs := map[string]string{
-		"main.go":           "runtime.WindowShow(app.ctx)",
-		"app.go":            "a.dc.SetGlobalHotkey(false)",
-		"notifications.go":  "exec.CommandContext(ctx",
+		"main.go":          "runtime.WindowShow(app.ctx)",
+		"app.go":           "a.dc.SetGlobalHotkey(false)",
+		"notifications.go": "exec.CommandContext(ctx",
 	}
 	for f, needle := range srcs {
 		data, err := os.ReadFile(f)


### PR DESCRIPTION
## Root cause
af20c5da (#1504) landed desktop/ggcode-desktop-wails/notifications_1504_test.go unformatted. The repo-wide Format probe ('gofmt -l .') has been red on main since - first observed failing #2060's PR checks (its merge-ref already contained #1504; earlier PRs like #2057 checked against pre-#1504 refs and passed). Every subsequent PR inherits the red Format until this lands.

## Change
Pure gofmt -w on that single file: 3 insertions, 3 deletions, whitespace only. Zero semantic change; gofmt -l . returns empty on this branch.

Note for #1504 domain owner: please run gofmt on new test files before commit - the repo-wide probe makes any single unformatted file block the whole pipeline.

## Verification
gofmt -l . (excluding .ggcode worktrees) = 0 files on this branch.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)