### PR TITLE
fix(agent): speculator stat-snapshot freshness; memo hit permission parity (#1831)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3152,7 +3152,7 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			}
 			var result tool.Result
 			memoHit := false
-			if memoResult, hit := a.toolMemo.get(tc.Name, tc.Arguments); hit {
+			if memoResult, hit := a.toolMemo.get(tc.Name, tc.Arguments); hit && a.speculativeHitAllowed(ctx, tc) {
 				result = memoResult
 				memoHit = true
 				// Annotate cache hits so the model knows this is cached content, not a

--- a/internal/agent/checks_1831_test.go
+++ b/internal/agent/checks_1831_test.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/topcheer/ggcode/internal/tool"
+)
+
+// #1831 cases 1+2 pin: an external write between speculation and hit is a
+// MISS (was: served for up to 30s and then memoized as immortal).
+func Test1831SpeculatorFreshness(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.txt")
+	os.WriteFile(p, []byte("v0"), 0o644)
+	args, _ := json.Marshal(map[string]any{"file_path": p, "limit": 100})
+
+	sp := newSpeculator()
+	sp.store("read_file", args, tool.Result{Content: "content of v0"})
+
+	if _, ok := sp.getCached("read_file", args); !ok {
+		t.Fatal("unchanged file must stay a hit")
+	}
+	// External write: miss even well within the 30s TTL.
+	os.WriteFile(p, []byte("v1-external"), 0o644)
+	if _, ok := sp.getCached("read_file", args); ok {
+		t.Fatal("external write must invalidate the speculative hit (TTL alone was not freshness)")
+	}
+}
+
+// #1831 case 3 pin: hasCached re-verifies freshness before the pre-execution
+// batch decides to skip a would-be-fresh execution.
+func Test1831HasCachedFreshness(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "g.txt")
+	os.WriteFile(p, []byte("v0"), 0o644)
+	args, _ := json.Marshal(map[string]any{"file_path": p})
+
+	sp := newSpeculator()
+	sp.store("read_file", args, tool.Result{Content: "v0"})
+	if !sp.hasCached("read_file", args) {
+		t.Fatal("precondition: unchanged entry must report cached")
+	}
+	os.WriteFile(p, []byte("changed"), 0o644)
+	if sp.hasCached("read_file", args) {
+		t.Fatal("hasCached must re-verify freshness before suppressing pre-execution")
+	}
+}
+
+// #1831 sentinel pins: appearing-since-speculation is drift; still-absent is not.
+func Test1831SpeculatorAbsenceSemantics(t *testing.T) {
+	dir := t.TempDir()
+	// Appeared after speculation.
+	p := filepath.Join(dir, "new.txt")
+	args, _ := json.Marshal(map[string]any{"file_path": p})
+	sp := newSpeculator()
+	sp.store("read_file", args, tool.Result{Content: "was absent"})
+	os.WriteFile(p, []byte("now here"), 0o644)
+	if _, ok := sp.getCached("read_file", args); ok {
+		t.Fatal("file appearing after speculation must read as drift")
+	}
+	// Still absent: no false drift.
+	p2 := filepath.Join(dir, "never.txt")
+	args2, _ := json.Marshal(map[string]any{"file_path": p2})
+	sp2 := newSpeculator()
+	sp2.store("read_file", args2, tool.Result{Content: "absent"})
+	if _, ok := sp2.getCached("read_file", args2); !ok {
+		t.Fatal("still-absent file must remain a hit (no false drift)")
+	}
+}

--- a/internal/agent/speculate.go
+++ b/internal/agent/speculate.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"os"
 	"sync"
 	"time"
 
@@ -124,6 +125,50 @@ const (
 type speculativeResult struct {
 	result   tool.Result
 	cachedAt time.Time
+	// #1831 cases 1+2: freshness snapshot of the primary file behind the
+	// speculated read, taken at speculation time. The TTL alone let an
+	// external writer's change (shared workspace, editor autosave) be
+	// served as a fresh read for up to 30s - and worse, agent.go then
+	// memoized the stale content with a CURRENT stat, making it
+	// effectively immortal (the memo's mtime self-heal could never fire
+	// because the recorded mtime always matched the already-changed disk).
+	// On hit, the snapshot is re-verified: any mtime/size drift is a miss.
+	// Empty for tools with no single-file primary arg (TTL-only, as before).
+	freshPath  string
+	freshMtime int64 // unix nanos
+	freshSize  int64
+}
+
+// statSnapshotFor returns the freshness snapshot for a speculated call, or
+// zero values when the tool has no single-file primary argument (#1831).
+func statSnapshotFor(toolName string, args json.RawMessage) (path string, mtime, size int64) {
+	p := extractFilePathFromArgs(toolName, args)
+	if p == "" {
+		return "", 0, 0
+	}
+	st, err := os.Stat(p)
+	if err != nil {
+		// Unstatable now: record the path with impossible sentinel values so
+		// any later successful stat (file appeared / became readable) reads
+		// as drift and forces a fresh execution.
+		return p, -1, -1
+	}
+	return p, st.ModTime().UnixNano(), st.Size()
+}
+
+// freshStill holds for a snapshot when the underlying file is unchanged.
+func (r *speculativeResult) freshStill() bool {
+	if r.freshPath == "" {
+		return true // no snapshot: TTL-only (previous behavior)
+	}
+	st, err := os.Stat(r.freshPath)
+	if err != nil {
+		return r.freshMtime == -1 // was already absent and still is
+	}
+	if r.freshMtime == -1 {
+		return false // appeared since speculation: drift
+	}
+	return st.ModTime().UnixNano() == r.freshMtime && st.Size() == r.freshSize
 }
 
 func newSpeculator() *speculator {
@@ -226,6 +271,17 @@ func (s *speculator) getCached(toolName string, args json.RawMessage) (tool.Resu
 		s.maybeAdaptThreshold()
 		return tool.Result{}, false
 	}
+	// #1831 cases 1+2: TTL freshness does not cover external writes - a
+	// shared-workspace edit lands in milliseconds, not after 30s. Serve the
+	// hit only when the stat snapshot still matches the disk.
+	if !cached.freshStill() {
+		s.removeFromCacheOrder(key)
+		delete(s.cache, key)
+		s.misses++
+		s.maybeAdaptThreshold()
+		debug.Log("speculate", "cache HIT rejected for %s: file changed since speculation (key=%s)", toolName, key)
+		return tool.Result{}, false
+	}
 	s.hits++
 	debug.Log("speculate", "cache HIT for %s (key=%s)", toolName, key)
 	return cached.result, true
@@ -277,9 +333,13 @@ func (s *speculator) store(toolName string, args json.RawMessage, result tool.Re
 		}
 	}
 
+	fp, fm, fs := statSnapshotFor(toolName, args)
 	s.cache[key] = &speculativeResult{
-		result:   result,
-		cachedAt: time.Now(),
+		result:     result,
+		cachedAt:   time.Now(),
+		freshPath:  fp,
+		freshMtime: fm,
+		freshSize:  fs,
 	}
 	s.cacheOrder = append(s.cacheOrder, key)
 }
@@ -303,7 +363,10 @@ func (s *speculator) hasCached(toolName string, args json.RawMessage) bool {
 	if !ok {
 		return false
 	}
-	return time.Since(cached.cachedAt) <= s.ttl
+	// #1831 case 3: same freshness contract as getCached. hasCached gates
+	// the PRE-EXECUTION batch (a true skip abandons a would-be-fresh
+	// execution); a stale-on-disk entry must not suppress it.
+	return time.Since(cached.cachedAt) <= s.ttl && cached.freshStill()
 }
 
 // predictArgs predicts the arguments for the next tool based on the pattern.


### PR DESCRIPTION
## Summary
Closes #1831 (all four cases — the core is freshness-signal misalignment across the three caches).

- **Case 1 (High)**: speculator entries now carry an mtime+size snapshot taken at speculation time; getCached re-stats on hit. Previously a hit that raced an external write was memoized with a CURRENT stat — the memo's mtime self-heal could never fire and the stale read was effectively immortal.
- **Case 2 (Med-High)**: the same snapshot closes the speculator's own TTL-only freshness hole (external writes served as fresh reads for up to 30s). Absence sentinels: appear-after-spec = drift, still-absent = hit.
- **Case 3 (Med)**: hasCached (the pre-execution skip gate) applies the same re-verification — stale entries no longer suppress a would-be-fresh execution.
- **Case 4 (Low-Med)**: the memo hit path runs speculativeHitAllowed (the #1496 speculator gate) — allow->deny policy transitions stop being bypassed by previously memoized entries.

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **22.8s PASS** (p=1). Pins: external write invalidates a TTL-valid hit; hasCached re-verifies; appear-after-spec is drift / still-absent is not.

Per team convention: merge only after this PR's CI is green.

Closes #1831

Generated with [ggcode](https://github.com/topcheer/ggcode)
