### PR TITLE
fix(agent): subgoal plan-intent gate; declaration negation/continuation veto; stall timer attribution (#1499)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1845,10 +1845,16 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 		// Premature success declaration: if the agent claimed completion in a
 		// prior iteration but has since continued making tool calls, flag the
 		// metacognitive calibration gap.
-		if sgMsg := a.subgoalTrack.maybeWarn(i + 1); sgMsg != "" {
-			debug.Log("agent", "Iteration %d: subgoal completion gap detected", i+1)
-			a.injectGuidance(sgMsg)
-			msgs = a.contextManager.Messages()
+		// #1499 case A: subgoal tracking is a lexical heuristic in the
+		// claims-supervision family - unconditioned, it interfered with
+		// every user by default while its sibling (success_declare) is
+		// opt-in. Same gate.
+		if a.claimsSupervision {
+			if sgMsg := a.subgoalTrack.maybeWarn(i + 1); sgMsg != "" {
+				debug.Log("agent", "Iteration %d: subgoal completion gap detected", i+1)
+				a.injectGuidance(sgMsg)
+				msgs = a.contextManager.Messages()
+			}
 		}
 		// Success-declaration calibration detector is gated behind
 		// claimsSupervision (default off): lexical success-phrase heuristics on
@@ -4311,7 +4317,15 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 				}
 				a.editPropagation.recordEdit(tc.Name, string(tc.Arguments))
 			}
-			a.successDeclare.recordToolCall()
+			// #1499 case C: only SIDE-EFFECTING calls count as post-
+			// declaration work - read-only exploration the agent announced
+			// in the same breath ("Next, I'll check the tests") executed as
+			// promised was tallied as "actions since declaring completion",
+			// turning a component-level claim plus its announced wrap-up
+			// into a false "premature declaration" accusation.
+			if fileEditingTools[tc.Name] || tc.Name == "run_command" {
+				a.successDeclare.recordToolCall()
+			}
 			a.subgoalTrack.recordToolCall(tc.Name, string(tc.Arguments))
 			// Attempt brief: record outcome for knowledge reuse.
 			a.attemptBrief.recordOutcome(tc.Name, extractToolTarget(tc.Name, string(tc.Arguments)), !result.IsError, i, result.Content)

--- a/internal/agent/checks_1499_test.go
+++ b/internal/agent/checks_1499_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"testing"
+)
+
+// #1499 case A pin: a diagnostic numbered list without plan intent is not
+// adopted as a plan.
+func Test1499DiagnosticListNotPlan(t *testing.T) {
+	s := newSubgoalState()
+	diag := "Found 3 problems:\n1. missing nil check in foo\n2. off-by-one in bar loop\n3. unhandled error in baz\n"
+	s.recordAssistantText(diag, 1)
+	if len(s.subgoals) != 0 {
+		t.Fatalf("diagnostic list must not become a plan (got %d subgoals)", len(s.subgoals))
+	}
+	// Plan-intent text IS adopted.
+	s2 := newSubgoalState()
+	plan := "My plan:\n1. fix nil check in foo\n2. fix off-by-one in bar loop\n3. handle error in baz\n"
+	s2.recordAssistantText(plan, 1)
+	if len(s2.subgoals) == 0 {
+		t.Fatal("plan-intent list must be adopted")
+	}
+}
+
+// #1499 case B pin: a negated declaration is not recorded.
+func Test1499NegatedDeclarationIgnored(t *testing.T) {
+	s := newSuccessDeclareState()
+	s.recordAssistantText("This part isn't done — I'll continue with the remaining work.", 2)
+	if s.declarationIter >= 0 {
+		t.Fatalf("negated declaration must not be recorded (iter=%d)", s.declarationIter)
+	}
+	// Affirmative declaration still records.
+	s2 := newSuccessDeclareState()
+	s2.recordAssistantText("All tests pass and the implementation is complete.", 2)
+	if s2.declarationIter < 0 {
+		t.Fatal("affirmative declaration must record")
+	}
+}
+
+// #1499 case C pin: continuation opener vetoes the declaration.
+func Test1499ContinuationVeto(t *testing.T) {
+	s := newSuccessDeclareState()
+	s.recordAssistantText("The fix works. Next, I'll clean up the tests.", 3)
+	if s.declarationIter >= 0 {
+		t.Fatal("component claim + announced continuation must not record a task-level declaration")
+	}
+}

