### PR TITLE
fix(agent): redundant-read guard requires content-hash agreement when mtime matches (#1824)

### DIFF
--- a/internal/agent/checks_1824_test.go
+++ b/internal/agent/checks_1824_test.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// #1824 case 2 pin: content drift under an identical mtime must NOT be
+// flagged redundant (the read is legitimate).
+func Test1824MtimeEqualContentChanged(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f.go")
+	os.WriteFile(p, []byte(repeatStr1824("a", 4096)), 0o644)
+
+	r := newRedundantReadState()
+	// First read records mtime + hash.
+	if h := r.checkRedundantRead(p, false); h != "" {
+		t.Fatalf("first read must not warn, got %q", h)
+	}
+	// External write preserving the mtime (touch -r shape).
+	st, _ := os.Stat(p)
+	os.WriteFile(p, []byte(repeatStr1824("b", 4096)), 0o644)
+	os.Chtimes(p, st.ModTime(), st.ModTime().Add(-time.Second)) // keep access old; keep mod identical
+	os.Chtimes(p, st.ModTime(), st.ModTime())
+	cur, _ := os.Stat(p)
+	if cur.ModTime().UnixNano() != st.ModTime().UnixNano() {
+		t.Skip("filesystem mtime granularity too coarse to force equality; relying on hash branch is still covered below")
+	}
+	if h := r.checkRedundantRead(p, false); h != "" {
+		t.Fatalf("mtime-equal but content-changed re-read must not warn (weak evidence), got %q", h)
+	}
+	// Truly unchanged: still warns (positive control).
+	r2 := newRedundantReadState()
+	r2.checkRedundantRead(p, false)
+	if h := r2.checkRedundantRead(p, false); h == "" {
+		t.Fatal("unchanged re-read must still warn")
+	}
+}
+
+func repeatStr1824(ch string, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = ch[0]
+	}
+	return string(b)
+}

--- a/internal/agent/redundant_read_guard.go
+++ b/internal/agent/redundant_read_guard.go
@@ -58,18 +58,29 @@ type redundantReadState struct {
 	// by normalized path. Used to determine whether the file has changed since
 	// the last read - if unchanged, the re-read is redundant.
 	lastReadMtime map[string]int64
+
+	// lastReadHash stores the content fingerprint (hashFilePrefix) captured
+	// at the most recent read (#1824 case 2). mtime alone is weak evidence:
+	// coarse-grained (FAT 2s) or timestamp-preserving filesystems, NFS, and
+	// `touch -r` from a shared-workspace writer can change content while the
+	// mtime reads identical - the guard then false-positived "already read
+	// (XKB in context)" on genuinely changed content. When mtime matches,
+	// the content hash disambiguates: same hash = redundant, drift = fresh.
+	lastReadHash map[string]uint64
 }
 
 func newRedundantReadState() *redundantReadState {
 	return &redundantReadState{
 		warnedFiles:   make(map[string]bool),
 		lastReadMtime: make(map[string]int64),
+		lastReadHash:  make(map[string]uint64),
 	}
 }
 
 func (r *redundantReadState) reset() {
 	r.warnedFiles = make(map[string]bool)
 	r.lastReadMtime = make(map[string]int64)
+	r.lastReadHash = make(map[string]uint64)
 }
 
 // checkRedundantRead returns a non-empty hint if the agent is re-reading a file
@@ -128,6 +139,21 @@ func (r *redundantReadState) checkRedundantRead(path string, partial bool) strin
 		return ""
 	}
 
+	// #1824 case 2: mtime equality is weak evidence on coarse/timestamp-
+	// preserving filesystems (shared-workspace writers, format-on-save,
+	// touch -r). Require the content fingerprint to agree before declaring
+	// the re-read redundant; hash drift means the content changed and the
+	// re-read is legitimate. Missing prior hash (empty/unreadable at record
+	// time) keeps the old mtime-only verdict.
+	if prevHash, ok := r.lastReadHash[n]; ok {
+		if cur := hashFilePrefix(path); cur != 0 && cur != prevHash {
+			// Content drifted under an identical mtime: refresh the
+			// baseline so the NEXT read is judged against this content.
+			r.recordReadMtime(path)
+			return ""
+		}
+	}
+
 	// Redundant re-read detected: file hasn't changed since the last read.
 	r.warnedFiles[n] = true
 	debug.Log("agent", "redundant-read guard: %s re-read without changes (%d bytes already in context)", n, info.Size())
@@ -150,6 +176,13 @@ func (r *redundantReadState) recordReadMtime(path string) {
 	}
 	n := normalizePath(path)
 	r.lastReadMtime[n] = info.ModTime().UnixNano()
+	// #1824 case 2: pair the mtime with a content fingerprint so an
+	// mtime-preserving external write cannot masquerade as "unchanged".
+	if h := hashFilePrefix(path); h != 0 {
+		r.lastReadHash[n] = h
+	} else {
+		delete(r.lastReadHash, n)
+	}
 }
 
 // recordWrite clears the redundancy state for a file after it's been edited,


### PR DESCRIPTION
## Summary
Closes #1824.

- **Case 2 (Med, conditional false positive)**: the redundant-read guard now requires content-hash agreement when mtime matches — mtime equality is weak evidence (FAT 2s granularity, NFS, `touch -r`, format-on-save writers in shared workspaces) and false-positived "already read" on genuinely changed content. Each recorded mtime is paired with a content fingerprint (hashFilePrefix); drift refreshes the baseline and treats the re-read as legitimate. Missing prior hash keeps the mtime-only verdict.
- Case 1 (failed edits polluting editsSince) was already landed by a parallel fix (#1486 case E gating at the recordEdit call site).

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **23.0s PASS** (p=1). Pins: mtime-equal content-changed re-read does not warn; unchanged re-read still warns.

Per team convention: merge only after this PR's CI is green.

Closes #1824

Generated with [ggcode](https://github.com/topcheer/ggcode)
