### PR TITLE
fix(agent): test-isolation cross-file vars, TestMain exempt, snapshot restore clean; impact cap + Ruby runner (#1502)

### DIFF
--- a/internal/agent/checks_1502_test.go
+++ b/internal/agent/checks_1502_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #1502 case C pin: TestMain's os.Setenv is the only legal form - exempt.
+func Test1502TestMainExempt(t *testing.T) {
+	dir := t.TempDir()
+	tf := filepath.Join(dir, "main_test.go")
+	src := `package x
+import ("os"; "testing")
+func TestMain(m *testing.M) { os.Setenv("K", "v"); os.Exit(m.Run()) }
+`
+	old := checkTestIsolation(tf, "", src)
+	if old != "" {
+		t.Fatalf("TestMain must be exempt, got %q", old)
+	}
+}
+
+// #1502 case B pin: cross-file package vars are detected.
+func Test1502CrossFileGlobalVar(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "foo.go"), []byte("package x\n\nvar flagVerbose bool\n"), 0o644)
+	tf := filepath.Join(dir, "foo_test.go")
+	src := `package x
+import "testing"
+func TestX(t *testing.T) { flagVerbose = true }
+`
+	if got := checkTestIsolation(tf, "", src); got == "" {
+		t.Fatal("cross-file global mutation must be detected")
+	}
+}
+
+// #1502 case D pin: snapshot+defer restore is hermetic - no warning.
+func Test1502SnapshotRestoreClean(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "bar.go"), []byte("package y\n\nvar level int\n"), 0o644)
+	tf := filepath.Join(dir, "bar_test.go")
+	src := `package y
+import "testing"
+func TestY(t *testing.T) {
+	old := level
+	level = 5
+	defer func() { level = old }
+	_ = level
+}
+`
+	if got := checkTestIsolation(tf, "", src); got != "" {
+		t.Fatalf("snapshot+restore must not warn, got %q", got)
+	}
+	// Unrestored write still warns.
+	src2 := `package y
+import "testing"
+func TestY(t *testing.T) { level = 5 }
+`
+	if got := checkTestIsolation(tf, src, src2); got == "" {
+		t.Fatal("unrestored global write must still warn")
+	}
+}
+
+// #1502 case F pin: swapping pollution kinds is not "fewer violations".
+func Test1502KindSwapDetected(t *testing.T) {
+	dir := t.TempDir()
+	tf := filepath.Join(dir, "k_test.go")
+	oldSrc := `package z
+import ("os"; "testing")
+func TestA(t *testing.T) { os.Setenv("A", "1"); os.Setenv("B", "2"); os.Setenv("C", "3") }
+`
+	newSrc := `package z
+import ("os"; "testing")
+func TestA(t *testing.T) { os.Stdout = nil }
+`
+	if got := checkTestIsolation(tf, oldSrc, newSrc); got == "" {
+		t.Fatal("kind swap (3x setenv -> 1x stdio) must still report the new kind")
+	}
+}

--- a/internal/agent/test_impact_deps.go
+++ b/internal/agent/test_impact_deps.go
@@ -417,23 +417,29 @@ func impactScopedTestCommandWithDeps(workingDir string) string {
 		}
 	}
 
