### PR TITLE
fix(tunnel,subagent): retry_after_ms clamped; EventsSince absolute cursor (#1816 cases 1+2)

### DIFF
--- a/internal/subagent/event_test.go
+++ b/internal/subagent/event_test.go
@@ -138,3 +138,38 @@ func TestTruncateStr(t *testing.T) {
 		}
 	}
 }
+
+// TestEventsSinceSurvivesEviction pins #1816 case 2: the cursor is ABSOLUTE
+// (len+dropped) - after ring eviction the total never falls back, and a
+// caller holding the pre-eviction cursor still gets the surviving events.
+func TestEventsSinceSurvivesEviction(t *testing.T) {
+	const total = maxAgentEvents + 2 // force at least 2 evictions
+	s := &SubAgent{}
+	for i := 0; i < total; i++ {
+		// Alternate Text/ToolCall: consecutive same-type events coalesce
+		// (textMergeInterval) - alternation keeps every append a real event.
+		if i%2 == 0 {
+			s.appendEvent(AgentEvent{Type: AgentEventText, Text: fmt.Sprintf("e%d", i)})
+		} else {
+			s.appendEvent(AgentEvent{Type: AgentEventToolCall, ToolName: fmt.Sprintf("t%d", i)})
+		}
+	}
+	events, got := s.EventsSince(0)
+	if got != total {
+		t.Fatalf("absolute total must be %d (kept+dropped), got %d", total, got)
+	}
+	if len(events) != maxAgentEvents {
+		t.Fatalf("cursor predating the window replays the survivors, got %d", len(events))
+	}
+	// Incremental consumption across eviction: hold an earlier cursor, then
+	// ask again after more evictions - must never silently return nothing.
+	mid := total - 1                                                      // one event exists beyond this cursor already
+	s.appendEvent(AgentEvent{Type: AgentEventToolCall, ToolName: "more"}) // evicts again
+	next, t2 := s.EventsSince(mid)
+	if t2 != total+1 {
+		t.Fatalf("cursor must advance monotonically, got %d", t2)
+	}
+	if len(next) == 0 {
+		t.Fatal("new events must be delivered across eviction")
+	}
+}

--- a/internal/subagent/manager.go
+++ b/internal/subagent/manager.go
@@ -241,19 +241,28 @@ func (s *SubAgent) Events() []AgentEvent {
 	return out
 }
 
-// EventsSince returns only events with index >= fromIdx.
+// EventsSince returns only events with ABSOLUTE index >= fromIdx.
 // This avoids copying the full event history when only incremental events
-// are needed (e.g. GUI agent panel updates). Returns the total event count
-// so callers can track the next fromIdx.
+// are needed (e.g. GUI agent panel updates). Returns the next absolute
+// cursor (len(events)+eventsDropped) so callers can track their position
+// across ring eviction - a relative cursor (plain len) fell BACKWARD when
+// the ring dropped old events, and a caller holding the old total then
+// saw fromIdx >= total and silently received nothing forever (#1636's
+// exact twin, fixed here before the first GUI consumer hits it).
 func (s *SubAgent) EventsSince(fromIdx int) ([]AgentEvent, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	total := len(s.events)
+	total := len(s.events) + s.eventsDropped
 	if fromIdx >= total {
 		return nil, total
 	}
+	if fromIdx < s.eventsDropped {
+		// Cursor predates the surviving window: replay from the oldest
+		// surviving event (repeatable, never a loss).
+		fromIdx = s.eventsDropped
+	}
 	out := make([]AgentEvent, total-fromIdx)
-	copy(out, s.events[fromIdx:])
+	copy(out, s.events[fromIdx-s.eventsDropped:])
 	return out, total
 }
 

--- a/internal/tunnel/relay_client.go
+++ b/internal/tunnel/relay_client.go
@@ -897,5 +897,18 @@ func parseRetryAfterMs(closeText string) int64 {
 	}
 	var ms int64
 	fmt.Sscanf(s, "%d", &ms)
+	// #1816 case 1: the relay is a REMOTE party - a poisoned or malicious
+	// value had two failure modes: ms > ~9.2e12 overflows time.Duration
+	// NEGATIVE (time.After(negative) fires immediately -> a zero-backoff
+	// dial storm against a restarting relay), and ms ~ 1e12 (~31 years)
+	// silenced reconnection for the process lifetime. Clamp to the same
+	// ceiling the exponential ladder uses.
+	const maxRetryAfterMs = 5 * 60 * 1000 // 5 min, matches the ladder cap
+	if ms < 0 {
+		return 0
+	}
+	if ms > maxRetryAfterMs {
+		return maxRetryAfterMs
+	}
 	return ms
 }

--- a/internal/tunnel/relay_client_test.go
+++ b/internal/tunnel/relay_client_test.go
@@ -267,3 +267,22 @@ func TestRelayClientHandleKeyOfferRespondsWithWrappedKey(t *testing.T) {
 		t.Fatal("timed out waiting for key_accept")
 	}
 }
+
+// TestParseRetryAfterMsClamp pins #1816 case 1: a remote relay's value is
+// untrusted - overflow (negative Duration -> zero-backoff dial storm) and
+// absurd magnitudes (~31 years -> never reconnect) both clamp into the
+// ladder's ceiling.
+func TestParseRetryAfterMsClamp(t *testing.T) {
+	if got := parseRetryAfterMs("retry_after_ms=1000"); got != 1000 {
+		t.Fatalf("normal value must pass through, got %d", got)
+	}
+	if got := parseRetryAfterMs("retry_after_ms=9999999999999999"); got != 300000 {
+		t.Fatalf("overflow-scale value must clamp to 300000 (5min), got %d", got)
+	}
+	if got := parseRetryAfterMs("retry_after_ms=-5"); got != 0 {
+		t.Fatalf("negative must clamp to 0, got %d", got)
+	}
+	if got := parseRetryAfterMs("no marker here"); got != 0 {
+		t.Fatalf("absent marker is 0, got %d", got)
+	}
+}


### PR DESCRIPTION
Case 1 (Med): `parseRetryAfterMs` trusted a **remote relay's** value - ms beyond ~9.2e12 overflowed time.Duration negative (`time.After(negative)` fires immediately -> **zero-backoff dial storm** against a restarting relay) and ~1e12 (~31 years) **silenced reconnection for the process lifetime**. Clamped to [0, the ladder's 5min ceiling].

Case 2 (Low-Med): `SubAgent.EventsSince` kept #1636's pre-fix shape (plain len as cursor) - ring eviction made the total fall **backward** and a caller holding the old total silently received nothing forever. The teammate twin was fixed in #1636; this is the absolute-cursor mirror (len+dropped, sub-window replay), pinned before the first GUI consumer arrives.

Both pinned (clamp round-trip; eviction-survival with alternating event types - textMerge coalescing documented).

Isolated worktree (fresh origin/main): tunnel 22.0s + subagent 2.3s full PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)