### PR TITLE
fix(swarm): stored teammate results survive the removal gate (#1814)

### DIFF
--- a/internal/swarm/manager.go
+++ b/internal/swarm/manager.go
@@ -677,22 +677,21 @@ func (m *Manager) GetTeammateResult(teamID, tmID string) (string, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Verify the teammate still exists in its team.
-	team, ok := m.teams[teamID]
-	if !ok {
-		return "", false
+	// #1814: the stored-result fallback used to sit AFTER the teammate
+	// existence gate - a shutdown removes the teammate, so "shut the
+	// worker down, THEN collect the output" (the most common order)
+	// returned "No result available" while the data sat in m.results.
+	// The fallback's own comment ("survives if teammate was removed")
+	// documented a purpose the gate made unreachable. Stored result
+	// first-checked without the gate; live teammate result still
+	// preferred when present.
+	if tm, ok := m.teams[teamID]; ok {
+		if live, ok := tm.getTeammate(tmID); ok {
+			if r := live.getResults(); r != "" {
+				return r, true
+			}
+		}
 	}
-	tm, ok := team.getTeammate(tmID)
-	if !ok {
-		return "", false
-	}
-
-	// Prefer the live result from the teammate (most up-to-date).
-	if r := tm.getResults(); r != "" {
-		return r, true
-	}
-
-	// Fall back to the stored result (survives if teammate was removed).
 	r, ok := m.results[tmID]
 	return r, ok && r != ""
 }

--- a/internal/swarm/manager_test.go
+++ b/internal/swarm/manager_test.go
@@ -1005,3 +1005,33 @@ func TestManager_ShutdownTeammateFreesResult(t *testing.T) {
 		}
 	}
 }
+
+// TestGetTeammateResultAfterShutdown pins #1814: the stored result must
+// stay retrievable after the teammate was shut down and REMOVED - the
+// fallback used to sit behind the existence gate, so "shut the worker,
+// then collect the output" (the most common order) hit a result
+// blackhole while the data sat in m.results.
+func TestGetTeammateResultAfterShutdown(t *testing.T) {
+	m := NewManager(config.SwarmConfig{}, nil, nil, nil)
+	team := m.CreateTeam("result-team", "leader-1")
+	tm, err := m.SpawnTeammate(team.ID, "worker-1", "", nil)
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	// Simulate a stored final result, then remove the teammate (what
+	// ShutdownTeammate's removal does once the goroutine exits).
+	m.mu.Lock()
+	m.results[tm.ID] = "final output"
+	// Drop the teammate from its team to model the post-shutdown state.
+	if t0, ok := m.teams[team.ID]; ok {
+		t0.mu.Lock()
+		delete(t0.Teammates, tm.ID)
+		t0.mu.Unlock()
+	}
+	m.mu.Unlock()
+
+	r, ok := m.GetTeammateResult(team.ID, tm.ID)
+	if !ok || r != "final output" {
+		t.Fatalf("stored result must survive teammate removal, got (%q, %v)", r, ok)
+	}
+}


### PR DESCRIPTION
The stored-result fallback sat **after** the teammate existence check - `ShutdownTeammate` removes the teammate, so 'shut the worker down, THEN collect the output' (the most common order) returned `No result available` while the data sat in `m.results`. Both the fallback's own comment ('survives if teammate was removed') and the emit-side promise ('leader can still retrieve after shutdown') documented a purpose the gate made unreachable (a #1633 regression).

The stored result is now checked without the gate; the live teammate result stays preferred when present. Pinned with a post-removal retrieval test.

Isolated worktree (fresh origin/main): swarm package full PASS (5.1s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)