### PR TITLE
fix(agent,tool): route fan-out writers through the pre-write dry-run gate (#1547 case A)

### DIFF
--- a/internal/agent/agent_tool.go
+++ b/internal/agent/agent_tool.go
@@ -382,7 +382,15 @@ func (a *Agent) executeTool(ctx context.Context, tc provider.ToolCallDelta) tool
 	}
 
 	// For file-editing tools: read old content, compute new, show diff, save checkpoint
-	if tc.Name == "multi_file_edit" {
+	// #1547 case A: every tool implementing PreviewChanges routes through
+	// the dry-run/preview/checkpoint path. Previously only multi_file_edit
+	// did - multi_edit_file, multi_file_write and batch_replace (the
+	// fan-out writers whose blast radius is largest) fell through to bare
+	// safeExecute with NO pre-write gate: one wrong batch edit punched
+	// through N files with only the post-write integrity floor left.
+	// notebook_edit/lsp_rename/file_ops stay exempt (no faithful preview).
+	if tc.Name == "multi_file_edit" || tc.Name == "multi_edit_file" ||
+		tc.Name == "multi_file_write" || tc.Name == "batch_replace" {
 		if previewer, ok := t.(interface {
 			PreviewChanges(input json.RawMessage) ([]tool.PlannedFileEdit, error)
 		}); ok {

--- a/internal/tool/preview_1547.go
+++ b/internal/tool/preview_1547.go
@@ -1,0 +1,135 @@
+package tool
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// PreviewChanges implementations for the fan-out write tools that were
+// routed through the bare safeExecute path (#1547 case A): a wrong batch
+// edit could punch through N files with no pre-write gate - the most
+// dangerous fan-out tools were exactly the unprotected ones.
+//
+// notebook_edit and lsp_rename stay exempt: the notebook preview value is
+// nil (JSON, not Go - the syntax gate is .go-scoped) and lsp_rename's
+// resulting content is produced by the language server, unknowable
+// pre-execution. file_ops move/delete cannot be dry-run (no content).
+
+// PreviewChanges plans multi_edit_file's in-memory result using the exact
+// planTextEdits matcher the executor uses.
+func (t MultiEditFile) PreviewChanges(input json.RawMessage) ([]PlannedFileEdit, error) {
+	var args struct {
+		FilePath string `json:"file_path"`
+		Edits    []struct {
+			OldText string `json:"old_text"`
+			NewText string `json:"new_text"`
+		} `json:"edits"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return nil, err
+	}
+	if args.FilePath == "" {
+		return nil, fmt.Errorf("missing file_path")
+	}
+	resolved, err := resolveToolPath(args.FilePath, t.WorkingDir)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, err
+	}
+	edits := make([]textEdit, len(args.Edits))
+	for i, e := range args.Edits {
+		edits[i] = textEdit{OldText: e.OldText, NewText: e.NewText}
+	}
+	original := string(data)
+	content, _, msg := planTextEdits(original, edits)
+	if msg != "" {
+		// Anchor mismatch: let the executor surface its error verbatim.
+		return nil, fmt.Errorf("%s", msg)
+	}
+	return []PlannedFileEdit{{Path: resolved, OldContent: original, NewContent: content}}, nil
+}
+
+// PreviewChanges plans multi_file_write (full content is given directly).
+func (t MultiFileWrite) PreviewChanges(input json.RawMessage) ([]PlannedFileEdit, error) {
+	var args struct {
+		Files []struct {
+			Path    string `json:"path"`
+			Content string `json:"content"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return nil, err
+	}
+	plans := make([]PlannedFileEdit, 0, len(args.Files))
+	for _, f := range args.Files {
+		resolved, err := resolveToolPath(f.Path, t.WorkingDir)
+		if err != nil {
+			return nil, err
+		}
+		old, _ := os.ReadFile(resolved) // missing file = create, old ""
+		plans = append(plans, PlannedFileEdit{Path: resolved, OldContent: string(old), NewContent: f.Content})
+	}
+	return plans, nil
+}
+
+// PreviewChanges plans batch_replace by simulating the executor's own
+// regex/literal replacement per file.
+func (t BatchReplace) PreviewChanges(input json.RawMessage) ([]PlannedFileEdit, error) {
+	var args struct {
+		Pattern     string   `json:"pattern"`
+		Replacement string   `json:"replacement"`
+		IsRegex     bool     `json:"is_regex"`
+		Files       []string `json:"files"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return nil, err
+	}
+	if args.Pattern == "" || len(args.Files) == 0 {
+		return nil, fmt.Errorf("missing pattern or files")
+	}
+	var re *regexp.Regexp
+	if args.IsRegex {
+		compiled, err := regexp.Compile(args.Pattern)
+		if err != nil {
+			// Invalid regex: the executor errors out anyway - let it speak.
+			return nil, err
+		}
+		re = compiled
+	}
+	plans := make([]PlannedFileEdit, 0, len(args.Files))
+	for _, f := range args.Files {
+		resolved, err := resolveToolPath(f, t.WorkingDir)
+		if err != nil {
+			return nil, err
+		}
+		data, err := os.ReadFile(resolved)
+		if err != nil {
+			continue // executor reports per-file errors; preview skips
+		}
+		content := string(data)
+		var newContent string
+		if re != nil {
+			if re.MatchString(content) {
+				newContent = re.ReplaceAllString(content, args.Replacement)
+			} else {
+				newContent = content
+			}
+		} else {
+			if strings.Contains(content, args.Pattern) {
+				newContent = strings.ReplaceAll(content, args.Pattern, args.Replacement)
+			} else {
+				newContent = content
+			}
+		}
+		if newContent != content {
+			plans = append(plans, PlannedFileEdit{Path: resolved, OldContent: content, NewContent: newContent})
+		}
+	}
+	return plans, nil
+}

--- a/internal/tool/preview_1547_test.go
+++ b/internal/tool/preview_1547_test.go
@@ -1,0 +1,81 @@
+package tool
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #1547 case A pins: the fan-out writers must expose faithful previews
+// (the dry-run gate runs on these).
+func Test1547PreviewMultiEditFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a.go")
+	os.WriteFile(p, []byte("package p\n\nfunc f() {}\n"), 0o644)
+	tt := MultiEditFile{WorkingDir: dir}
+	input, _ := json.Marshal(map[string]any{
+		"file_path": p,
+		"edits": []map[string]string{
+			{"old_text": "func f() {}", "new_text": "func g() {}"},
+		},
+	})
+	plans, err := tt.PreviewChanges(input)
+	if err != nil || len(plans) != 1 {
+		t.Fatalf("preview failed: %v plans=%d", err, len(plans))
+	}
+	if plans[0].OldContent == plans[0].NewContent || !contains1547(plans[0].NewContent, "func g()") {
+		t.Fatalf("preview must simulate the edit, got new=%q", plans[0].NewContent)
+	}
+}
+
+func Test1547PreviewMultiFileWrite(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "b.txt")
+	os.WriteFile(p, []byte("old"), 0o644)
+	tt := MultiFileWrite{WorkingDir: dir}
+	input, _ := json.Marshal(map[string]any{
+		"files": []map[string]string{{"path": p, "content": "brand new"}},
+	})
+	plans, err := tt.PreviewChanges(input)
+	if err != nil || len(plans) != 1 {
+		t.Fatalf("preview failed: %v plans=%d", err, len(plans))
+	}
+	if plans[0].OldContent != "old" || plans[0].NewContent != "brand new" {
+		t.Fatalf("bad plan: old=%q new=%q", plans[0].OldContent, plans[0].NewContent)
+	}
+}
+
+func Test1547PreviewBatchReplace(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "c.txt")
+	os.WriteFile(p, []byte("foo1 foo2"), 0o644)
+	tt := BatchReplace{WorkingDir: dir}
+	// literal
+	input, _ := json.Marshal(map[string]any{"pattern": "foo", "replacement": "bar", "files": []string{p}})
+	plans, err := tt.PreviewChanges(input)
+	if err != nil || len(plans) != 1 || plans[0].NewContent != "bar1 bar2" {
+		t.Fatalf("literal preview wrong: err=%v plans=%d new=%q", err, len(plans), plans[0].NewContent)
+	}
+	// regex
+	input2, _ := json.Marshal(map[string]any{"pattern": `foo(\d)`, "replacement": "n$1", "is_regex": true, "files": []string{p}})
+	plans2, err := tt.PreviewChanges(input2)
+	if err != nil || len(plans2) != 1 || plans2[0].NewContent != "n1 n2" {
+		t.Fatalf("regex preview wrong: err=%v new=%q", err, plans2[0].NewContent)
+	}
+	// no match -> no plan
+	input3, _ := json.Marshal(map[string]any{"pattern": "zzz", "replacement": "x", "files": []string{p}})
+	plans3, _ := tt.PreviewChanges(input3)
+	if len(plans3) != 0 {
+		t.Fatalf("no-match must yield no plan, got %d", len(plans3))
+	}
+}
+
+func contains1547(h, n string) bool {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
Closes #1547 (case A; case B — extractEditFilePaths 9-tool coverage — already landed via parallel fix).

- **Case A (Med)**: the dry-run pre-write defense covered only 3 of 9 source-mutating tools. multi_edit_file, multi_file_write and batch_replace — the fan-out writers with the largest blast radius — fell through to bare safeExecute. They now implement PreviewChanges (multi_edit reuses the executor's exact planTextEdits matcher; batch_replace simulates the executor's own regex/literal ReplaceAll) and route through executeMultiFileTool's dry-run batch gate + diff confirm + post-write guidance.
- notebook_edit / lsp_rename / file_ops stay exempt with documented rationale (no faithful pre-execution content).

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/tool **74.1s** + internal/agent **32.9s** PASS (p=1). Pins: multi_edit preview simulates the edit; multi_file_write carries old/new; batch_replace literal/regex/no-match triple.

Per team convention: merge only after this PR's CI is green.

Closes #1547

Generated with [ggcode](https://github.com/topcheer/ggcode)