--- a/internal/agent/stream_health.go
+++ b/internal/agent/stream_health.go
@@ -44,14 +44,24 @@ func streamWithStallDetection(stream <-chan provider.StreamEvent, stallThreshold
 					return
 				}
 				warned = false
+				// #1499 case D: the timer must measure UPSTREAM arrival
+				// gaps, not forward-completion gaps. It previously was
+				// reset BEFORE the send, so while a slow consumer (IM
+				// bridge, desktop rendering a large diff) blocked `out <-
+				// event`, the clock kept running; on unblock the already-
+				// fired timer branch won the next select and blamed the
+				// CONNECTION ("no data for 30s") for local backpressure.
+				// Stop the timer while forwarding; reset only after the
+				// send completes, so backpressure time never counts as a
+				// stall.
 				if !timer.Stop() {
 					select {
 					case <-timer.C:
 					default:
 					}
 				}
-				timer.Reset(stallThreshold)
 				out <- event
+				timer.Reset(stallThreshold)
 			case <-timer.C:
 				if !warned {
 					warned = true

--- a/internal/agent/subgoal_track.go
+++ b/internal/agent/subgoal_track.go
@@ -148,11 +148,35 @@ func (s *subgoalState) recordAssistantText(text string, iter int) {
 		return
 	}
 	subs := extractSubgoals(text)
-	if len(subs) >= sgMinSubgoals {
+	// #1499 case A: a numbered list is NOT necessarily a plan - diagnostic
+	// output ("Found 3 problems: 1. missing nil check ...") matched the
+	// same regex, got promoted to "planned subgoals", and the agent was
+	// later accused of skipping steps it never planned. Require plan
+	// intent in the surrounding text before adopting a list.
+	if len(subs) >= sgMinSubgoals && hasPlanIntent(text) {
 		s.subgoals = subs
 		s.planIter = iter
 		debug.Log("agent", "subgoal_track: plan detected at iter %d with %d subgoals", iter, len(subs))
 	}
+}
+
+// sgPlanIntentPhrases mark text that ANNOUNCES a plan (vs. text that
+// merely ENUMERATES findings, errors, options...).
+var sgPlanIntentPhrases = []string{
+	"plan", "steps", "going to", "will do", "todo", "to-do", "to do",
+	"approach", "roadmap", "checklist", "road map", "next up", "my tasks",
+	"任务", "计划", "步骤",
+}
+
+// hasPlanIntent reports whether the text carries plan-intent language.
+func hasPlanIntent(text string) bool {
+	lower := strings.ToLower(text)
+	for _, p := range sgPlanIntentPhrases {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // recordToolCall checks whether a tool call addresses any unaddressed subgoal.

--- a/internal/agent/success_declare.go
+++ b/internal/agent/success_declare.go
@@ -150,6 +150,21 @@ func (s *successDeclareState) recordAssistantText(text string, iter int) {
 	if sdHasCaveatWindowed(lower, declIdx, declIdx+len(declPhrase)) {
 		return
 	}
+	// #1499 case C: continuation openers veto even across the sentence
+	// boundary (see sdContinuationPhrases).
+	if sdHasContinuationWindowed(lower, declIdx+len(declPhrase)) {
+		return
+	}
+
+	// #1499 case B: NEGATION on the declaration itself inverts its meaning
+	// - "This part isn't done - I'll continue" hits bare "done" (word
+	// boundary passes) with no caveat, was recorded as a COMPLETION claim,
+	// and the follow-up work then "proved" it premature. #364 fixed
+	// negation only on the caveat side. A short lookbehind window before
+	// the phrase now vetoes negated declarations.
+	if sdHasNegationBefore(lower, declIdx) {
+		return
+	}
 
 	s.declarationIter = iter
 	// Store a short snippet for the debug log.
@@ -160,6 +175,32 @@ func (s *successDeclareState) recordAssistantText(text string, iter int) {
 	s.declarationTxt = snippet
 	s.actionsSince = 0
 	debug.Log("agent", "Success declaration recorded at iteration %d: %s", iter, snippet)
+}
+
+// sdNegationPatterns mark text directly contradicting a completion claim
+// within the lookbehind window before the declaration phrase.
+var sdNegationPatterns = []string{
+	"isn't done", "not done", "aren't done", "not finished",
+	"isn't complete", "not complete", "isn't working", "not working",
+	"isn't fixed", "not fixed", "isn't resolved", "not resolved",
+	"nothing is done", "not yet", "isn't ready", "not ready",
+}
+
+// sdHasNegationBefore reports whether a negation appears in the window
+// immediately before the declaration phrase (#1499 case B).
+func sdHasNegationBefore(lowerText string, declIdx int) bool {
+	const lookbehind = 48
+	start := declIdx - lookbehind
+	if start < 0 {
+		start = 0
+	}
+	window := lowerText[start:declIdx]
+	for _, n := range sdNegationPatterns {
+		if strings.Contains(window, n) {
+			return true
+		}
+	}
+	return false
 }
 
 // recordToolCall increments the action counter if we're tracking a declaration.
@@ -298,6 +339,40 @@ func sdContainsDeclaration(lowerText string) bool {
 //     commentary ("All done. Note that I also refactored X.", "The task is
 //     complete. However, see the docs.") — does NOT veto.
 //   - Negated hedges ("no remaining issues") never veto.
+//
+// sdContinuationPhrases announce follow-up work in the same breath as a
+// component-level claim ("The fix works. Next, I'll clean up the tests.").
+// #1499 case C: they sit AFTER the sentence boundary, so the #352
+// trailing-veto and the caveat table both missed them (double miss) - the
+// announced wrap-up then counted as evidence of a premature TASK-level
+// declaration. Unlike hedging caveats, these veto ACROSS the sentence
+// boundary: a continuation opener always means more work is coming.
+var sdContinuationPhrases = []string{
+	"next,",
+	"next up",
+	"then i",
+	"now let's",
+	"now lets",
+	"moving on",
+	"after that",
+}
+
+// sdHasContinuationWindowed reports whether a continuation opener appears
+// within the caveat window after the declaration, sentence boundary or not.
+func sdHasContinuationWindowed(lowerText string, declEnd int) bool {
+	end := declEnd + sdCaveatWindow
+	if end > len(lowerText) {
+		end = len(lowerText)
+	}
+	after := lowerText[declEnd:end]
+	for _, c := range sdContinuationPhrases {
+		if strings.Contains(after, c) {
+			return true
+		}
+	}
+	return false
+}
+
 func sdHasCaveatWindowed(lowerText string, declStart, declEnd int) bool {
 	start := declStart - sdCaveatWindow
 	if start < 0 {


### PR DESCRIPTION
## Summary
Closes #1499 (all four cases).

- **Case A (Med)**: subgoal_track requires plan INTENT before adopting a numbered list (diagnostic "Found 3 problems: 1. ..." was promoted to a plan, then the agent was accused of skipping steps it never planned); maybeWarn additionally gated behind claimsSupervision like its success_declare sibling.
- **Case B (Med)**: negated declarations ("This part isn't done — I'll continue") are discarded via a 48-char lookbehind veto — they were recorded as COMPLETION claims (semantic inverse).
- **Case C (Med)**: continuation openers ("Next, I'll clean up the tests") veto across the sentence boundary (they sat in the #352/#364 double-miss gap), and recordToolCall counts only side-effecting calls — announced read-only wrap-up no longer inflates actionsSince.
- **Case D (Low)**: the stall timer is stopped during event forwarding and reset after — slow-consumer backpressure no longer gets misattributed as "connection may be degraded".

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **23.2s PASS** (p=1). Pins: diagnostic list not adopted / plan-intent adopted; negated declaration ignored / affirmative recorded; continuation opener vetoes.

Per team convention: merge only after this PR's CI is green.

Closes #1499

Generated with [ggcode](https://github.com/topcheer/ggcode)
