### PR TITLE
fix(tool): explicit empty string is provided for delete-semantics params (#1838)

### DIFF
--- a/internal/agent/agent_tool.go
+++ b/internal/agent/agent_tool.go
@@ -328,7 +328,7 @@ func (a *Agent) executeTool(ctx context.Context, tc provider.ToolCallDelta) tool
 	// instead of a confusing downstream failure. This complements
 	// CoerceArguments (which fixes types, not omissions) and is a no-op for
 	// tools that already call CheckRequired internally.
-	if missingMsg := tool.ValidateRequiredParams(t.Parameters(), tc.Arguments); missingMsg != "" {
+	if missingMsg := tool.ValidateRequiredParams(t.Parameters(), tc.Arguments, tc.Name); missingMsg != "" {
 		debug.Log("agent", "required param validation failed for %s: %s", tc.Name, missingMsg)
 		return tool.Result{
 			Content: fmt.Sprintf("Tool %q: %s. Please provide all required parameters and retry.", tc.Name, missingMsg),

--- a/internal/tool/arg_coercion.go
+++ b/internal/tool/arg_coercion.go
@@ -257,7 +257,35 @@ func coerceBoolean(val json.RawMessage) (json.RawMessage, bool) {
 // object {} counts as provided — it carries meaning (e.g. clearing a list).
 // Numeric and boolean values (including 0 and false) are always considered
 // present.
-func ValidateRequiredParams(schema json.RawMessage, args json.RawMessage) string {
+// emptyStringLegalParams lists (tool, param) pairs where an EXPLICIT empty
+// string is a meaningful provided value, not an omission:
+//   - edit_file new_text: "" is the DELETE semantics - the handler's own
+//     CheckRequired deliberately omits new_text for exactly this reason
+//     (#742 presence-only decision). The blanket empty=missing rule (#542)
+//     silently overrode it upstream: every delete edit was rejected with
+//     "missing required parameter: new_text" and the suggested remedy
+//     (provide new_text) is unsatisfiable for a deletion - futile retry
+//     loop (#568 family) or a risky full-file rewrite instead (#1838).
+//   - write_file content: "" creates an empty file (legitimate).
+//   - batch_replace replacement: "" deletes the matches.
+//
+// Absence and null are still missing; only a PRESENT "" is accepted.
+var emptyStringLegalParams = map[string]map[string]bool{
+	"edit_file":     {"new_text": true},
+	"write_file":    {"content": true},
+	"batch_replace": {"replacement": true},
+}
+
+// emptyStringIsLegal reports whether tool/param accepts an explicit "".
+func emptyStringIsLegal(toolName, param string) bool {
+	if toolName == "" {
+		return false
+	}
+	m, ok := emptyStringLegalParams[toolName]
+	return ok && m[param]
+}
+
+func ValidateRequiredParams(schema json.RawMessage, args json.RawMessage, toolName string) string {
 	if len(schema) == 0 || len(args) == 0 {
 		return ""
 	}
@@ -288,6 +316,12 @@ func ValidateRequiredParams(schema json.RawMessage, args json.RawMessage) string
 	for _, field := range requiredFields {
 		val, exists := argMap[field]
 		if !exists || isEmptyValue(val) {
+			// #1838: presence-only for params whose explicit "" is legal
+			// (delete semantics) - a PRESENT empty string passes; absence
+			// and null still fail.
+			if exists && emptyStringIsLegal(toolName, field) && !isNullValue(val) {
+				continue
+			}
 			missing = append(missing, field)
 		}
 	}
@@ -324,6 +358,11 @@ func isEmptyValue(val json.RawMessage) bool {
 		// Malformed quoted value — treat as non-empty so validation stays neutral.
 	}
 	return false
+}
+
+// isNullValue reports whether the raw JSON value is null.
+func isNullValue(val json.RawMessage) bool {
+	return strings.TrimSpace(string(val)) == "null"
 }
 
 // isJSONNumber returns true if val is a JSON number (not a string).

--- a/internal/tool/checks_1838_test.go
+++ b/internal/tool/checks_1838_test.go
@@ -1,0 +1,44 @@
+package tool
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// #1838 case 1 pins: explicit "" is provided for delete-semantics params;
+// absence and null are still missing.
+func Test1838EmptyStringLegal(t *testing.T) {
+	editSchema := json.RawMessage(`{"type":"object","properties":{"file_path":{"type":"string"},"old_text":{"type":"string"},"new_text":{"type":"string"}},"required":["file_path","old_text","new_text"]}`)
+	// Delete edit: new_text "" present — must pass.
+	if msg := ValidateRequiredParams(editSchema, json.RawMessage(`{"file_path":"a.go","old_text":"X","new_text":""}`), "edit_file"); msg != "" {
+		t.Fatalf("delete edit must pass, got: %s", msg)
+	}
+	// new_text ABSENT — must fail.
+	if msg := ValidateRequiredParams(editSchema, json.RawMessage(`{"file_path":"a.go","old_text":"X"}`), "edit_file"); msg == "" {
+		t.Fatal("absent new_text must still be missing")
+	}
+	// new_text null — must fail.
+	if msg := ValidateRequiredParams(editSchema, json.RawMessage(`{"file_path":"a.go","old_text":"X","new_text":null}`), "edit_file"); msg == "" {
+		t.Fatal("null new_text must still be missing")
+	}
+	// Whitespace content on a whitelisted param IS content (replacing with
+	// two spaces is a real edit); #542's whitespace=missing is preserved for
+	// NON-whitelisted params (see file_path below).
+	if msg := ValidateRequiredParams(editSchema, json.RawMessage(`{"file_path":"a.go","old_text":"X","new_text":"  "}`), "edit_file"); msg != "" {
+		t.Fatalf("whitespace replacement content must be provided, got: %s", msg)
+	}
+	// Empty file creation: write_file content "".
+	wfSchema := json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}`)
+	if msg := ValidateRequiredParams(wfSchema, json.RawMessage(`{"path":"empty.txt","content":""}`), "write_file"); msg != "" {
+		t.Fatalf("empty-file creation must pass, got: %s", msg)
+	}
+	// Delete-by-empty-replacement: batch_replace replacement "".
+	brSchema := json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string"},"replacement":{"type":"string"},"files":{"type":"array"}},"required":["pattern","replacement","files"]}`)
+	if msg := ValidateRequiredParams(brSchema, json.RawMessage(`{"pattern":"TODO","replacement":"","files":["a.go"]}`), "batch_replace"); msg != "" {
+		t.Fatalf("delete-by-empty-replacement must pass, got: %s", msg)
+	}
+	// Whitelist is tool-scoped: "" for a NON-whitelisted tool still missing.
+	if msg := ValidateRequiredParams(editSchema, json.RawMessage(`{"file_path":"","old_text":"X","new_text":"Y"}`), "edit_file"); msg == "" {
+		t.Fatal("empty file_path (not whitelisted) must still be missing")
+	}
+}

--- a/internal/tool/description_fallback_test.go
+++ b/internal/tool/description_fallback_test.go
@@ -44,7 +44,7 @@ func TestInjectDescriptionFallback_MissingUILabel(t *testing.T) {
 		t.Errorf("fallback should mention primary arg, got %q", m["description"])
 	}
 	// Injected args must now pass required validation - the rejection loop is broken.
-	if msg := ValidateRequiredParams(json.RawMessage(uiLabelSchema), out); msg != "" {
+	if msg := ValidateRequiredParams(json.RawMessage(uiLabelSchema), out, ""); msg != "" {
 		t.Errorf("after fallback, validation should pass, got: %s", msg)
 	}
 }
@@ -79,7 +79,7 @@ func TestInjectDescriptionFallback_SemanticDescriptionNotInjected(t *testing.T) 
 	if string(out) != string(in) {
 		t.Errorf("semantic description must NOT be auto-filled, got %s", out)
 	}
-	if msg := ValidateRequiredParams(json.RawMessage(semanticSchema), out); msg == "" {
+	if msg := ValidateRequiredParams(json.RawMessage(semanticSchema), out, ""); msg == "" {
 		t.Fatal("semantic description missing should still be rejected")
 	}
 }

--- a/internal/tool/issue542_fix_test.go
+++ b/internal/tool/issue542_fix_test.go
@@ -267,7 +267,7 @@ func TestValidateRequiredParams_WhitespaceBypass(t *testing.T) {
 		"required": ["pattern"]
 	}`)
 	args := json.RawMessage(`{"pattern": " "}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg == "" {
 		t.Fatal("whitespace-only required param must be flagged as missing")
 	}
@@ -280,23 +280,23 @@ func TestValidateRequiredParams_WhitespaceBypass(t *testing.T) {
 // #568 — an explicit [] or {} counts as provided; absent and null stay missing.
 func TestValidateRequiredParams_ExplicitEmptyIsProvided(t *testing.T) {
 	schema := json.RawMessage(`{"type":"object","properties":{"files":{"type":"array"}},"required":["files"]}`)
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":[]}`)); msg != "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":[]}`), ""); msg != "" {
 		t.Fatalf("explicit empty array must be provided, got: %s", msg)
 	}
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":["a"]}`)); msg != "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":["a"]}`), ""); msg != "" {
 		t.Fatalf("non-empty array flagged: %s", msg)
 	}
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":0}`)); msg != "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":0}`), ""); msg != "" {
 		t.Fatalf("numeric 0 must be considered present: %s", msg)
 	}
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{}`)); msg == "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{}`), ""); msg == "" {
 		t.Fatal("absent required field must still be flagged missing")
 	}
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":null}`)); msg == "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":null}`), ""); msg == "" {
 		t.Fatal("null required field must still be flagged missing")
 	}
 	objSchema := json.RawMessage(`{"type":"object","properties":{"opts":{"type":"object"}},"required":["opts"]}`)
