### PR TITLE
fix(agent): window-consistent failure-mode density; transient streak sync; scoped churn clearing (#1561)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4080,7 +4080,14 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 					a.editPropagation.recordGreenBuild()
 					// #1460-C: a green verification confirms the edit
 					// sequence was legitimate refinement, not churn.
-					a.fileChurn.recordVerifySuccess()
+					// #1561 case B: only failure-aware verification (test/
+					// build/vet-class) may clear, and the clear is scoped
+					// to the command's path arguments - `gofmt -l .` (green
+					// while REPORTING problems), `make clean` and
+					// scope-unrelated commands no longer wipe the books.
+					if isStrictVerifyCommand(cmd) {
+						a.fileChurn.recordVerifySuccess(cmd)
+					}
 				}
 			}
 			// Convergence lock: record verification result to detect post-verify

--- a/internal/agent/checks_1561_test.go
+++ b/internal/agent/checks_1561_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import "testing"
+
+// #1561 case A pin: mid-run spiral must fire within the streak window,
+// not need S*3/7 consecutive failures over a lifelong denominator.
+func Test1561StructuralDensityWindow(t *testing.T) {
+	s := &failureModeState{fired: map[FailureMode]bool{}}
+	// 50 successful calls first (the old math needed 22 consecutive fails).
+	for i := 0; i < 50; i++ {
+		s.recordResult("read_file", false, "")
+	}
+	fired := ""
+	for i := 0; i < 6 && fired == ""; i++ {
+		fired = s.recordResult("edit_file", true, "anchor not found")
+	}
+	if fired == "" {
+		t.Fatal("true mid-run spiral (6 consecutive structural fails after 50 successes) must fire")
+	}
+	// Scattered FIXED failures never fire (streak reset already guards).
+	s2 := &failureModeState{fired: map[FailureMode]bool{}}
+	for round := 0; round < 10; round++ {
+		s2.recordResult("edit_file", true, "anchor not found")
+		s2.recordResult("edit_file", true, "anchor not found")
+		s2.recordResult("edit_file", true, "anchor not found")
+		if g := s2.recordResult("run_command", false, ""); g != "" {
+			t.Fatalf("fixed-in-round failures must not fire, got %q", g)
+		}
+	}
+}
+
+// #1561 case C pin: scattered recovered transients never fire.
+func Test1561TransientStreak(t *testing.T) {
+	s := &failureModeState{fired: map[FailureMode]bool{}}
+	for round := 0; round < 5; round++ {
+		s.recordResult("run_command", true, "i/o timeout")
+		s.recordResult("run_command", true, "context deadline exceeded")
+		if g := s.recordResult("read_file", false, ""); g != "" {
+			t.Fatalf("recovered timeout pair must not fire, got %q", g)
+		}
+	}
+	// Three CONSECUTIVE transients fire.
+	s3 := &failureModeState{fired: map[FailureMode]bool{}}
+	s3.recordResult("run_command", true, "i/o timeout")
+	s3.recordResult("run_command", true, "timeout")
+	var fired string
+	for i := 0; i < 2 && fired == ""; i++ {
+		fired = s3.recordResult("run_command", true, "timed out")
+	}
+	if fired == "" {
+		t.Fatal("3 consecutive transients must fire")
+	}
+}
+
+// #1561 case D pin: fired latch resets on success (same-batch ordering).
+func Test1561FiredRelatch(t *testing.T) {
+	s := &failureModeState{fired: map[FailureMode]bool{}}
+	for i := 0; i < 5; i++ {
+		s.recordResult("edit_file", true, "anchor not found")
+	}
+	if !s.fired[FailureModeStructural] {
+		t.Fatal("precondition: alert fired")
+	}
+	s.recordResult("run_command", false, "")
+	if s.fired[FailureModeStructural] {
+		t.Fatal("success must un-latch the premature fired flag")
+	}
+}
+
+// #1561 case E pin: coordinate-embedded numbers are not status codes.
+func Test1561TransientWordBoundary(t *testing.T) {
+	if classifyFailureMode("run_command", "foo.go:429:5: syntax error") == FailureModeTransient {
+		t.Fatal("file:line coordinate 429 must not classify TRANSIENT")
+	}
+	if classifyFailureMode("run_command", "ifoo.go:1502: missing") == FailureModeTransient {
+		t.Fatal("coordinate 502 must not classify TRANSIENT")
+	}
+	if classifyFailureMode("run_command", "HTTP 429 Too Many Requests") != FailureModeTransient {
+		t.Fatal("genuine HTTP 429 must classify TRANSIENT")
+	}
+	if classifyFailureMode("run_command", "error 503 service unavailable") != FailureModeTransient {
+		t.Fatal("genuine 503 must classify TRANSIENT")
+	}
+	if classifyFailureMode("run_command", "14293 connection issue") == FailureModeTransient {
+		t.Fatal("embedded digit run 14293 must not match 429")
+	}
+}
+
+// #1561 case B pins: strict gate + scoped clearing.
+func Test1561ChurnStrictScopedClear(t *testing.T) {
+	c := &churnState{editCounts: map[string]int{}}
+	c.recordEdit([]string{"/w/internal/a/foo.go", "/w/internal/b/bar.go"})
+	// gofmt -l is NOT a strict verify - the agent.go gate never reaches
+	// recordVerifySuccess for it, so the books survive.
+	if isStrictVerifyCommand("gofmt -l .") {
+		t.Fatal("gofmt -l must not be strict verify")
+	}
+	if c.editCounts["/w/internal/a/foo.go"] != 1 {
+		t.Fatal("gofmt -l green must not clear churn books (gate upstream)")
+	}
+	// Scoped: go test ./internal/a only clears a/.
+	c.recordVerifySuccess("go test ./internal/a/...")
+	if _, ok := c.editCounts["/w/internal/a/foo.go"]; ok {
+		t.Fatal("scoped command must clear its scope")
+	}
+	if c.editCounts["/w/internal/b/bar.go"] != 1 {
+		t.Fatal("out-of-scope file must survive scoped clear")
+	}
+	// Repo-wide clears everything; make clean is not strict.
+	if !isStrictVerifyCommand("go test ./...") || isStrictVerifyCommand("make clean") {
+		t.Fatal("strict classification wrong")
+	}
+	c.recordVerifySuccess("go test ./...")
+	if len(c.editCounts) != 0 {
+		t.Fatal("repo-wide strict verify must clear all")
+	}
+}

