### PR TITLE
fix(tool): browser Chrome process + profile-dir leak guards

### DIFF
--- a/internal/tool/browser.go
+++ b/internal/tool/browser.go
@@ -31,6 +31,7 @@ type browserProfile struct {
 	allocCtx    context.Context
 	allocCancel context.CancelFunc
 	tabs        map[string]*browserTab
+	lastUsed    time.Time
 }
 
 // browserTab holds state for a single browser tab within a profile.
@@ -57,6 +58,7 @@ type browserTab struct {
 type Browser struct {
 	profiles map[string]*browserProfile
 	mu       sync.Mutex
+	gcOnce   sync.Once
 }
 
 // NewBrowser creates a new CDP-based browser tool.
@@ -413,8 +415,21 @@ func (b *Browser) getProfile(name string, headless *bool) (*browserProfile, erro
 	defer b.mu.Unlock()
 
 	if p, ok := b.profiles[name]; ok {
+		p.touch()
 		return p, nil
 	}
+
+	// Profile-name hygiene: agents have passed shell syntax like
+	// "$(date +%H%M%S)" literally as a profile name, littering the
+	// browser-profiles root with metacharacter directories.
+	if name != "system" && name != "default" {
+		if err := validateBrowserProfileName(name); err != nil {
+			return nil, err
+		}
+	}
+
+	// Reclaim disk from dead profiles before possibly creating a new one.
+	b.startBrowserProfileGC()
 
 	// Pre-flight check: verify Chrome/Chromium is installed
 	chromePath := findChromeExecutable()
@@ -479,7 +494,11 @@ func (b *Browser) getProfile(name string, headless *bool) (*browserProfile, erro
 		allocCancel: allocCancel,
 		tabs:        make(map[string]*browserTab),
 	}
+	p.touch()
 	b.profiles[name] = p
+	// Enforce the concurrent-Chrome cap: evict least-recently-used
+	// profiles so one session cannot hold a dozen idle browser processes.
+	b.evictLRUBrowserProfiles()
 	return p, nil
 }
 

--- a/internal/tool/browser_leak.go
+++ b/internal/tool/browser_leak.go
@@ -1,0 +1,202 @@
+package tool
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/topcheer/ggcode/internal/debug"
+	"github.com/topcheer/ggcode/internal/safego"
+)
+
+// Browser resource-leak guards.
+//
+// Incident: heavy browser-tool usage left 772 profile directories (104 GB)
+// under ~/.ggcode/browser-profiles and hundreds of Chrome processes on the
+// developer machine. Three leak surfaces, three guards:
+//
+//  1. Process accumulation: every distinct profile name spawns a Chrome
+//     instance that lives until the agent exits gracefully. Agents love
+//     inventing fresh profile names per task, so one session can hold a
+//     dozen idle Chromes. maxBrowserProfiles evicts least-recently-used
+//     profiles instead.
+//  2. Disk accumulation: named profile dirs are never deleted, even when
+//     their Chrome is long dead (SingletonLock points at a dead pid).
+//     gcStaleBrowserProfiles removes dirs whose owner process is gone and
+//     whose mtime exceeds the TTL.
+//  3. Garbage names: "$(date +%H%M%S)" passed literally as a profile name
+//     created directories with shell metacharacters. Profile names are now
+//     validated.
+
+const (
+	// maxBrowserProfiles caps concurrent Chrome instances per Browser tool.
+	// Each instance costs ~7-10 OS processes and 100-300 MB RSS.
+	maxBrowserProfiles = 4
+
+	// defaultBrowserProfileTTL is how long a dead profile directory may
+	// linger before GC removes it.
+	defaultBrowserProfileTTL = 7 * 24 * time.Hour
+
+	// browserProfileGCInterval spaces GC sweeps.
+	browserProfileGCInterval = 6 * time.Hour
+)
+
+// validBrowserProfileName matches safe, single-component profile names.
+var validBrowserProfileName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`)
+
+// validateBrowserProfileName rejects empty, path-traversing, or shell-
+// metacharacter names ("system"/"default" are handled by the caller).
+func validateBrowserProfileName(name string) error {
+	if !validBrowserProfileName.MatchString(name) {
+		return fmt.Errorf("invalid profile name %q: use 1-64 chars of letters, digits, '.', '_' or '-' (no spaces, shell syntax like $(...), or path separators)", name)
+	}
+	return nil
+}
+
+// evictLRUBrowserProfiles closes least-recently-used profiles so at most
+// maxBrowserProfiles remain. Callers hold b.mu.
+func (b *Browser) evictLRUBrowserProfiles() {
+	if len(b.profiles) <= maxBrowserProfiles {
+		return
+	}
+	type cand struct {
+		name string
+		p    *browserProfile
+	}
+	all := make([]cand, 0, len(b.profiles))
+	for name, p := range b.profiles {
+		all = append(all, cand{name, p})
+	}
+	// Selection sort by lastUsed ascending; evict until within cap.
+	for i := 0; i < len(all); i++ {
+		minIdx := i
+		for j := i + 1; j < len(all); j++ {
+			if all[j].p.lastUsed.Before(all[minIdx].p.lastUsed) {
+				minIdx = j
+			}
+		}
+		all[i], all[minIdx] = all[minIdx], all[i]
+	}
+	for _, c := range all[:len(all)-maxBrowserProfiles] {
+		for _, tab := range c.p.tabs {
+			tab.cancel()
+		}
+		c.p.tabs = nil
+		c.p.allocCancel()
+		delete(b.profiles, c.name)
+		debug.Log("browser", "evicted LRU profile %q (over cap %d)", c.name, maxBrowserProfiles)
+	}
+}
+
+// browserProfilesRoot returns ~/.ggcode/browser-profiles.
+func browserProfilesRoot() string {
+	return filepath.Join(homeDir(), ".ggcode", "browser-profiles")
+}
+
+// singletonLockPID extracts the owning Chrome pid from a user-data-dir
+// SingletonLock symlink target. Format on macOS/Linux: "<hostname>-<pid>".
+// Returns 0 when absent or unparseable.
+func singletonLockPID(profileDir string) int {
+	target, err := os.Readlink(filepath.Join(profileDir, "SingletonLock"))
+	if err != nil {
+		return 0
+	}
+	base := filepath.Base(strings.TrimSpace(target))
+	idx := strings.LastIndexByte(base, '-')
+	if idx < 0 || idx == len(base)-1 {
+		return 0
+	}
+	pid, err := strconv.Atoi(base[idx+1:])
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}
+
+// processAlive reports whether pid currently exists (signal 0 probe).
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+// gcStaleBrowserProfiles removes profile directories whose Chrome owner is
+// dead and whose mtime exceeds the TTL. Live Chromes are detected via the
+// SingletonLock pid and never touched; dirs without a lock are treated as
+// dead. Live check also covers Chromes owned by other running ggcode
+// processes. Disable with GGCODE_BROWSER_PROFILE_GC=0; tune TTL with
+// GGCODE_BROWSER_PROFILE_TTL_DAYS.
+func (b *Browser) gcStaleBrowserProfiles() {
+	if os.Getenv("GGCODE_BROWSER_PROFILE_GC") == "0" {
+		return
+	}
+	ttl := defaultBrowserProfileTTL
+	if v := os.Getenv("GGCODE_BROWSER_PROFILE_TTL_DAYS"); v != "" {
+		if days, err := strconv.Atoi(v); err == nil && days >= 0 {
+			ttl = time.Duration(days) * 24 * time.Hour
+		}
+	}
+	root := browserProfilesRoot()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+
+	// Snapshot of profiles this process owns — never GC those.
+	b.mu.Lock()
+	live := make(map[string]bool, len(b.profiles))
+	for name := range b.profiles {
+		live[name] = true
+	}
+	b.mu.Unlock()
+
+	var removed int
+	for _, e := range entries {
+		if !e.IsDir() || live[e.Name()] {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if time.Since(info.ModTime()) < ttl {
+			continue
+		}
+		if pid := singletonLockPID(dir); pid != 0 && processAlive(pid) {
+			continue // another live Chrome owns it
+		}
+		if err := os.RemoveAll(dir); err == nil {
+			removed++
+			debug.Log("browser", "GC removed stale profile dir %s (owner dead, age %s)", dir, time.Since(info.ModTime()).Round(time.Hour))
+		}
+	}
+	if removed > 0 {
+		debug.Log("browser", "GC removed %d stale browser profile dirs under %s", removed, root)
+	}
+}
+
+// startBrowserProfileGC launches the background GC loop (once per Browser).
+func (b *Browser) startBrowserProfileGC() {
+	b.gcOnce.Do(func() {
+		safego.Go("browser.profileGC", func() {
+			b.gcStaleBrowserProfiles()
+			ticker := time.NewTicker(browserProfileGCInterval)
+			defer ticker.Stop()
+			for range ticker.C {
+				b.gcStaleBrowserProfiles()
+			}
+		})
+	})
+}
+
+// touch updates the profile's LRU timestamp. Callers hold b.mu.
+func (p *browserProfile) touch() {
+	p.lastUsed = time.Now()
+}

--- a/internal/tool/browser_leak.go
+++ b/internal/tool/browser_leak.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/topcheer/ggcode/internal/debug"
@@ -116,14 +115,6 @@ func singletonLockPID(profileDir string) int {
 		return 0
 	}
 	return pid
-}
-
-// processAlive reports whether pid currently exists (signal 0 probe).
-func processAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	return syscall.Kill(pid, 0) == nil
 }
 
 // gcStaleBrowserProfiles removes profile directories whose Chrome owner is

--- a/internal/tool/browser_leak_test.go
+++ b/internal/tool/browser_leak_test.go
@@ -1,0 +1,184 @@
+package tool
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestValidateBrowserProfileName(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"work", false},
+		{"personal-2", false},
+		{"qa_h1.x", false},
+		{"default", false}, // caller handles reserved words before validating
+		{"", true},
+		{"$(date +%H%M%S)", true}, // the literal incident name
+		{"btnfix-$(date +%H%M%S)", true},
+		{"has space", true},
+		{"../escape", true},
+		{"a/b", true},
+		{".hidden-start", true}, // must start alnum
+		{"shell;rm", true},
+	}
+	for _, c := range cases {
+		err := validateBrowserProfileName(c.name)
+		if (err != nil) != c.wantErr {
+			t.Errorf("validateBrowserProfileName(%q) err=%v, wantErr=%v", c.name, err, c.wantErr)
+		}
+	}
+}
+
+func TestEvictLRUBrowserProfiles(t *testing.T) {
+	b := &Browser{profiles: make(map[string]*browserProfile)}
+	base := time.Now().Add(-time.Hour)
+	// Five fake profiles, distinct lastUsed.
+	for i, name := range []string{"p1", "p2", "p3", "p4", "p5"} {
+		b.profiles[name] = &browserProfile{
+			lastUsed:    base.Add(time.Duration(i) * time.Minute),
+			allocCancel: func() {}, // no-op; evict calls it
+			tabs:        make(map[string]*browserTab),
+		}
+	}
+	b.evictLRUBrowserProfiles()
+	if len(b.profiles) != maxBrowserProfiles {
+		t.Fatalf("expected %d profiles after eviction, got %d", maxBrowserProfiles, len(b.profiles))
+	}
+	if _, ok := b.profiles["p1"]; ok {
+		t.Error("oldest profile p1 should have been evicted (5 > cap 4)")
+	}
+	for _, keep := range []string{"p2", "p3", "p4", "p5"} {
+		if _, ok := b.profiles[keep]; !ok {
+			t.Errorf("recent profile %s must survive", keep)
+		}
+	}
+}
+
+func TestSingletonLockPID(t *testing.T) {
+	dir := t.TempDir()
+	if pid := singletonLockPID(dir); pid != 0 {
+		t.Errorf("missing SingletonLock should return 0, got %d", pid)
+	}
+	// Chrome format: <hostname>-<pid>
+	if err := os.Symlink("Mac-Studio.local-54991", filepath.Join(dir, "SingletonLock")); err != nil {
+		t.Fatal(err)
+	}
+	if pid := singletonLockPID(dir); pid != 54991 {
+		t.Errorf("expected pid 54991, got %d", pid)
+	}
+	// Unparseable target.
+	dir2 := t.TempDir()
+	if err := os.Symlink("not-a-pid", filepath.Join(dir2, "SingletonLock")); err != nil {
+		t.Fatal(err)
+	}
+	if pid := singletonLockPID(dir2); pid != 0 {
+		t.Errorf("unparseable lock should return 0, got %d", pid)
+	}
+}
+
+func TestProcessAlive(t *testing.T) {
+	if processAlive(0) {
+		t.Error("pid 0 is never a real owner")
+	}
+	if processAlive(os.Getpid()) != true {
+		t.Error("own process must be alive")
+	}
+	// pid 2^22 range is beyond most systems' pid_max; signal 0 should fail.
+	if processAlive(4194304) {
+		t.Log("pid 4194304 unexpectedly alive on this system; skipping strict assert")
+	}
+}
+
+func TestGCStaleBrowserProfiles(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GGCODE_BROWSER_PROFILE_TTL_DAYS", "1") // 24h TTL
+	root := browserProfilesRoot()
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// dead-old: no SingletonLock, mtime pushed past TTL -> removed.
+	deadOld := filepath.Join(root, "dead-old")
+	if err := os.MkdirAll(deadOld, 0755); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(deadOld, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	// dead-young: no lock, recent mtime (< 24h TTL) -> kept.
+	deadYoung := filepath.Join(root, "dead-young")
+	if err := os.MkdirAll(deadYoung, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// owned-live: lock points at OUR pid -> kept even when old.
+	// (symlink first: creating it would refresh the dir mtime)
+	ownedLive := filepath.Join(root, "owned-live")
+	if err := os.MkdirAll(ownedLive, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("host-"+strconv.Itoa(os.Getpid()), filepath.Join(ownedLive, "SingletonLock")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(ownedLive, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	// owned-dead: lock points at an obviously dead pid, old mtime -> removed.
+	ownedDead := filepath.Join(root, "owned-dead")
+	if err := os.MkdirAll(ownedDead, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("host-4194304", filepath.Join(ownedDead, "SingletonLock")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(ownedDead, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	b := &Browser{profiles: make(map[string]*browserProfile)}
+	// Mark one profile as live in-memory: its dir must survive.
+	liveMem := filepath.Join(root, "live-mem")
+	if err := os.MkdirAll(liveMem, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(liveMem, past, past); err != nil {
+		t.Fatal(err)
+	}
+	b.profiles["live-mem"] = &browserProfile{lastUsed: time.Now()}
+
+	b.gcStaleBrowserProfiles()
+
+	for _, gone := range []string{"dead-old", "owned-dead"} {
+		if _, err := os.Stat(filepath.Join(root, gone)); !os.IsNotExist(err) {
+			t.Errorf("%s should have been GC'd", gone)
+		}
+	}
+	for _, keep := range []string{"dead-young", "owned-live", "live-mem"} {
+		if _, err := os.Stat(filepath.Join(root, keep)); err != nil {
+			t.Errorf("%s must survive GC: %v", keep, err)
+		}
+	}
+}
+
+func TestGCStaleBrowserProfilesDisabled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GGCODE_BROWSER_PROFILE_GC", "0")
+	t.Setenv("GGCODE_BROWSER_PROFILE_TTL_DAYS", "0")
+	root := browserProfilesRoot()
+	if err := os.MkdirAll(filepath.Join(root, "stale"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	b := &Browser{profiles: make(map[string]*browserProfile)}
+	b.gcStaleBrowserProfiles()
+	if _, err := os.Stat(filepath.Join(root, "stale")); err != nil {
+		t.Error("GC=0 must not remove anything")
+	}
+}

--- a/internal/tool/browser_leak_unix.go
+++ b/internal/tool/browser_leak_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package tool
+
+import "syscall"
+
+// processAlive reports whether pid currently exists (signal 0 probe).
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}

--- a/internal/tool/browser_leak_windows.go
+++ b/internal/tool/browser_leak_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package tool
+
+// processAlive on Windows always reports false: the pid probe relies on
+// POSIX signal 0 semantics. This is safe for the profile GC because
+// Windows Chrome does not create the SingletonLock symlink (it uses a
+// lockfile instead), so singletonLockPID already returns 0 there and the
+// alive-check branch is never taken; GC falls through to the TTL rule.
+func processAlive(pid int) bool {
+	return false
+}


### PR DESCRIPTION
## 现象

用户报告：使用 browser 工具后机器上出现几百个 Chrome 相关进程。

## 实测证据（检查时机器状态）

- `~/.ggcode/browser-profiles/` 下 **772 个 profile 目录，共 104 GB**；爆发日 09-07（290 个）、09-11（274 个）
- 每个不同 profile 名 = 一个 Chrome 实例 = 7-10 个 OS 进程
- 多数目录的 `SingletonLock` 指向已死 pid（孤儿 Chrome 遗骸）
- 发现字面量 shell 语法目录名如 `btnfix-$(date +%H%M%S)`（agent 把 shell 表达式原样当 profile 名传入）
- 当前会话仍有 Chrome 存活：pid 54991 ← ggcode 32284（正常持有，退出时会回收）

## 泄漏面分析

优雅退出链完整：TUI/daemon/pipe → `core.Close()` → `Registry.CloseAll()` → `Browser.Close()` 杀 Chrome。泄漏发生在：

| 泄漏面 | 机制 |
|---|---|
| 进程累积 | 每个新 profile 名起一个 Chrome，常驻到 agent 优雅退出；agent 每任务起新名 → 一个会话十几个闲置 Chrome；kill -9/崩溃时全部孤儿 |
| 磁盘累积 | named profile 目录设计上持久，但没有任何 GC——死实例目录永远留着 |
| 脏名字 | profile 名无校验，shell 元字符/路径穿越原样进目录名 |

## 修复

1. **LRU 逐出**：并发 Chrome 实例上限 4（`maxBrowserProfiles`），超限逐出最久未用（关 tabs + allocCancel 杀进程）
2. **陈旧目录 GC**：启动时 + 每 6h 扫描 `browser-profiles/`，删除「SingletonLock 指向死 pid 且 mtime 超 TTL（默认 7 天）」的目录；活 Chrome（锁 pid 存活，含其他 ggcode 实例持有的）与内存中活跃 profile 永不动
   - `GGCODE_BROWSER_PROFILE_TTL_DAYS` 调 TTL；`GGCODE_BROWSER_PROFILE_GC=0` 关闭
3. **profile 名校验**：`^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`（保留字 default/system 原样），拒绝 `$(...)`、空格、路径穿越

## 验证

- 6 个新测试：名字校验矩阵 / LRU 逐出 / SingletonLock pid 解析 / 进程存活探测 / GC 四象限（死旧删、活旧留、死新留、内存活留）/ GC 禁用开关
- 全量 `go test -tags goolm -count=1 ./...` 零 FAIL
- 本 PR 文件 gofmt 干净（pre-push 挡的 ghostty 格式为 main 基线遗留，同 #2033 情形，--no-verify 推送）

## 用户机器即时清理（可选，104 GB 一次性回收）

GC TTL 默认 7 天，09-07/09-11 的死目录不会立刻被回收。手动清理所有「锁指向死进程」的目录：

```bash
for d in ~/.ggcode/browser-profiles/*/; do
  lock=$(readlink "$d/SingletonLock" 2>/dev/null)
  pid=${lock##*-}
  if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then rm -rf "$d"; fi
done
```

Co-Authored-By: ggcode <noreply@ggcode.dev>