### PR TITLE
fix(agent): todo_drop CJK bigram similarity + rune-safe truncation (#1506 case A)

### DIFF
--- a/internal/agent/checks_1506_test.go
+++ b/internal/agent/checks_1506_test.go
@@ -1,0 +1,30 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// #1506 case A pin: CJK rewording survives - bigram similarity instead of
+// space-token Jaccard.
+func Test1506CJKRewordNotDrop(t *testing.T) {
+	if sim := todoDropSimilarityOf("修复登录bug", "修复登录的bug"); sim < todoDropSimilarity {
+		t.Fatalf("CJK reword similarity %.2f must clear the threshold %.2f", sim, todoDropSimilarity)
+	}
+	// English path unchanged.
+	if sim := todoDropSimilarityOf("write unit tests for parser", "write unit tests for parser"); sim != 1.0 {
+		t.Fatalf("identical English items must be 1.0, got %.2f", sim)
+	}
+}
+
+// #1506 case A pin: truncateStr never splits a rune.
+func Test1506TruncateRuneSafe(t *testing.T) {
+	out := truncateStr("修复登录页面的权限校验并补充单元测试用例", 8)
+	if !utf8.ValidString(out) {
+		t.Fatalf("truncateStr produced invalid UTF-8: %q", out)
+	}
+	if !strings.HasSuffix(out, "...") {
+		t.Fatalf("truncated string should end with ..., got %q", out)
+	}
+}

--- a/internal/agent/todo_drop.go
+++ b/internal/agent/todo_drop.go
@@ -134,7 +134,7 @@ func (t *todoDropState) itemSurvives(item todoItem, curr []todoItem) bool {
 		}
 		// Fuzzy content match: item was reworded but carried forward.
 		if item.Content != "" && c.Content != "" {
-			sim := todoDropJaccard(item.Content, c.Content)
+			sim := todoDropSimilarityOf(item.Content, c.Content)
 			if sim >= todoDropSimilarity {
 				return true
 			}
@@ -201,6 +201,33 @@ func todoDropJaccard(a, b string) float64 {
 	return float64(intersection) / float64(union)
 }
 
+// hasCJK reports whether the string contains CJK runes.
+func hasCJK(s string) bool {
+	for _, r := range s {
+		if r >= 0x4E00 && r <= 0x9FFF {
+			return true
+		}
+	}
+	return false
+}
+
+// cjkBigramSet tokenizes a CJK string into overlapping character bigrams
+// (#1506 case A). strings.Fields splits on SPACES - a Chinese sentence is
+// one giant token, so rewording (修复登录bug -> 修复登录的bug) scored
+// Jaccard 0 and was branded an "abandoned item" despite the module's
+// promise to avoid flagging rewording as a drop.
+func cjkBigramSet(s string) map[string]bool {
+	runes := []rune(strings.ToLower(s))
+	set := make(map[string]bool, len(runes))
+	for i := 0; i+1 < len(runes); i++ {
+		set[string(runes[i:i+2])] = true
+	}
+	if len(runes) > 0 {
+		set[string(runes[len(runes)-1:])] = true
+	}
+	return set
+}
+
 // wordSet tokenizes a string into a lowercase word set.
 func wordSet(s string) map[string]bool {
 	words := strings.Fields(strings.ToLower(s))
@@ -215,12 +242,46 @@ func wordSet(s string) map[string]bool {
 	return set
 }
 
-// truncateStr shortens a string to maxLen, appending "..." if truncated.
+// todoDropSimilarityOf is Jaccard similarity with a CJK fallback: when
+// either side contains CJK (space-less language), compare character
+// bigrams instead of space-split words (#1506 case A).
+func todoDropSimilarityOf(a, b string) float64 {
+	if hasCJK(a) || hasCJK(b) {
+		return jaccardOfSets(cjkBigramSet(a), cjkBigramSet(b))
+	}
+	return todoDropJaccard(a, b)
+}
+
+// jaccardOfSets computes Jaccard over two arbitrary sets.
+func jaccardOfSets(a, b map[string]bool) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	intersection := 0
+	for k := range a {
+		if b[k] {
+			intersection++
+		}
+	}
+	union := len(a) + len(b) - intersection
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}
+
+// truncateStr shortens a string to maxLen runes, appending "..." if
+// truncated (#1506 case A: byte slicing split multi-byte CJK runes and
+// produced mojibake in the guidance).
 func truncateStr(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
-	return s[:maxLen-3] + "..."
+	if maxLen <= 3 {
+		return string(runes[:maxLen])
+	}
+	return string(runes[:maxLen-3]) + "..."
 }
 
 // checkTodoDrop is the entry point called from the agent loop after a


### PR DESCRIPTION
## Summary
Closes #1506 (case A; cases B and C already landed under the #1506/#1695 markers in tool_claim_verify.go).

- **Case A (Med-Low)**: CJK todo rewording no longer scores Jaccard 0 against itself — when either side contains CJK, similarity is computed over character bigrams (修复登录bug → 修复登录的bug now survives as a reword, not an "abandoned item"). truncateStr switched from byte slicing (which split multi-byte runes into mojibake) to rune slicing.

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **24.5s PASS** (p=1). Pins: CJK reword clears the threshold / identical English stays 1.0; truncation is rune-safe and suffixes "...".

Per team convention: merge only after this PR's CI is green.

Closes #1506

Generated with [ggcode](https://github.com/topcheer/ggcode)
