### PR TITLE
fix(cmd): stderr tee covers riscv64/loong64; restore keeps the spare fd (#1818 cases 1+2)

### DIFF
--- a/cmd/ggcode/stderr_tee_dup2.go
+++ b/cmd/ggcode/stderr_tee_dup2.go
@@ -1,4 +1,4 @@
-//go:build !windows && !(linux && arm64)
+//go:build !windows && !(linux && (arm64 || riscv64 || loong64))
 
 package main
 

--- a/cmd/ggcode/stderr_tee_dup3.go
+++ b/cmd/ggcode/stderr_tee_dup3.go
@@ -1,4 +1,4 @@
-//go:build linux && arm64
+//go:build linux && (arm64 || riscv64 || loong64)
 
 package main
 

--- a/cmd/ggcode/stderr_tee_unix.go
+++ b/cmd/ggcode/stderr_tee_unix.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"sync"
 	"syscall"
+
+	"github.com/topcheer/ggcode/internal/debug"
 )
 
 // teeStderrFD duplicates fd 2 so runtime-level fatal dumps are captured too.
@@ -33,7 +35,16 @@ func teeStderrFD(w *os.File) (restore func(), ok bool) {
 	var once sync.Once
 	return func() {
 		once.Do(func() {
-			_ = dupTo(origFD, 2)
+			// #1818 case 2: if dupTo fails (fd table exhausted - EMFILE),
+			// fd 2 still points at the tee pipe; closing origFD then
+			// destroyed the LAST copy of the real terminal stderr, and a
+			// runtime fatal dump (this mechanism's purpose) was lost to
+			// EPIPE. Keep the spare fd on failure - a later manual restore
+			// stays possible.
+			if err := dupTo(origFD, 2); err != nil {
+				debug.Log("stderr-tee", "restore dupTo failed (%v) - keeping spare fd %d open; stderr still teed", err, origFD)
+				return
+			}
 			_ = syscall.Close(origFD)
 		})
 	}, true


### PR DESCRIPTION
Case 1 (High, **cross-compile break**): Go's syscall mirrors the kernel ABI - linux/riscv64 and linux/loong64 have no `dup2` either, so the arm64-only dup3 file left both ports on `undefined: syscall.Dup2` (the issue reproduced pre-fix on both; post-fix, cross `go vet` is tee-clean on both). Tags widened to `linux && (arm64 || riscv64 || loong64)`; **ppc64/s390x keep dup2** (their kernels still provide it).

Case 2 (Low): on restore, a failed `dupTo` (fd table exhausted - EMFILE) was discarded and `origFD` closed **unconditionally** - the last copy of the real terminal stderr was destroyed while fd 2 still pointed at the tee pipe, so a runtime fatal dump (this mechanism's whole purpose) was lost to EPIPE. The spare fd stays open on failure and the failure is logged.

Isolated worktree (fresh origin/main): repo build + cmd tests PASS, gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)