-	if msg := ValidateRequiredParams(objSchema, json.RawMessage(`{"opts":{}}`)); msg != "" {
+	if msg := ValidateRequiredParams(objSchema, json.RawMessage(`{"opts":{}}`), ""); msg != "" {
 		t.Fatalf("explicit empty object must be provided, got: %s", msg)
 	}
 }

--- a/internal/tool/required_validation_test.go
+++ b/internal/tool/required_validation_test.go
@@ -12,7 +12,7 @@ func TestValidateRequiredParams_AllPresent(t *testing.T) {
 		"required": ["path", "pattern"]
 	}`)
 	args := json.RawMessage(`{"path": "/tmp/test.go", "pattern": "TODO"}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg != "" {
 		t.Errorf("expected no missing params, got: %s", msg)
 	}
@@ -25,7 +25,7 @@ func TestValidateRequiredParams_OneMissing(t *testing.T) {
 		"required": ["path", "pattern"]
 	}`)
 	args := json.RawMessage(`{"path": "/tmp/test.go"}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg == "" {
 		t.Fatal("expected missing param error, got empty")
 	}
@@ -41,7 +41,7 @@ func TestValidateRequiredParams_MultipleMissing(t *testing.T) {
 		"required": ["path", "pattern", "description"]
 	}`)
 	args := json.RawMessage(`{"path": "/tmp"}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg == "" {
 		t.Fatal("expected missing params error, got empty")
 	}
