### PR TITLE
fix(agent): drift recurrence counts failed verifications; weak-baseline bar for the scattering branch (#1544)

### DIFF
--- a/internal/agent/checks_1544_test.go
+++ b/internal/agent/checks_1544_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import "testing"
+
+// recordEditFiltered mirrors driftRecurrenceRecord's ok-gating without an Agent.
+func recordEditFilteredFor1544(d *driftRecurrenceState, tool, path string, ok bool) {
+	if productiveEditTools[tool] && ok {
+		d.recordEdit(path)
+	}
+}
+
+// #1544 case B pin: a FAILED verification still counts as verification run.
+func Test1544FailedVerificationCounts(t *testing.T) {
+	d := newDriftRecurrenceState()
+	d.markWarning(5)
+	// red-phase go test that FAILED (ok=false)
+	d.recordVerification()
+	d.recordEdit("/w/src/a.go")
+	if d.postWarnVerifies != 1 {
+		t.Fatalf("failed verification must count, got %d", d.postWarnVerifies)
+	}
+	// failed edit must NOT count
+	d2 := newDriftRecurrenceState()
+	d2.markWarning(5)
+	recordEditFilteredFor1544(d2, "edit_file", "/w/src/a.go", false)
+	if d2.postWarnEdits != 0 {
+		t.Fatalf("failed edit must not count, got %d", d2.postWarnEdits)
+	}
+}
+
+// #1544 case C pin: weak (empty) pre-warn baseline -> the 2-3-new-dirs
+// relaxed branch must not fire; fat baseline keeps it.
+func Test1544WeakBaselineRaisesBar(t *testing.T) {
+	weak := newDriftRecurrenceState()
+	weak.markWarning(5) // baseline 0 (plan-drift early arm)
+	for _, p := range []string{"/w/src/x.go", "/w/src/x_test.go"} {
+		weak.recordEdit(p)
+	}
+	if msg := weak.check(); msg != "" {
+		t.Fatalf("weak baseline + normal 2-dir workflow must not fire, got: %s", msg)
+	}
+
+	fat := newDriftRecurrenceState()
+	for i := 0; i < 5; i++ {
+		fat.recordEdit("/w/dir" + string(rune('a'+i)) + "/f.go")
+	}
+	fat.markWarning(5) // fat baseline
+	fat.recordEdit("/w/new1/a.go")
+	fat.recordEdit("/w/new2/b.go")
+	for i := 0; i < 6; i++ {
+		fat.recordEdit("/w/new1/a.go") // reach min edits
+	}
+	if msg := fat.check(); msg == "" {
+		t.Fatal("fat baseline scattering with zero verifies must fire")
+	}
+	// #1452-A reconciliation: empty baseline with THREE scattered dirs and
+	// zero verifies must still fire (converged-single-dir stays spared).
+	d3 := newDriftRecurrenceState()
+	d3.markWarning(5)
+	d3.recordEdit("/a/x.go")
+	d3.recordEdit("/b/y.go")
+	d3.recordEdit("/c/z.go")
+	for i := 0; i < 5; i++ {
+		d3.recordEdit("/a/x.go")
+	}
+	if msg := d3.check(); msg == "" {
+		t.Fatal("empty baseline 3-dir scattering with zero verifies must fire")
+	}
+}

--- a/internal/agent/drift_recurrence_detect.go
+++ b/internal/agent/drift_recurrence_detect.go
@@ -85,6 +85,8 @@ type driftRecurrenceState struct {
 	// preWarnDirs is the set of unique directory signatures touched BEFORE
 	// any drift warning fired. Used to identify NEW directories post-warning.
 	preWarnDirs map[string]bool
+	// preWarnBaseline is the baseline size captured at arm time (#1544 C).
+	preWarnBaseline int
 
 	// postWarnDirs is the set of unique directory signatures touched AFTER
 	// a drift warning fired.
@@ -165,6 +167,13 @@ func (d *driftRecurrenceState) markWarning(iteration int) {
 	if !d.warned {
 		d.warned = true
 		d.warnIteration = iteration
+		// #1544 case C: the diff against preWarnDirs assumes the pre-warn
+		// baseline is FAT (scope_drift arms late, after ~5 dirs). plan_drift
+		// arms EARLY on the wrap-up path, where the baseline can be empty -
+		// every subsequent dir then counts as "new", and the normal
+		// src + _test two-dir workflow read as "STILL SCATTERING". Record
+		// the baseline size so check() can raise the bar for weak baselines.
+		d.preWarnBaseline = len(d.preWarnDirs)
 	}
 }
 
@@ -212,6 +221,15 @@ func (d *driftRecurrenceState) check() string {
 	// a single concentrated dir is convergence, not recurrence.
 	if newDirs < driftRecurrenceNewDirThreshold {
 		if newDirs <= 1 {
+			return ""
+		}
+		// #1544 case C: the relaxed 2-3-new-dirs scattering branch assumes
+		// a non-empty pre-warn baseline (late-armed scope_drift, #473's
+		// shape). An early-armed plan_drift with an EMPTY baseline makes
+		// every dir trivially "new" - a normal src+_test workflow was
+		// branded "STILL SCATTERING". With an empty baseline, require the
+		// FULL threshold; any non-empty baseline keeps #473 semantics.
+		if d.preWarnBaseline == 0 && newDirs <= 2 {
 			return ""
 		}
 		// Under threshold but scattering (2-3 new dirs): require zero
@@ -266,10 +284,16 @@ func (d *driftRecurrenceState) check() string {
 // lookup classified every run_command as verifying, contradicting the
 // debt detector on the same command.
 func (a *Agent) driftRecurrenceRecord(toolName string, fileHint string, args string, ok bool) {
-	if a.driftRecurrence == nil || !ok {
+	if a.driftRecurrence == nil {
 		return
 	}
-	if productiveEditTools[toolName] {
+	// #1544 case B: the blanket !ok gate also swallowed FAILED
+	// verifications - a red-phase `go test` (non-zero exit, IsError=true)
+	// is still verification RUN, but the warning then claimed "You have
+	// not run ANY verification" about an agent that just ran it. Only the
+	// EDIT side keeps the !ok gate (#1452-B, aligned with the sibling
+	// detectors' IsError gates); verification counting is outcome-blind.
+	if productiveEditTools[toolName] && ok {
 		a.driftRecurrence.recordEdit(fileHint)
 	}
 	if toolName == "run_command" {


### PR DESCRIPTION
## Summary
Closes #1544 (cases B and C; case A already fixed via #1522).

- **Case B (Low-Med)**: failed verifications (red-phase `go test`, non-zero exit) now count as verification RUN — the "You have not run ANY verification" accusation no longer lands on an agent that just ran one. The edit side keeps the #1452-B !ok gate.
- **Case C (Low)**: an EMPTY pre-warn baseline (early-armed plan_drift) no longer makes the normal src+_test two-dir workflow "STILL SCATTERING" — the relaxed 2-3-dir branch requires 3+ new dirs on an empty baseline; non-empty baselines keep #473 semantics and the #1452-A 3-dir scattering pin still fires.

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **24.2s PASS** (p=1), full drift-recurrence family green. Pins: failed verification counts / failed edit does not; empty baseline + 2-dir workflow silent / 3-dir scattering fires / fat baseline keeps firing.

Per team convention: merge only after this PR's CI is green.

Closes #1544

Generated with [ggcode](https://github.com/topcheer/ggcode)