--- a/internal/agent/failure_mode.go
+++ b/internal/agent/failure_mode.go
@@ -83,6 +83,13 @@ type failureModeState struct {
 
 	// total tool calls (for ratio calculation)
 	totalCalls int
+
+	// #1561 case A: totalCalls snapshot when the current structural streak
+	// began - the density denominator must measure the SAME window as the
+	// streak numerator, not the lifelong total (streak/lifelong made the
+	// mid-run death spiral mathematically unreachable: after 50 successful
+	// calls, firing needs 22 CONSECUTIVE failures - beyond most run caps).
+	structuralStreakStart int
 }
 
 func newFailureModeState() *failureModeState {
@@ -175,6 +182,16 @@ func classifyFailureMode(toolName, errorContent string) FailureMode {
 		"capacity",
 	}
 	for _, p := range transientPatterns {
+		// #1561 case E: digit-only patterns need token boundaries -
+		// `foo.go:429:5: syntax error` contains "429" and a DETERMINISTIC
+		// compile error was classified TRANSIENT ('retry with delays' for
+		// a syntax error). Word patterns stay substring-matched.
+		if isAllDigits1561(p) {
+			if containsToken1561(c, p) {
+				return FailureModeTransient
+			}
+			continue
+		}
 		if strings.Contains(c, p) {
 			return FailureModeTransient
 		}
@@ -196,7 +213,19 @@ func (s *failureModeState) recordResult(toolName string, isError bool, errorCont
 		// #1460-B: successes decay the structural streak - a long run with
 		// isolated, FIXED failures must not accumulate into a strategy
 		// verdict ('approach is fundamentally wrong, Do NOT retry').
+		// #1561 case D: also un-latch the fired flag - a premature alert
+		// from same-batch parallel ordering ([edit xN, verify green] with
+		// the verify result landing after the edits) must not leave a
+		// stale fired latch for the rest of the run.
 		s.structuralCount = 0
+		delete(s.fired, FailureModeStructural)
+		// #1561 case C: transient gets the SAME streak treatment - a
+		// lifelong counter fired '[retry strategy isn't working]' after 3
+		// scattered, individually-recovered timeouts spaced 100 calls
+		// apart. Consecutive failures are the signal; recovered ones are
+		// noise.
+		s.transientCount = 0
+		delete(s.fired, FailureModeTransient)
 		return ""
 	}
 
@@ -205,6 +234,10 @@ func (s *failureModeState) recordResult(toolName string, isError bool, errorCont
 	case FailureModeTransient:
 		s.transientCount++
 	case FailureModeStructural:
+		if s.structuralCount == 0 {
+			// Streak begins NOW: the density window opens with it (#1561 A).
+			s.structuralStreakStart = s.totalCalls
+		}
 		s.structuralCount++
 	case FailureModeSystemic:
 		s.systemicCount++
@@ -248,9 +281,19 @@ func (s *failureModeState) checkDominantMode() string {
 	// STRUCTURAL is also the fallback default class, so it inflates easily.
 	// totalCalls (previously a write-only field 'for ratio calculation'
 	// that never calculated) finally earns its keep.
+	// #1561 case A: windowed density - denominator is calls since the
+	// streak began, matching the numerator's window. The old
+	// streak/lifelong ratio made a genuine mid-run spiral unreachable
+	// (after S successful calls it needs S*3/7 CONSECUTIVE failures, e.g.
+	// 22 after 50); the scattered-fixed-failure false positive it guarded
+	// against was ALREADY eliminated by the streak reset above.
+	streakWindow := s.totalCalls - s.structuralStreakStart + 1
+	if s.structuralStreakStart == 0 {
+		streakWindow = s.totalCalls
+	}
 	structuralRatio := 0.0
-	if s.totalCalls > 0 {
-		structuralRatio = float64(s.structuralCount) / float64(s.totalCalls)
+	if streakWindow > 0 {
+		structuralRatio = float64(s.structuralCount) / float64(streakWindow)
 	}
 	if s.structuralCount >= 4 && structuralRatio >= 0.30 && !s.fired[FailureModeStructural] {
 		s.fired[FailureModeStructural] = true
@@ -263,3 +306,40 @@ func (s *failureModeState) checkDominantMode() string {
 
 	return ""
 }
+
+// isAllDigits1561 reports whether the pattern is a bare number (needs
+// token-boundary matching, #1561 case E).
+func isAllDigits1561(p string) bool {
+	if p == "" {
+		return false
+	}
+	for i := 0; i < len(p); i++ {
+		if p[i] < '0' || p[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// containsToken1561 reports whether s contains the digit run needle as a
+// status-code-shaped token: it must not be embedded in a larger digit run
+// AND must not sit in a file:line:col position slot (adjacent ':' or '/'
+// delimiters on either side mark compiler coordinate output like
+// "foo.go:429:5: syntax error", which is a DETERMINISTIC error - matching
+// it as HTTP 429 prescribed retry delays for a syntax error, #1561 E).
+func containsToken1561(s, needle string) bool {
+	for i := 0; i+len(needle) <= len(s); i++ {
+		if s[i:i+len(needle)] != needle {
+			continue
+		}
+		leftOK := i == 0 || (!isDigitByte1561(s[i-1]) && s[i-1] != ':' && s[i-1] != '/')
+		j := i + len(needle)
+		rightOK := j == len(s) || (!isDigitByte1561(s[j]) && s[j] != ':')
+		if leftOK && rightOK {
+			return true
+		}
+	}
+	return false
+}
+
+func isDigitByte1561(b byte) bool { return b >= '0' && b <= '9' }

--- a/internal/agent/file_churn_detect.go
+++ b/internal/agent/file_churn_detect.go
@@ -69,10 +69,62 @@ func (c *churnState) reset() {
 // is confirmed green are legitimate refinement - the old bare count
 // reached the threshold on the third polish pass and ordered the agent
 // to 'STOP editing, your initial assumptions were wrong'.
-func (c *churnState) recordVerifySuccess() {
-	for p := range c.editCounts {
-		delete(c.editCounts, p)
+func (c *churnState) recordVerifySuccess(cmd string) {
+	// #1561 case B: scope the clear to what the command actually verified.
+	// `go test ./internal/a/...` green certifies internal/a - it says
+	// nothing about internal/b being blindly re-edited; a repo-wide command
+	// (no path arguments) certifies everything.
+	scopes := commandPathScopes1561(cmd)
+	if len(scopes) == 0 {
+		for p := range c.editCounts {
+			delete(c.editCounts, p)
+		}
+		return
 	}
+	for p := range c.editCounts {
+		for _, sc := range scopes {
+			if pathUnderScope1561(p, sc) {
+				delete(c.editCounts, p)
+				break
+			}
+		}
+	}
+}
+
+// commandPathScopes1561 extracts path-shaped tokens from a command
+// (arguments containing '/' or './' style roots). Returns nil when the
+// command is repo-wide.
+func commandPathScopes1561(cmd string) []string {
+	var scopes []string
+	for _, tok := range strings.Fields(strings.ToLower(cmd)) {
+		if tok == "./..." || tok == "." || tok == "..." {
+			return nil // repo-wide
+		}
+		if strings.HasPrefix(tok, "./") || strings.HasPrefix(tok, "/") ||
+			(strings.Contains(tok, "/") && !strings.Contains(tok, "=")) {
+			scopes = append(scopes, strings.TrimSuffix(tok, "/..."))
+		}
+	}
+	return scopes
+}
+
+// pathUnderScope1561 reports whether file path p falls under scope dir.
+// The scope may be relative (./internal/a from `go test ./internal/a/...`)
+// while edit paths are absolute (/w/repo/internal/a/foo.go) - match on the
+// core segment boundary, not byte prefix.
+func pathUnderScope1561(p, scope string) bool {
+	scope = strings.TrimSuffix(scope, "/...")
+	scope = strings.TrimPrefix(scope, "./")
+	if scope == "" || scope == "/" || scope == "." {
+		return true
+	}
+	pp := strings.ToLower(p)
+	if strings.HasPrefix(pp, scope+"/") || pp == scope {
+		return true
+	}
+	// Segment-boundary containment: ./internal/a matches
+	// /w/repo/internal/a/foo.go, but NOT /w/repo/xinternal/a/foo.go.
+	return strings.Contains(pp, "/"+scope+"/")
 }
 
 // recordEdit increments the edit count for the given file paths.


### PR DESCRIPTION
## Summary
Closes #1561 (all five cases).

- **Case A (Med-High)**: density gate denominator now matches the streak's window instead of lifelong totalCalls — the old ratio made a genuine mid-run death spiral mathematically unreachable (22 consecutive failures needed after 50 successes).
- **Case B (Med)**: churn clearing gated on the canonical strictVerifyCommands table (reusing fix_cascade's hardened isStrictVerifyCommand) and scoped by the command's path arguments — `gofmt -l .` (green while reporting problems), `make clean`, and scope-unrelated commands no longer wipe the books.
- **Case C (Low-Med)**: transientCount mirrors the structural streak treatment — scattered recovered timeouts no longer accumulate to a false "[retry strategy isn't working]".
- **Case D (Low)**: fired latches reset on success — same-batch premature alerts don't persist all run.
- **Case E (Low)**: digit-only status patterns match with coordinate-slot-aware boundaries — `foo.go:429:5: syntax error` is STRUCTURAL, `HTTP 429` is TRANSIENT.

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **22.5s PASS** (p=1). Pins: mid-run spiral fires in-window; scattered fixed failures silent; transient 3-consecutive vs recovered-pair; coordinate-vs-HTTP 429; strict gate + scoped/repo-wide clearing.

Per team convention: merge only after this PR's CI is green.

Closes #1561

Generated with [ggcode](https://github.com/topcheer/ggcode)
