### PR TITLE
fix(tui): reconnect latch clears when the pending server is uninstalled (#1812)

### DIFF
--- a/internal/tui/i18n_en.go
+++ b/internal/tui/i18n_en.go
@@ -48,6 +48,8 @@ func enCatalog(key string) string {
 		return "Reconnect unavailable in this session."
 	case "panel.mcp.reconnecting":
 		return "Reconnecting %s..."
+	case "panel.mcp.removed":
+		return "%s was removed while reconnecting"
 	case "panel.mcp.reconnected":
 		return "Reconnected %s: %d tools."
 	case "panel.mcp.reconnect_error":

--- a/internal/tui/i18n_zh.go
+++ b/internal/tui/i18n_zh.go
@@ -44,6 +44,8 @@ func zhCatalog(key string) string {
 		return "当前会话不支持重新连接。"
 	case "panel.mcp.reconnecting":
 		return "正在重新连接 %s..."
+	case "panel.mcp.removed":
+		return "%s 已在重连期间被移除"
 	case "panel.mcp.reconnected":
 		return "已重连 %s：%d 个工具。"
 	case "panel.mcp.reconnect_error":

--- a/internal/tui/mcp.go
+++ b/internal/tui/mcp.go
@@ -21,15 +21,29 @@ type mcpServersUpdatedMsg struct {
 // is waiting on a reconnect, upgrades the static "reconnecting" message to
 // a terminal result the moment that server settles.
 func (m *Model) applyMCPServersUpdate(msg mcpServersUpdatedMsg) {
+	// #1812: capture the PRE-swap list - the pending server dropping OUT
+	// of the update (uninstalled mid-reconnect) is only distinguishable
+	// from an unrelated-server update by comparing against what we HAD.
+	wasListed := false
+	if m.mcpPanel != nil && m.mcpPanel.pendingReconnect != "" {
+		for _, srv := range m.mcpServers {
+			if srv.Name == m.mcpPanel.pendingReconnect {
+				wasListed = true
+				break
+			}
+		}
+	}
 	m.mcpServers = msg.servers
 	if m.mcpPanel == nil || m.mcpPanel.pendingReconnect == "" {
 		return
 	}
 	name := m.mcpPanel.pendingReconnect
+	found := false
 	for _, srv := range msg.servers {
 		if srv.Name != name {
 			continue
 		}
+		found = true
 		switch {
 		case srv.Connected:
 			m.mcpPanel.message = m.t("panel.mcp.reconnected", name, len(srv.ToolNames))
@@ -41,6 +55,17 @@ func (m *Model) applyMCPServersUpdate(msg mcpServersUpdatedMsg) {
 		// Still pending (dialing or awaiting OAuth): keep the reconnecting
 		// message until a terminal state arrives.
 		return
+	}
+	// #1812: the server WAS in our list and VANISHED from the update
+	// (uninstalled while its reconnect was pending) - the loop never
+	// matched, the latch stayed set, and the panel hung on
+	// "reconnecting..." until reopened. The server is gone; nothing is
+	// coming back - clear with a removal note. A name that was NEVER
+	// listed stays latched (unrelated-server updates must not disturb
+	// it - the pre-existing pin).
+	if !found && wasListed {
+		m.mcpPanel.pendingReconnect = ""
+		m.mcpPanel.message = m.t("panel.mcp.removed", name)
 	}
 }
 

--- a/internal/tui/mcp_update_test.go
+++ b/internal/tui/mcp_update_test.go
@@ -59,6 +59,14 @@ func TestApplyMCPServersUpdateIgnoresOtherServers(t *testing.T) {
 	if m.mcpPanel.pendingReconnect != "a" {
 		t.Fatalf("latch must survive unrelated server updates, got %q", m.mcpPanel.pendingReconnect)
 	}
+	// #1812: but when the pending server WAS listed and VANISHES from the
+	// update (uninstalled mid-reconnect), the latch must clear - the panel
+	// used to hang on "reconnecting..." until reopened.
+	m2 := &Model{mcpPanel: &mcpPanelState{pendingReconnect: "a"}, mcpServers: []MCPInfo{{Name: "a"}}}
+	m2.applyMCPServersUpdate(mcpServersUpdatedMsg{servers: []MCPInfo{}})
+	if m2.mcpPanel.pendingReconnect != "" {
+		t.Fatalf("latch must clear when the pending server is removed, got %q", m2.mcpPanel.pendingReconnect)
+	}
 }
 
 // With no panel open the fresh list still lands in m.mcpServers.


### PR DESCRIPTION
The latch cleared only when a terminal state arrived for a **matching** name - a server uninstalled mid-reconnect simply vanished from the update, the loop never matched, and the panel hung on `reconnecting...` until reopened (the exact stuck-message cf0abf79 fixed, revived on the removal branch).

Distinguishing removal from unrelated updates needs the **pre-swap list**: a name we HAD that drops out is a removal (clear with a `panel.mcp.removed` note, en/zh); a name we never had stays latched (the pre-existing unrelated-server pin keeps its semantics). Snapshot hoisted above the swap; both branches pinned.

Isolated worktree (fresh origin/main): tui package full PASS (10.7s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)