### PR TITLE
fix(im,tui): stale approval replies dropped; questionnaire wins dual-pending routing (#1833)

### DIFF
--- a/internal/im/inbound_route.go
+++ b/internal/im/inbound_route.go
@@ -39,6 +39,17 @@ func RouteInboundText(text string, hasPendingApproval, hasPendingAskUser bool) I
 	if IsInboundShellCommand(trimmed) {
 		return InboundRoute{Kind: InboundRouteShell, Text: trimmed}
 	}
+	// #1833 case 2: when BOTH an approval and a questionnaire are pending,
+	// the questionnaire wins. Questionnaire confirmations ("y"/"ok"/"好的")
+	// sit squarely inside ParseApprovalReply's affirmative set, so the old
+	// approval-first order intercepted them: the approval the user had not
+	// even seen got released and the questionnaire answer vanished - after
+	// a multi-round questionnaire, the confirm word colliding with a newly
+	// inserted approval misfired every time. Questionnaires carry explicit
+	// question-number semantics, so the disambiguation is deterministic.
+	if hasPendingAskUser {
+		return InboundRoute{Kind: InboundRouteAskUser, Text: trimmed}
+	}
 	if hasPendingApproval {
 		if decision, ok := ParseApprovalReply(trimmed); ok {
 			return InboundRoute{
@@ -48,9 +59,6 @@ func RouteInboundText(text string, hasPendingApproval, hasPendingAskUser bool) I
 				AlwaysAllow: decision == permission.Allow && IsApprovalAlwaysReply(trimmed),
 			}
 		}
-	}
-	if hasPendingAskUser {
-		return InboundRoute{Kind: InboundRouteAskUser, Text: trimmed}
 	}
 	return InboundRoute{Kind: InboundRouteMessage, Text: trimmed}
 }

--- a/internal/im/inbound_route_1833_test.go
+++ b/internal/im/inbound_route_1833_test.go
@@ -1,0 +1,27 @@
+package im
+
+import "testing"
+
+// #1833 case 2 pin: when both are pending, a confirm word routes to the
+// questionnaire, not the approval.
+func Test1833QuestionnaireWinsWhenBothPending(t *testing.T) {
+	r := RouteInboundText("y", true, true)
+	if r.Kind != InboundRouteAskUser {
+		t.Fatalf("confirm word must answer the questionnaire when both pending, got %v", r.Kind)
+	}
+	// Approval-only still parses.
+	r2 := RouteInboundText("y", true, false)
+	if r2.Kind != InboundRouteApproval {
+		t.Fatalf("approval-only must route approval, got %v", r2.Kind)
+	}
+	// Questionnaire-only unaffected.
+	r3 := RouteInboundText("anything free text", false, true)
+	if r3.Kind != InboundRouteAskUser {
+		t.Fatalf("questionnaire-only must route ask-user, got %v", r3.Kind)
+	}
+	// No pending: message.
+	r4 := RouteInboundText("hello", false, false)
+	if r4.Kind != InboundRouteMessage {
+		t.Fatalf("no pending must route message, got %v", r4.Kind)
+	}
+}

--- a/internal/im/inbound_route_test.go
+++ b/internal/im/inbound_route_test.go
@@ -14,7 +14,8 @@ func TestRouteInboundTextSlashWins(t *testing.T) {
 }
 
 func TestRouteInboundTextApproval(t *testing.T) {
-	route := RouteInboundText("always", true, true)
+	// #1833 case 2: approval-only pending routes "always" as before.
+	route := RouteInboundText("always", true, false)
 	if route.Kind != InboundRouteApproval {
 		t.Fatalf("Kind = %q, want %q", route.Kind, InboundRouteApproval)
 	}

--- a/internal/tui/update_remote.go
+++ b/internal/tui/update_remote.go
@@ -66,6 +66,18 @@ func (m Model) handleRemoteInbound(msg remoteInboundMsg, spinnerCmd tea.Cmd) (te
 	}
 
 	if route.Kind == im.InboundRouteApproval {
+		// #1833 case 1: mirror the questionnaire branch's stale guard (and
+		// the daemon bridge's #569 A timeout drop). The route decision came
+		// from a snapshot taken before handleRemoteInbound; if the approval
+		// was already answered locally / timed out in between, the late IM
+		// "y" must be dropped - leaking it further would crash on the nil
+		// ToolName read below or, worse, resubmit "y" as a fresh prompt.
+		if m.pendingApproval == nil {
+			if msg.Response != nil {
+				msg.Response <- nil
+			}
+			return m, nil
+		}
 		toolName := m.pendingApproval.ToolName
 		decisionStr := "deny"
 		var cmd tea.Cmd


### PR DESCRIPTION
## Summary
Closes #1833 (both cases).

- **Case 1 (Med)**: TUI approval branch gains the stale guard the questionnaire branch already had (and daemon bridge's #569 A): a late IM approval reply after local answer/timeout is dropped instead of crashing on nil ToolName or leaking "y" as a fresh prompt.
- **Case 2 (Med)**: dual-pending (approval + questionnaire) now routes to the questionnaire — confirm words ("y"/"ok"/"好的") sit inside ParseApprovalReply's affirmative set, so the old approval-first order released an unseen approval and swallowed the questionnaire answer. Questionnaires carry explicit question-number semantics, making the disambiguation deterministic.

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/im **65.2s** + internal/tui **11.0s** PASS (p=1). Pins: confirm word answers questionnaire under dual-pending; approval-only / questionnaire-only / no-pending unaffected. TestRouteInboundTextApproval updated to the new contract (it pinned the old approval-first order).

Per team convention: merge only after this PR's CI is green.

Closes #1833

Generated with [ggcode](https://github.com/topcheer/ggcode)