@@ -60,7 +60,7 @@ func TestValidateRequiredParams_EmptyString(t *testing.T) {
 		"required": ["path"]
 	}`)
 	args := json.RawMessage(`{"path": ""}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg == "" {
 		t.Fatal("expected missing param error for empty string")
 	}
@@ -76,7 +76,7 @@ func TestValidateRequiredParams_WhitespaceString(t *testing.T) {
 	// CheckRequired's Trim behavior in tool.go — a whitespace path or grep
 	// pattern is useless and previously bypassed the required-param gateway.
 	args := json.RawMessage(`{"path": "  "}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg == "" {
 		t.Fatal("expected missing param error for whitespace-only string")
 	}
@@ -89,7 +89,7 @@ func TestValidateRequiredParams_NullValue(t *testing.T) {
 		"required": ["path"]
 	}`)
 	args := json.RawMessage(`{"path": null}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg == "" {
 		t.Fatal("expected missing param error for null value")
 	}
@@ -103,7 +103,7 @@ func TestValidateRequiredParams_NumberZero(t *testing.T) {
 	}`)
 	// 0 is a valid value — should NOT be treated as missing
 	args := json.RawMessage(`{"offset": 0}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg != "" {
 		t.Errorf("0 should not be treated as missing, got: %s", msg)
 	}
@@ -117,7 +117,7 @@ func TestValidateRequiredParams_BooleanFalse(t *testing.T) {
 	}`)
 	// false is a valid value — should NOT be treated as missing
 	args := json.RawMessage(`{"headless": false}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg != "" {
 		t.Errorf("false should not be treated as missing, got: %s", msg)
 	}
@@ -132,15 +132,15 @@ func TestValidateRequiredParams_EmptyArray(t *testing.T) {
 		"required": ["files"]
 	}`)
 	args := json.RawMessage(`{"files": []}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg != "" {
 		t.Errorf("explicit empty array should be treated as provided, got: %s", msg)
 	}
 	// Absent key and null must still be reported as missing.
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{}`)); msg == "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{}`), ""); msg == "" {
 		t.Error("absent required field should be reported missing")
 	}
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":null}`)); msg == "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"files":null}`), ""); msg == "" {
 		t.Error("null required field should be reported missing")
 	}
 }
@@ -152,7 +152,7 @@ func TestValidateRequiredParams_NonEmptyArray(t *testing.T) {
 		"required": ["files"]
 	}`)
 	args := json.RawMessage(`{"files": ["a.go"]}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg != "" {
 		t.Errorf("non-empty array should not be missing, got: %s", msg)
 	}
@@ -164,7 +164,7 @@ func TestValidateRequiredParams_NoRequiredFields(t *testing.T) {
 		"properties": {"path": {"type": "string"}}
 	}`)
 	args := json.RawMessage(`{}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg != "" {
 		t.Errorf("no required fields = no error, got: %s", msg)
 	}
@@ -172,7 +172,7 @@ func TestValidateRequiredParams_NoRequiredFields(t *testing.T) {
 
 func TestValidateRequiredParams_NoSchema(t *testing.T) {
 	args := json.RawMessage(`{"path": "/tmp"}`)
-	msg := ValidateRequiredParams(nil, args)
+	msg := ValidateRequiredParams(nil, args, "")
 	if msg != "" {
 		t.Errorf("nil schema = no error, got: %s", msg)
 	}
@@ -181,7 +181,7 @@ func TestValidateRequiredParams_NoSchema(t *testing.T) {
 func TestValidateRequiredParams_UnparseableSchema(t *testing.T) {
 	schema := json.RawMessage(`{invalid json}`)
 	args := json.RawMessage(`{"path": "/tmp"}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg != "" {
 		t.Errorf("unparseable schema should silently pass, got: %s", msg)
 	}
@@ -190,7 +190,7 @@ func TestValidateRequiredParams_UnparseableSchema(t *testing.T) {
 func TestValidateRequiredParams_UnparseableArgs(t *testing.T) {
 	schema := json.RawMessage(`{"required": ["path"]}`)
 	args := json.RawMessage(`{invalid}`)
-	msg := ValidateRequiredParams(schema, args)
+	msg := ValidateRequiredParams(schema, args, "")
 	if msg != "" {
 		t.Errorf("unparseable args should silently pass (let tool handle), got: %s", msg)
 	}

--- a/internal/tool/zz_issue568_test.go
+++ b/internal/tool/zz_issue568_test.go
@@ -23,7 +23,7 @@ func TestEmptyArrayRequiredNotMissing(t *testing.T) {
 	}`)
 	// The todo_write clear operation: "Existing todos not in this list are
 	// removed" — [] is the legitimate clearing value.
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"todos":[]}`)); msg != "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"todos":[]}`), ""); msg != "" {
 		t.Fatalf("explicit [] must be treated as provided, got: %s", msg)
 	}
 	if msg := isEmptyValue(json.RawMessage(`[]`)); msg {
@@ -33,13 +33,13 @@ func TestEmptyArrayRequiredNotMissing(t *testing.T) {
 		t.Fatal("isEmptyValue({}) must be false — explicit empty object is provided")
 	}
 	// Guards: key absent and null are still missing.
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{}`)); msg == "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{}`), ""); msg == "" {
 		t.Fatal("absent required field must still be missing")
 	}
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"todos":null}`)); msg == "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"todos":null}`), ""); msg == "" {
 		t.Fatal("null required field must still be missing")
 	}
-	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"todos":""}`)); msg == "" {
+	if msg := ValidateRequiredParams(schema, json.RawMessage(`{"todos":""}`), ""); msg == "" {
 		t.Fatal("empty string required field must still be missing")
 	}
 }


### PR DESCRIPTION
## Summary
Closes #1838.

- **Case 1 (Med-High)**: an explicit `""` now counts as PROVIDED for the three delete-semantics params — edit_file `new_text` (deletion), write_file `content` (empty-file creation), batch_replace `replacement` (delete matches). The #542 blanket empty=missing rule rejected every delete edit with an unsatisfiable remedy (futile retry loop or forced full-file rewrite). Absence and null still fail; #542 is untouched for all other tool/param pairs; the handlers' #742 presence-only decision is restored upstream.
- Case 2: the shadowed rich preflight validator is documented as accepted (superset behavior; still reachable off the strict path).

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/tool **127.0s** + internal/agent **23.3s** PASS (p=1). Pins: delete edit passes / absent & null still missing / whitespace content is provided / whitelist is tool-scoped.

Per team convention: merge only after this PR's CI is green.

Closes #1838

Generated with [ggcode](https://github.com/topcheer/ggcode)
