### PR TITLE
fix(agent): guidance budget slot/dedup/pool semantics; cross-path conflict arbitration (#1840)

### DIFF
--- a/internal/agent/checks_1840_test.go
+++ b/internal/agent/checks_1840_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1840 case 1 pin: a budget-rejected hint must not occupy its dedup slot.
+func Test1840DedupSlotOnlyOnDelivery(t *testing.T) {
+	g := &guidanceBudget{injected: guidanceBudgetPerTurn} // count cap reached
+	long := "[loop-guard] " + strings.Repeat("x", 100)
+	if g.allowDeduped(long) {
+		t.Fatal("precondition: count cap must reject")
+	}
+	// The rejected hint must NOT have taken its dedup slot.
+	if g.seenHintTags["loop-guard"] {
+		t.Fatal("rejected hint must not occupy the dedup slot")
+	}
+	// Positive control: a delivered hint DOES take it.
+	if !g.allowDeduped("[hardcoded-secret] critical passes the count cap") {
+		t.Fatal("critical must bypass the count cap")
+	}
+	if !g.seenHintTags["hardcoded-secret"] {
+		t.Fatal("delivered hint must occupy the dedup slot")
+	}
+	if g.allowDeduped("[hardcoded-secret] duplicate copy") {
+		t.Fatal("delivered tag must dedup later copies")
+	}
+}
+
+// #1840 case 2 pin: critical hints have a dedicated byte pool - a full
+// advisory pool cannot starve them.
+func Test1840CriticalDedicatedPool(t *testing.T) {
+	g := &guidanceBudget{}
+	g.appendedBytes = guidanceBudgetBytesPerTurn // advisory pool FULL
+	if !g.allowDeduped("[hardcoded-secret] critical notice") {
+		t.Fatal("critical must not starve behind a full advisory pool")
+	}
+	// Flood of critical is still bounded by the dedicated pool.
+	g2 := &guidanceBudget{}
+	big := "[hardcoded-secret] " + strings.Repeat("y", guidanceBudgetCriticalBytesPerTurn-100)
+	if !g2.allowDeduped(big) {
+		t.Fatal("first big critical fits the dedicated pool")
+	}
+	if g2.allowDeduped("[SAFETY] " + strings.Repeat("z", 100)) {
+		t.Fatal("dedicated critical pool must still bound floods")
+	}
+}
+
+// #1840 case 3 pin: same-tag dedup loss is visible.
+func Test1840DedupLossVisible(t *testing.T) {
+	hints := []string{
+		"[loop-guard] first content",
+		"[loop-guard] different content same tag",
+		"[other] fine",
+	}
+	out, dropped := dedupByTag(hints)
+	if dropped != 1 || len(out) != 2 {
+		t.Fatalf("dedup wrong: out=%d dropped=%d", len(out), dropped)
+	}
+	notated := noteDedupDropped(out, dropped)
+	joined := strings.Join(notated, "\n")
+	if !strings.Contains(joined, "duplicate tags") {
+		t.Fatalf("loss must be visible, got %q", joined)
+	}
+}
+
+// #1840 case 4 pin: iteration-level guidance joins conflict arbitration.
+func Test1840ConflictAcrossPaths(t *testing.T) {
+	g := &guidanceBudget{}
+	g.delivered = []string{"Error rush: ACT NOW and commit to a fix."}
+	ch := detectGuidanceConflict(append(append([]string{}, g.delivered...), "Recommendation: EXPLORE alternatives before editing."))
+	if ch == "" {
+		t.Fatal("ACT NOW vs EXPLORE across paths must be arbitrated")
+	}
+}

--- a/internal/agent/guidance_budget.go
+++ b/internal/agent/guidance_budget.go
@@ -50,6 +50,16 @@ const (
 	// - or tool-hint bytes silently starve detector guidance and vice versa).
 	// Critical hints bypass the count cap but still charge this byte cap.
 	guidanceBudgetBytesPerTurn = 2048
+
+	// #1840 case 2: critical hints charge a DEDICATED sub-pool instead of
+	// competing with advisory in the shared one. The shared pool is
+	// allocated first-come-first-served across parallel tool results, so
+	// early results' advisory could eat all 2048 bytes and later results'
+	// [hardcoded-secret]/[git-destructive] notices were silently dropped -
+	// priority only existed WITHIN a single result. The dedicated pool
+	// keeps #1197's flood bound (a critical-tag stream is still capped,
+	// just separately) while making critical priority real cross-result.
+	guidanceBudgetCriticalBytesPerTurn = 1024
 )
 
 // #441: critical classification uses ONLY the head tag (extractHintTag)
@@ -68,6 +78,15 @@ type guidanceBudget struct {
 	// tool-result hint path (allowDeduped) and injectGuidance charge against it
 	// (#1206 symmetry fix).
 	appendedBytes int
+	// criticalBytes is the dedicated critical-hint byte pool (#1840 case 2).
+	criticalBytes int
+	// delivered records the guidance texts actually delivered this turn
+	// across BOTH paths (#1840 case 4) so conflict arbitration can see the
+	// union - injectGuidance guidance previously bypassed the conflict
+	// detector entirely (it only scanned a single tool result's hint set),
+	// so an errorRush "ACT NOW" injection could coexist with a later
+	// "EXPLORE" hint with no arbitration.
+	delivered []string
 	// seenHintTags records tags of tool-result hints already injected this
 	// turn (#607 B3: cross-result dedup - the same meta-hint must not be
 	// re-injected into every subsequent tool result).
@@ -84,22 +103,27 @@ func (g *guidanceBudget) reset() {
 	g.suppressed = 0
 	g.seenHintTags = nil
 	g.appendedBytes = 0
+	g.criticalBytes = 0
+	g.delivered = nil
 }
 
 // allow checks whether a guidance message with the given text should be
 // injected. Returns true if the message should proceed (either within
 // budget or critical), false if it should be suppressed.
 func (g *guidanceBudget) allow(text string) bool {
-	// Byte-level flood cap applies to EVERYTHING, including critical hints:
-	// a stream of [SECURITY]-tagged notices can otherwise drown a result
-	// just as effectively as advisory noise (#1197).
+	// Critical messages first, against their dedicated pool (#1840 case 2).
+	if isCriticalGuidance(text) {
+		if g.criticalBytes+len(text) > guidanceBudgetCriticalBytesPerTurn {
+			g.suppressed++
+			return false
+		}
+		return true
+	}
+	// Byte-level flood cap for advisory (#1197: a stream of tagged notices
+	// can otherwise drown a result just as effectively as noise).
 	if g.appendedBytes+len(text) > guidanceBudgetBytesPerTurn {
 		g.suppressed++
 		return false
-	}
-	// Critical messages always pass through.
-	if isCriticalGuidance(text) {
-		return true
 	}
 	if g.injected < guidanceBudgetPerTurn {
 		g.injected++
@@ -126,18 +150,34 @@ func (g *guidanceBudget) allowDeduped(text string) bool {
 			g.suppressed++
 			return false
 		}
-		g.seenHintTags[tag] = true
+		// #1840 case 1: mark the dedup slot ONLY on delivery. Marking
+		// before allow() left the tag permanently recorded when the byte
+		// pool rejected the hint - the same tag (including later CRITICAL
+		// copies, which check dedup before the critical bypass) was then
+		// blocked for the rest of the turn while the hint was never
+		// delivered: the #681 "returned != delivered" residue.
 	}
 	ok := g.allow(text)
 	if ok {
-		g.chargeBytes(len(text))
+		if tag != "" {
+			if g.seenHintTags == nil {
+				g.seenHintTags = make(map[string]bool)
+			}
+			g.seenHintTags[tag] = true
+		}
+		g.chargeBytes(len(text), isCriticalGuidance(text))
+		g.delivered = append(g.delivered, text)
 	}
 	return ok
 }
 
 // chargeBytes records that n bytes of hint text were actually appended to
 // a tool result (#1197). Called by allowDeduped after a successful allow.
-func (g *guidanceBudget) chargeBytes(n int) {
+func (g *guidanceBudget) chargeBytes(n int, critical bool) {
+	if critical {
+		g.criticalBytes += n
+		return
+	}
 	g.appendedBytes += n
 }
 
@@ -181,7 +221,21 @@ func (a *Agent) injectGuidance(text string) bool {
 	// gated by the byte cap but never charged it, so tool-hint bytes could
 	// silently starve iteration-level detector guidance (and unlimited
 	// iteration injections never filled the pool for tool hints either).
-	a.guidanceBudget.chargeBytes(len(text))
+	// #1840 case 4: iteration-level guidance joins the conflict scan set.
+	// detectGuidanceConflict previously ran only over one tool result's
+	// retained hints; this path's injections (errorRush "ACT NOW" etc.)
+	// could contradict them unimpeded.
+	if ch := detectGuidanceConflict(append(append([]string{}, a.guidanceBudget.delivered...), text)); ch != "" && a.guidanceBudget.allowDeduped(ch) {
+		a.contextManager.Add(provider.Message{
+			Role: "user",
+			Content: []provider.ContentBlock{{
+				Type: "text",
+				Text: ch,
+			}},
+		})
+	}
+	a.guidanceBudget.chargeBytes(len(text), isCriticalGuidance(text))
+	a.guidanceBudget.delivered = append(a.guidanceBudget.delivered, text)
 	a.contextManager.Add(provider.Message{
 		Role: "user",
 		Content: []provider.ContentBlock{{

--- a/internal/agent/guidance_coalesce.go
+++ b/internal/agent/guidance_coalesce.go
@@ -141,13 +141,14 @@ func coalesceGuidance(hints []string) []string {
 	}
 	if len(hints) <= coalesceMaxHints {
 		// Even with few hints, deduplicate by tag.
-		return dedupByTag(hints)
+		deduped, dropped := dedupByTag(hints)
+		return noteDedupDropped(deduped, dropped)
 	}
 
 	// Deduplicate first.
-	deduped := dedupByTag(hints)
+	deduped, dropped := dedupByTag(hints)
 	if len(deduped) <= coalesceMaxHints {
-		return deduped
+		return noteDedupDropped(deduped, dropped)
 	}
 
 	// Separate critical from advisory.
@@ -194,18 +195,23 @@ func coalesceGuidance(hints []string) []string {
 }
 
 // dedupByTag removes hints with duplicate tags, keeping the first
-// occurrence of each tag.
-func dedupByTag(hints []string) []string {
+// occurrence of each tag. Dropped copies are reported via the returned
+// count so the loss is visible (#1840 case 3): same-tag drops used to be
+// fully silent AND ran before the cap stage, so they never reached the
+// suppression summary - two detectors reusing one tag collided invisibly.
+func dedupByTag(hints []string) ([]string, int) {
 	if len(hints) <= 1 {
-		return hints
+		return hints, 0
 	}
 
 	seen := make(map[string]bool, len(hints))
 	result := make([]string, 0, len(hints))
+	dropped := 0
 
 	for _, h := range hints {
 		tag := extractHintTag(h)
 		if tag != "" && seen[tag] {
+			dropped++
 			continue
 		}
 		if tag != "" {
@@ -213,8 +219,18 @@ func dedupByTag(hints []string) []string {
 		}
 		result = append(result, h)
 	}
+	return result, dropped
+}
 
-	return result
+// noteDedupDropped appends a one-line visibility note when same-tag
+// dedup dropped content (#1840 case 3).
+func noteDedupDropped(result []string, dropped int) []string {
+	if dropped <= 0 {
+		return result
+	}
+	return append(result, fmt.Sprintf(
+		"[%d additional hint(s) with duplicate tags were merged into the ones above]",
+		dropped))
 }
 
 // appendWithSuppression adds a suppression summary when critical hints

--- a/internal/agent/guidance_coalesce_test.go
+++ b/internal/agent/guidance_coalesce_test.go
@@ -214,7 +214,7 @@ func TestDedupByTag(t *testing.T) {
 		"[C] third",
 		"[B] duplicate of B",
 	}
-	result := dedupByTag(hints)
+	result, _ := dedupByTag(hints)
 	if len(result) != 3 {
 		t.Fatalf("expected 3 after dedup, got %d: %v", len(result), result)
 	}


### PR DESCRIPTION
## Summary
Closes #1840 (all four cases).

- **Case 1 (Med)**: dedup slots are taken only on delivery — a budget-rejected hint no longer permanently blocks its tag (including later critical copies).
- **Case 2 (Med-Low)**: critical hints charge a dedicated 1024-byte pool — early tool results' advisory can no longer eat the shared 2048-byte pool and starve later results' critical notices; the #1197 flood bound is preserved per-pool.
- **Case 3 (Low)**: same-tag dedup drops are counted and surfaced — the loss was invisible (dedup ran before the cap stage, never reaching the suppression summary).
- **Case 4 (Low-Med)**: injectGuidance joins conflict arbitration — delivered texts are tracked per turn across both paths and the union is scanned, closing the errorRush "ACT NOW" vs later "EXPLORE" coexistence gap.

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **21.5s PASS** (p=1). Pins: rejected hint leaves no slot / delivered tag dedups; critical passes a full advisory pool while the dedicated pool still bounds floods; dedup loss visible; cross-path conflict arbitrated.

Per team convention: merge only after this PR's CI is green.

Closes #1840

Generated with [ggcode](https://github.com/topcheer/ggcode)
