### PR TITLE
fix(agentruntime,desktop): complete the silent-error-swallow family in recovery/replay paths (#1802)

### DIFF
--- a/desktop/ggcode-desktop-wails/app.go
+++ b/desktop/ggcode-desktop-wails/app.go
@@ -1512,12 +1512,17 @@ func (a *App) resumeLatestSession() string {
 	// Try the latest session first (fast path).
 	latest, err := store.LatestForWorkspace(wd)
 	if err == nil && latest != nil {
+		// #1802 case 4: the load error's REASON was discarded ("unavailable")
+		// and the resume log claimed "latest was locked" regardless of the
+		// actual cause - a corrupt JSONL (silently falling back to an OLDER
+		// session, the newest conversation effectively disappearing) was
+		// indistinguishable from a transient lock.
 		if loadErr := chat.LoadSession(latest.ID); loadErr == nil {
 			debug.Log("app", "resumed latest session: %s", latest.ID)
 			return latest.ID
 		}
 		// Latest is locked or load failed — fall through to iterate.
-		debug.Log("app", "resumeLatestSession: latest session %s unavailable, trying others", latest.ID)
+		debug.Log("app", "resumeLatestSession: latest session %s failed to load: %v - trying older sessions", latest.ID, loadErr)
 	}
 
 	// Fall back: iterate all sessions for this workspace, try each until
@@ -1532,8 +1537,10 @@ func (a *App) resumeLatestSession() string {
 			continue
 		}
 		if err := chat.LoadSession(ses.ID); err == nil {
-			debug.Log("app", "resumed session: %s (latest was locked)", ses.ID)
+			debug.Log("app", "resumed older session %s (latest failed to load - see reason above)", ses.ID)
 			return ses.ID
+		} else {
+			debug.Log("app", "resumeLatestSession: session %s also failed: %v", ses.ID, err)
 		}
 	}
 	debug.Log("app", "resumeLatestSession: no unlocked sessions found for %s", wd)

--- a/desktop/wailskit/chat.go
+++ b/desktop/wailskit/chat.go
@@ -1259,6 +1259,13 @@ func (b *ChatBridge) LoadSession(id string) error {
 				agent := b.agent
 				b.mu.Unlock()
 				agentruntime.ApplyProviderToAgent(agent, prov, resolved)
+			} else {
+				// #1802 case 3: the session's model was silently swapped for
+				// the global default on restore failure (model deleted /
+				// vendor gone). Every sibling restore field logs; the model
+				// must too, or the user never learns the conversation is no
+				// longer running on the model they saved it with.
+				debug.Log("chat", "LoadSession: restoring session model %q (vendor=%q endpoint=%q) failed: %v - keeping InitAgent's current model", sesModel, sesVendor, sesEndpoint, err)
 			}
 		}
 	}

--- a/internal/agentruntime/tunnel_host.go
+++ b/internal/agentruntime/tunnel_host.go
@@ -558,6 +558,11 @@ func (h *TunnelHost) TunnelEvents() []tunnel.GatewayMessage {
 	}
 	events, err := ProjectionReplay(store, ses.ID)
 	if err != nil {
+		// #1802 case 2: this was the third zero-log break site - once set,
+		// TunnelEvents stays nil and the PrepareOnlineShare snapshot
+		// provider (TunnelEvents itself) goes empty too, so BOTH replay
+		// and snapshot fallback vanish with no diagnostic anywhere.
+		debug.Log("tunnel-host", "ProjectionReplay failed: %v (session=%s) - projection circuit-broken; snapshot+replay both empty", err, ses.ID)
 		h.mu.Lock()
 		h.projBroken = true
 		h.mu.Unlock()


### PR DESCRIPTION
## Summary
Closes #1802 (completes the family; cases 1 and 2's main sites were already fixed on main under #1802 markers).

- **tunnel_host ProjectionReplay break (case 2, third site)**: the projection circuit-break tripped with zero logging — once set, both replay AND the PrepareOnlineShare snapshot fallback go empty with no diagnostic anywhere. Now logged with the IO error and session ID.
- **chat.go LoadSession model restore (case 3)**: ActivateCurrentSelection failure silently kept the global default model — the restore now logs like every sibling field, so a silent model swap is observable.
- **app.go resumeLatestSession (case 4)**: the load error's reason is now logged on both the latest and fallback iterations; the misleading "(latest was locked)" wording is gone — a corrupt JSONL silently falling back to an older session is now distinguishable from a transient lock.

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agentruntime **12.8s** + desktop/wailskit **10.4s** PASS (p=1); desktop-wails module blocked only by the pre-existing frontend-dist embed (built in CI with npm).

Per team convention: merge only after this PR's CI is green.

Closes #1802

Generated with [ggcode](https://github.com/topcheer/ggcode)
