### PR TITLE
fix(image,desktop): clipboard stream cap; TCC distinction; paste budget (#1807 cases 1+2+3)

### DIFF
--- a/desktop/ggcode-desktop-wails/app.go
+++ b/desktop/ggcode-desktop-wails/app.go
@@ -1023,6 +1023,29 @@ func (a *App) SendMessageWithImages(userMsg string, images []PastedImage) error 
 	}
 	text := strings.TrimSpace(userMsg)
 	imgs := append([]PastedImage(nil), images...)
+	// #1807 case 3: a single image is capped at 20MB, but an arbitrary
+	// array reached the agent untouched - 5x15MB originals became a
+	// ~100MB base64 message in context, persisted to the session JSONL
+	// and REPLAYED on every subsequent turn. Budget the entry point:
+	// count and total bytes.
+	const maxPasteImages = 5
+	const maxPasteTotalBytes = 30 << 20
+	if len(imgs) > maxPasteImages {
+		return fmt.Errorf("too many pasted images: %d (max %d) - send them in smaller batches", len(imgs), maxPasteImages)
+	}
+	var total int
+	for _, img := range imgs {
+		decoded, err := base64.StdEncoding.DecodeString(img.Base64)
+		if err == nil {
+			total += len(decoded)
+		} else {
+			// Undecodable payload still counts by its raw length.
+			total += len(img.Base64)
+		}
+	}
+	if total > maxPasteTotalBytes {
+		return fmt.Errorf("pasted images total %d bytes exceeds the %d byte budget - compress or send in batches", total, maxPasteTotalBytes)
+	}
 	safego.Go("wails-send-message-images", func() {
 		content := make([]provider.ContentBlock, 0, 1+len(imgs))
 		if text != "" {

--- a/internal/image/clipboard_darwin.go
+++ b/internal/image/clipboard_darwin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 func ReadClipboard() (Image, error) {
@@ -17,12 +18,27 @@ func ReadClipboard() (Image, error) {
 	defer os.RemoveAll(tmpDir)
 
 	pngPath := filepath.Join(tmpDir, "clipboard.png")
-	if err := writeClipboardImage("«class PNGf»", pngPath); err == nil {
+	// #1807 case 2: an osascript failure (TCC denial - the user clicked
+	// "Don't Allow" on the permission prompt) used to fold into
+	// ErrClipboardImageUnavailable, i.e. "no image" - every subsequent
+	// paste silently no-op'd and the user was nudged into pointless
+	// re-copying. #425 fixed this exact distinction for the file-list
+	// path; the image path lagged. Mirror it: only a TRULY empty
+	// clipboard maps to Unavailable.
+	pngErr := writeClipboardImage("«class PNGf»", pngPath)
+	if pngErr == nil {
 		return ReadFile(pngPath)
+	}
+	if !isNoClipboardImageError(pngErr) {
+		return Image{}, pngErr
 	}
 
 	tiffPath := filepath.Join(tmpDir, "clipboard.tiff")
-	if err := writeClipboardImage("TIFF picture", tiffPath); err != nil {
+	tiffErr := writeClipboardImage("TIFF picture", tiffPath)
+	if tiffErr != nil && !isNoClipboardImageError(tiffErr) {
+		return Image{}, tiffErr
+	}
+	if tiffErr != nil {
 		return Image{}, ErrClipboardImageUnavailable
 	}
 	if err := convertClipboardTIFFToPNG(tiffPath, pngPath); err != nil {
@@ -66,4 +82,20 @@ func convertClipboardTIFFToPNG(srcPath, dstPath string) error {
 		return commandOutputError("converting clipboard image", err, output)
 	}
 	return nil
+}
+
+// isNoClipboardImageError reports whether the osascript error means the
+// clipboard simply has no image (the AppleScript "missing value" /
+// clipboard-set-to-text family) - as opposed to a TCC permission denial
+// or an execution failure, which must surface (#1807 case 2, mirroring
+// the #425 file-list distinction).
+func isNoClipboardImageError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "missing value") ||
+		strings.Contains(msg, "can't get") ||
+		strings.Contains(msg, "doesn't contain") ||
+		strings.Contains(msg, "type of")
 }

--- a/internal/image/clipboard_linux.go
+++ b/internal/image/clipboard_linux.go
@@ -5,6 +5,7 @@ package image
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -129,9 +130,30 @@ func runClipboardCommand(name string, args ...string) ([]byte, error) {
 	cmd := exec.Command(name, args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
-	out, err := cmd.Output()
+	// #1807 case 1: Output() buffers the WHOLE stdout before any size
+	// check - a 2GB bitmap paste filled ~2GB of RAM on a shared machine
+	// before the 20MB check ever ran. The file-path side got a Stat
+	// pre-check in #438; the clipboard side lagged. Stream through a
+	// capped reader instead: too-large never materializes in full.
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, commandOutputError("reading clipboard image", err, stderr.Bytes())
 	}
-	return out, nil
+	if err := cmd.Start(); err != nil {
+		return nil, commandOutputError("reading clipboard image", err, stderr.Bytes())
+	}
+	const clipHardCap = 64 << 20 // 3x the 20MB logical limit: decode slack
+	capped := io.LimitReader(stdout, clipHardCap+1)
+	data, rerr := io.ReadAll(capped)
+	werr := cmd.Wait()
+	if rerr != nil {
+		return nil, commandOutputError("reading clipboard image", rerr, stderr.Bytes())
+	}
+	if int64(len(data)) > clipHardCap {
+		return nil, fmt.Errorf("clipboard image exceeds %d bytes", clipHardCap)
+	}
+	if werr != nil {
+		return nil, commandOutputError("reading clipboard image", werr, stderr.Bytes())
+	}
+	return data, nil
 }


### PR DESCRIPTION
Case 1 (Med, OOM): the Linux clipboard path buffered the **whole wl-paste/xclip stdout** before any size check - a 2GB bitmap paste filled ~2GB of RAM before the 20MB check ran. The file-path side got its Stat pre-check in #438; the clipboard side lagged. Streamed through a 64MB-capped reader: too-large never materializes in full.

Case 2 (Med): a macOS TCC denial (user clicked Don't Allow) folded into `ErrClipboardImageUnavailable` - 'no image' - so every subsequent paste silently no-op'd, nudging pointless re-copying. #425 fixed this exact distinction for the file-list path; the image path now mirrors it.

Case 3 (Med): `SendMessageWithImages` accepted arbitrary arrays - 5x15MB originals became a **~100MB base64 message in context, persisted to session JSONL and replayed every turn**. Entry-point budget: <=5 images, <=30MB total, with actionable errors.

Isolated worktree (fresh origin/main): image package full PASS; app.go verified via CI. gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)