-	// Build final list: always include all changed dirs, then add importers up to cap.
-	finalList := make([]string, 0, len(changedInList))
-	finalList = append(finalList, changedInList...)
-
-	remainingCap := 20 - len(changedInList)
-	var omittedImporters int
-	if remainingCap > 0 && len(importersInList) > 0 {
-		// Importers are already sorted from the earlier sort.Strings(dirList).
-		if len(importersInList) > remainingCap {
-			finalList = append(finalList, importersInList[:remainingCap]...)
-			omittedImporters = len(importersInList) - remainingCap
-		} else {
-			finalList = append(finalList, importersInList...)
+	// Build final list: changed dirs first, importers after, under the
+	// total cap. #1502 case F: the old code appended ALL changed dirs
+	// unconditionally ("Cap at 20" never applied when changed dirs alone
+	// exceeded it) and the `# +more` fallback annotated lists that had
+	// omitted NOTHING - 25 changed packages were all listed AND claimed
+	// omission. Enforce the cap on the TOTAL and only annotate real
+	// omissions.
+	const pkgCap = 20
+	finalList := make([]string, 0, pkgCap)
+	var omitted int
+	for _, d := range changedInList {
+		if len(finalList) >= pkgCap {
+			omitted++
+			continue
 		}
-	} else if len(importersInList) > 0 {
-		// No cap remaining but we have importers.
-		omittedImporters = len(importersInList)
+		finalList = append(finalList, d)
+	}
+	for _, d := range importersInList {
+		if len(finalList) >= pkgCap {
+			omitted++
+			continue
+		}
+		finalList = append(finalList, d)
 	}
 
 	parts := make([]string, len(finalList))
@@ -448,11 +454,8 @@ func impactScopedTestCommandWithDeps(workingDir string) string {
 		cmd += " -tags " + strings.Join(tags, ",")
 	}
 	cmd += " " + strings.Join(parts, " ")
-	if omittedImporters > 0 {
-		cmd += fmt.Sprintf(" # +%d importers omitted", omittedImporters)
-	} else if len(allDirs) > 20 {
-		// Fallback for edge cases: all changed, no importers, but still truncated.
-		cmd += " # +more"
+	if omitted > 0 {
+		cmd += fmt.Sprintf(" # +%d packages omitted", omitted)
 	}
 
 	if len(importerDirs) > 0 {

--- a/internal/agent/test_impact_lang.go
+++ b/internal/agent/test_impact_lang.go
@@ -303,9 +303,22 @@ var rubyLangProfile = langProfile{
 	},
 	TargetedTestCmd: func(workingDir, srcFile string) string {
 		dir := filepath.Dir(srcFile)
-		// Check for rspec
-		if fileExists(filepath.Join(workingDir, ".rspec")) ||
-			strings.Contains(dir, "spec") {
+		// #1502 case F: (1) a directory merely CONTAINING the substring
+		// "spec" (app/services/spec_builder/) is not an RSpec project -
+		// Minitest projects got rspec commands that fail outright. Require
+		// the marker config, or a path segment that IS "spec".
+		// (2) `rspec <srcFile>` on a SOURCE (non-_spec) file matches 0
+		// examples: it "passes" without verifying anything. Only emit rspec
+		// for spec files themselves; for source files fall through to the
+		// project's test runner.
+		isRSpecProject := fileExists(filepath.Join(workingDir, ".rspec")) ||
+			fileExists(filepath.Join(workingDir, "spec"))
+		for _, seg := range strings.Split(filepath.ToSlash(dir), "/") {
+			if seg == "spec" {
+				isRSpecProject = true
+			}
+		}
+		if isRSpecProject && strings.HasSuffix(srcFile, "_spec.rb") {
 			return "rspec " + filepath.ToSlash(srcFile)
 		}
 		return "bundle exec rake test"

--- a/internal/agent/test_isolation_check.go
+++ b/internal/agent/test_isolation_check.go
@@ -50,6 +50,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -75,13 +77,24 @@ func checkTestIsolation(filePath, oldContent, newContent string) string {
 	oldViolations := findGlobalStateMutations(filePath, oldContent)
 	newViolations := findGlobalStateMutations(filePath, newContent)
 
-	// Delta: only flag if new content has MORE violations than old.
-	if len(newViolations) <= len(oldViolations) {
+	typeCounts := computeNetCounts(newViolations, oldViolations)
+	// #1502 case F: the old TOTAL-count gate (`len(new) <= len(old)`)
+	// let a rewrite swap pollution kinds - old 3x os-setenv -> new 1x
+	// os-stdio was "fewer violations" and passed silently. Report when ANY
+	// kind has a net increase.
+	anyIncrease := false
+	introduced := 0
+	for _, c := range typeCounts {
+		if c > 0 {
+			anyIncrease = true
+		}
+		if c > 0 {
+			introduced += c
+		}
+	}
+	if !anyIncrease {
 		return ""
 	}
-
-	introduced := len(newViolations) - len(oldViolations)
-	typeCounts := computeNetCounts(newViolations, oldViolations)
 	details := formatIsolationDetails(typeCounts)
 
 	if len(details) == 0 {
@@ -155,12 +168,27 @@ func findGlobalStateMutations(filename, src string) []globalStateMutation {
 		return nil
 	}
 
+	// #1502 case B: package vars are almost always declared in the SOURCE
+	// file under test, not the test file itself - collecting only the test
+	// file's own VAR decls (plus the single-file Obj==nil resolution quirk)
+	// made global-var detection near-inert in real projects. Collect the
+	// sibling non-test .go files' package-level vars too.
 	packageVars := collectPackageVarNames(file)
+	for n := range collectSiblingPackageVarNames(filename) {
+		packageVars[n] = true
+	}
 
 	var mutations []globalStateMutation
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || !isTestFunction(fn.Name.Name) {
+			continue
+		}
+		// #1502 case C: TestMain has no *testing.T - t.Setenv is unusable
+		// there and the Go docs require env setup BEFORE m.Run via plain
+		// os.Setenv. Advising otherwise makes the agent emit code that does
+		// not compile. Exempt TestMain entirely from this check.
+		if fn.Name.Name == "TestMain" {
 			continue
 		}
 		mutations = append(mutations, inspectTestFuncBody(fn.Body, packageVars, fset)...)
@@ -193,6 +221,14 @@ func collectPackageVarNames(file *ast.File) map[string]bool {
 
 // inspectTestFuncBody walks a test function body and collects global state mutations.
 func inspectTestFuncBody(body *ast.BlockStmt, packageVars map[string]bool, fset *token.FileSet) []globalStateMutation {
+	// #1502 case D: the SNAPSHOT pattern (`old := X; X = v; defer func()
+	// { X = old }()`) is fully hermetic, but both the forward assignment
+	// and the restore count as mutations (net +2) - a perfectly restoring
+	// test was branded "global-state mutations" and the guidance pushed
+	// the agent to dismantle correct restoration code. Collect the names
+	// assigned inside defer/cleanup closures FIRST and treat their writes
+	// as restores.
+	restores := collectRestoredVars(body)
 	var mutations []globalStateMutation
 	ast.Inspect(body, func(n ast.Node) bool {
 		switch node := n.(type) {
@@ -201,11 +237,115 @@ func inspectTestFuncBody(body *ast.BlockStmt, packageVars map[string]bool, fset 
 				mutations = append(mutations, *m)
 			}
 		case *ast.AssignStmt:
-			mutations = append(mutations, detectAssignMutations(node, packageVars, fset)...)
+			mutations = append(mutations, detectAssignMutations(node, packageVars, restores, fset)...)
 		}
 		return true
 	})
 	return mutations
+}
+
+// collectRestoredVars returns the variable names assigned inside function
+// literals reached via defer or t.Cleanup (the restore half of the snapshot
+// pattern) plus any variable BOTH written outside and restored inside.
+func collectRestoredVars(body *ast.BlockStmt) map[string]bool {
+	restored := map[string]bool{}
+	var walkDefer bool
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.DeferStmt:
+			walkDefer = true
+			ast.Inspect(node.Call, func(m ast.Node) bool {
+				if fl, ok := m.(*ast.FuncLit); ok {
+					collectAssignedNames(fl.Body, restored)
+				}
+				return true
+			})
+			walkDefer = false
+		case *ast.CallExpr:
+			if !walkDefer {
+				if se, ok := node.Fun.(*ast.SelectorExpr); ok && se.Sel != nil && se.Sel.Name == "Cleanup" {
+					for _, arg := range node.Args {
+						ast.Inspect(arg, func(m ast.Node) bool {
+							if fl, ok := m.(*ast.FuncLit); ok {
+								collectAssignedNames(fl.Body, restored)
+							}
+							return true
+						})
+					}
+				}
+			}
+		}
+		return true
+	})
+	if len(restored) == 0 {
+		return nil
+	}
+	// Only names also assigned OUTSIDE the closures count as snapshotted
+	// (restore-without-write is dead code; write-without-restore must stay
+	// flagged).
+	snapshotted := map[string]bool{}
+	var outside func(n ast.Node) bool
+	outside = func(n ast.Node) bool {
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false // skip closure interiors; handled above
+		}
+		if as, ok := n.(*ast.AssignStmt); ok {
+			for _, lhs := range as.Lhs {
+				if id, ok := lhs.(*ast.Ident); ok && restored[id.Name] {
+					snapshotted[id.Name] = true
+				}
+			}
+		}
+		return true
+	}
+	ast.Inspect(body, outside)
+	return snapshotted
+}
+
+// collectAssignedNames records simple identifier LHS names in a body.
+func collectAssignedNames(body ast.Node, into map[string]bool) {
+	if body == nil {
+		return
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		if as, ok := n.(*ast.AssignStmt); ok {
+			for _, lhs := range as.Lhs {
+				if id, ok := lhs.(*ast.Ident); ok && id.Name != "" && id.Name != "_" {
+					into[id.Name] = true
+				}
+			}
+		}
+		return true
+	})
+}
+
+// collectSiblingPackageVarNames parses sibling non-test .go files in the
+// same directory and collects their package-level variable names (#1502 B).
+func collectSiblingPackageVarNames(testFilePath string) map[string]bool {
+	names := map[string]bool{}
+	dir := filepath.Dir(testFilePath)
+	if dir == "" || dir == "." {
+		return names
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return names
+	}
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, filepath.Join(dir, n), nil, 0)
+		if err != nil || f == nil {
+			continue
+		}
+		for name := range collectPackageVarNames(f) {
+			names[name] = true
+		}
+	}
+	return names
 }
 
 // detectOSSetenvCall checks if a CallExpr is os.Setenv and returns a mutation if so.
@@ -228,9 +368,16 @@ func detectOSSetenvCall(node *ast.CallExpr, fset *token.FileSet) *globalStateMut
 }
 
 // detectAssignMutations inspects an AssignStmt's LHS for global state mutations.
-func detectAssignMutations(node *ast.AssignStmt, packageVars map[string]bool, fset *token.FileSet) []globalStateMutation {
+// restores (#1502 D): names in the snapshot-restore set are skipped.
+func detectAssignMutations(node *ast.AssignStmt, packageVars map[string]bool, restores map[string]bool, fset *token.FileSet) []globalStateMutation {
 	var mutations []globalStateMutation
 	for _, lhs := range node.Lhs {
+		if id, ok := lhs.(*ast.Ident); ok && restores != nil && restores[id.Name] {
+			continue
+		}
+		if sel, ok := lhs.(*ast.SelectorExpr); ok && sel.Sel != nil && restores != nil && restores["os."+sel.Sel.Name] {
+			continue
+		}
 		if m := detectOSGlobalAssignment(lhs, fset); m != nil {
 			mutations = append(mutations, *m)
 			continue
@@ -268,13 +415,15 @@ func detectOSGlobalAssignment(lhs ast.Expr, fset *token.FileSet) *globalStateMut
 // detectPackageVarAssignment checks if an LHS expression writes to a package-level variable.
 func detectPackageVarAssignment(lhs ast.Expr, packageVars map[string]bool, fset *token.FileSet) *globalStateMutation {
 	ident, ok := lhs.(*ast.Ident)
-	if !ok || !packageVars[ident.Name] || ident.Obj == nil {
+	if !ok || !packageVars[ident.Name] {
 		return nil
 	}
-	if ident.Obj.Kind == ast.Var {
-		return &globalStateMutation{kind: "global-var", line: fset.Position(lhs.Pos()).Line}
-	}
-	return nil
+	// #1502 case B: ident.Obj is ALWAYS nil for names resolved outside the
+	// single-file parse (i.e. declared in a sibling source file) - the old
+	// `ident.Obj == nil` + `Obj.Kind == Var` gate skipped exactly the
+	// cross-file mutations that matter most. packageVars membership (now
+	// sibling-aware) is the authority.
+	return &globalStateMutation{kind: "global-var", line: fset.Position(lhs.Pos()).Line}
 }
 
 // isTestFunction returns true if the function name matches Go test conventions:


### PR DESCRIPTION
## Summary
Closes #1502.

- **Case B (Med)**: global-var detection now collects package vars from sibling source files (declaration-in-source-file is the common case; the single-file Obj==nil gate made detection near-inert).
- **Case C (Med)**: TestMain exempt — os.Setenv there is the only legal form; old advice produced non-compiling code.
- **Case D (Med)**: snapshot pattern (write + defer/cleanup restore) no longer counted net +2 — hermetic tests stay silent; unrestored writes still flag.
- **Case F1**: per-kind net counts replace the total-count gate — pollution-kind swaps no longer pass as "fewer violations".
- **Case F2**: the 20-package cap is enforced on the total (changed dirs no longer overflow it) and "# +N packages omitted" only annotates real omissions.
- **Case F3 (Ruby)**: "spec" must be a path segment (or .rspec / spec/ dir) — substring dirs no longer mistype Minitest projects; rspec only emitted for _spec.rb (0-example passes on source files verified nothing).
- Cases A/E landed earlier (Maven test path; Rust inline #[test] via #1778).

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **22.8s PASS** (p=1). Pins: TestMain exempt; cross-file global detected; snapshot+restore silent / unrestored warns; kind swap reported.

Per team convention: merge only after this PR's CI is green.

Closes #1502

Generated with [ggcode](https://github.com/topcheer/ggcode)
