### PR TITLE
fix(agentruntime,desktop): vision turn switch inherits current selection; restore persists; auto-title edge cases (#1670)

### DIFF
--- a/desktop/wailskit/chat.go
+++ b/desktop/wailskit/chat.go
@@ -4615,6 +4615,18 @@ func (b *ChatBridge) beginVisionTurnIfNeeded(content []provider.ContentBlock) fu
 			b.mu.Lock()
 			b.resolved = r
 			b.mu.Unlock()
+			// #1670 case 2: the vision switch writes the TRANSIENT
+			// ep.SelectedModel on the SHARED cfg, and this desktop process
+			// has many cfg.Save() surfaces (settings panel, IM, config
+			// editors) that can fire mid-turn and persist that transient
+			// vision model. The model_switch core deliberately does not
+			// Save (session-scoped selection), so without this write-back
+			// the NEXT app start loaded the vision model. Persisting the
+			// restored user selection closes the window on this
+			// desktop-in-process path only.
+			if err := cfg.Save(); err != nil {
+				debug.Log("chat", "vision fallback: persisting restored model failed: %v", err)
+			}
 		} else {
 			debug.Log("chat", "vision fallback restore failed: %v", err)
 		}

--- a/internal/agentruntime/auto_title.go
+++ b/internal/agentruntime/auto_title.go
@@ -49,7 +49,11 @@ var (
 	// markdownHeadingRe matches markdown headings (#, ##, etc.).
 	markdownHeadingRe = regexp.MustCompile(`^#{1,6}\s+`)
 	// markdownBoldItalicRe matches **bold**, *italic*, __bold__, _italic_.
-	markdownBoldItalicRe = regexp.MustCompile(`\*{1,3}([^*]+)\*{1,3}|_{1,3}([^_]+)_{1,3}`)
+	// #1670 Low 1: the underscore branch must not fire mid-word -
+	// `fix_user_id` matched _user_ (italic) and lost its underscores,
+	// gluing the identifier together. Word-boundary anchors on both sides
+	// keep genuine _italic_ working while snake_case identifiers survive.
+	markdownBoldItalicRe = regexp.MustCompile(`\*{1,3}([^*]+)\*{1,3}|(^|[\s（(\[【{"'，、])_{1,3}([^_]+)_{1,3}($|[\s，。！？)\]】}"'.,;:!?])`)
 	// longFilePathRe matches paths that look like file references (3+ segments).
 	longFilePathRe = regexp.MustCompile(`[\w\-./]+\b\.\w{1,5}\b`)
 	// commandPrefixRe strips leading shell comment or prompt artifacts.
@@ -78,7 +82,7 @@ func GenerateTitle(userMessage string) string {
 	s = markdownHeadingRe.ReplaceAllString(s, "")
 
 	// 5. Unwrap bold/italic markers, keep inner text.
-	s = markdownBoldItalicRe.ReplaceAllString(s, "$1$2")
+	s = markdownBoldItalicRe.ReplaceAllString(s, "$1$2$3$4")
 
 	// 6. Collapse file paths to just the basename (last segment).
 	s = longFilePathRe.ReplaceAllStringFunc(s, func(m string) string {
@@ -125,6 +129,19 @@ func firstSentence(s string) string {
 	endChars := ".!?。！？"
 	runeIdx := 0
 	for i, r := range s {
+		// #1670 Low 2: a period between digits is a decimal point, not a
+		// terminator - "支持 v2.0 的功能" was truncated to "支持 v2".
+		if r == '.' {
+			hasPrev := i > 0 && isASCIIDigit(s[i-1])
+			hasNext := i+1 < len(s) && isASCIIDigit(s[i+1])
+			if hasPrev && hasNext {
+				runeIdx++
+				if runeIdx >= titleMaxRunes*2 {
+					break
+				}
+				continue
+			}
+		}
 		if strings.ContainsRune(endChars, r) {
 			candidate := strings.TrimSpace(s[:i+utf8.RuneLen(r)])
 			if utf8.RuneCountInString(candidate) >= titleMinRunes {
@@ -138,6 +155,9 @@ func firstSentence(s string) string {
 	}
 	return s
 }
+
+// isASCIIDigit reports whether b is an ASCII digit.
+func isASCIIDigit(b byte) bool { return b >= '0' && b <= '9' }
 
 // truncateTitle truncates to maxRunes at a word boundary (space for Latin,
 // any rune boundary for CJK). Appends "…" if truncated.

--- a/internal/agentruntime/checks_1670_test.go
+++ b/internal/agentruntime/checks_1670_test.go
@@ -1,0 +1,32 @@
+package agentruntime
+
+import (
+	"testing"
+
+	"github.com/topcheer/ggcode/internal/config"
+)
+
+// #1670 case 1 pin: ("", "", model) inherits the CURRENT vendor/endpoint
+// instead of failing on the empty vendor.
+func Test1670EmptyVendorInheritsCurrent(t *testing.T) {
+	cfg := &config.Config{
+		Vendor:   "zai",
+		Endpoint: "main",
+		Vendors: map[string]config.VendorConfig{
+			"zai": {Endpoints: map[string]config.EndpointConfig{
+				"main": {BaseURL: "https://api.z.ai/v1", APIKey: "k", Protocol: "openai", SelectedModel: "glm-5.3"},
+			}},
+		},
+	}
+	// Before the fix this returned `vendor "" is not configured`.
+	if _, _, err := ActivateCurrentSelection(cfg, "", "", "glm-5.3-vision"); err != nil {
+		t.Fatalf("vision-form switch must inherit the current selection, got: %v", err)
+	}
+	if cfg.Model != "glm-5.3-vision" {
+		t.Fatalf("model must switch, got %q", cfg.Model)
+	}
+	// Restore form works too.
+	if _, _, err := ActivateCurrentSelection(cfg, "", "", "glm-5.3"); err != nil {
+		t.Fatalf("restore-form switch must inherit too, got: %v", err)
+	}
+}

--- a/internal/agentruntime/model_switch.go
+++ b/internal/agentruntime/model_switch.go
@@ -45,6 +45,20 @@ func ActivateCurrentSelection(cfg *config.Config, vendor, endpoint, model string
 	if cfg == nil {
 		return nil, nil, fmt.Errorf("config is nil")
 	}
+	// #1670 case 1: empty vendor/endpoint means "inherit the CURRENT
+	// selection", not "look up vendor \"\"". The IM/daemon/desktop vision
+	// turn switchers all pass ("", "", visionModel) - the original TUI
+	// implementation passed the active cfg.Vendor/Endpoint explicitly, but
+	// the ported callers dropped them, so every switch died on
+	// `vendor "" is not configured`, the failure only hit the debug log,
+	// and the image was silently stripped to a non-vision model (the
+	// feature was dead on arrival for IM/desktop).
+	if vendor == "" {
+		vendor = cfg.Vendor
+	}
+	if endpoint == "" {
+		endpoint = cfg.Endpoint
+	}
 	if vendor != "" || endpoint != "" || model != "" {
 		// #1487: snapshot the active selection before SetActiveSelection
 		// rewrites it, so a failed Resolve can roll back. Without this, a


### PR DESCRIPTION
## Summary
Closes #1670.

- **Case 1 (High)**: `ActivateCurrentSelection(cfg, "", "", model)` — the form every IM/daemon/desktop vision-turn switcher uses — no longer fails on `vendor "" is not configured`; empty vendor/endpoint inherits the CURRENT selection (the original TUI passed them explicitly; the port dropped them, making the vision fallback dead-on-arrival with only a debug log and silent image stripping).
- **Case 2 (Med, desktop-only)**: the desktop vision-restore path now persists the restored user selection — mid-turn cfg.Save() surfaces could otherwise freeze the transient vision model to disk for the next app start.
- **Low×2 (auto_title)**: underscore italic stripping no longer fires mid-word (snake_case identifiers survive); a digit-period-digit sequence is a decimal point, not a sentence terminator.

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agentruntime **12.9s** + desktop/wailskit **10.7s** + cmd/ggcode **4.7s** PASS (p=1). Pins: ("","",model) inherits current vendor and switches; restore form also inherits.

Per team convention: merge only after this PR's CI is green.

Closes #1670

Generated with [ggcode](https://github.com/topcheer/ggcode)
