### PR TITLE
fix(tui): early tunnel-connected replayed; unknown approval decisions dropped (#1825 cases 1+2)

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -341,7 +341,11 @@ type Model struct {
 	tunnelUserMessageOverride *tunnel.MessageData
 	suppressNextTunnelSystem  string
 	tunnelClientNoticeShown   bool
-	tunnelSpawned             map[string]bool // tracks which subagents have been announced to mobile
+	// pendingTunnelConnected (#1825 case 1): a client connected while
+	// StartShare was still running - replay the connected handling once
+	// tunnelStartMsg lands.
+	pendingTunnelConnected bool
+	tunnelSpawned          map[string]bool // tracks which subagents have been announced to mobile
 
 	// External pane manager for sub-agent/teammate output
 	extPaneMgr *extpane.Manager

--- a/internal/tui/tunnel.go
+++ b/internal/tui/tunnel.go
@@ -359,6 +359,13 @@ func (m *Model) handleTunnelStartMsg(msg tunnelStartMsg) (tea.Model, tea.Cmd) {
 	// SetSessionInfo, PrepareOnlineShare (replay, announce active_session).
 	// We just store refs and show the QR.
 	m.tunnelSession = msg.session
+	// #1825 case 1: replay a connected event that raced StartShare.
+	if m.pendingTunnelConnected {
+		m.pendingTunnelConnected = false
+		return m, func() tea.Msg {
+			return tunnelClientConnectedMsg{generation: m.tunnelGeneration}
+		}
+	}
 	m.tunnelBroker = msg.broker
 	m.tunnelSpawned = make(map[string]bool)
 
@@ -416,6 +423,12 @@ func (m *Model) handleTunnelClientConnectedMsgForGeneration(generation uint64) (
 		return m, nil
 	}
 	if m.tunnelSession == nil {
+		// #1825 case 1: a paired client can reconnect (or land via the P2P
+		// fast path) while StartShare is still executing - the connected
+		// message then arrives BEFORE tunnelStartMsg assigns the session,
+		// and OnConnected fires exactly once per connection. Cache it and
+		// replay once the session lands (the relay-replay pattern).
+		m.pendingTunnelConnected = true
 		return m, nil
 	}
 	if m.qrOverlay != nil {
@@ -2071,7 +2084,15 @@ func (m *Model) handleTunnelApprovalResponse(msg tunnelApprovalResponseMsg) (tea
 	if m.pendingApproval == nil {
 		return m, nil
 	}
-	if m.tunnelPendingApprovalID != "" && msg.id != "" && msg.id != m.tunnelPendingApprovalID {
+	// #1825 case 2: the old match required BOTH ids non-empty - an
+	// empty-id reply (stale/malformed) bypassed the match entirely and
+	// the decision below then applied to whatever approval happened to be
+	// pending. An empty id carries no identity: drop it.
+	if msg.id == "" {
+		debug.Log("tui", "tunnel approval response with empty id dropped (stale/malformed) - pending approval untouched")
+		return m, nil
+	}
+	if m.tunnelPendingApprovalID != "" && msg.id != m.tunnelPendingApprovalID {
 		return m, nil
 	}
 
@@ -2084,9 +2105,17 @@ func (m *Model) handleTunnelApprovalResponse(msg tunnelApprovalResponseMsg) (tea
 		cmd = m.handleApproval(decision)
 	case "always_allow", "always":
 		cmd = m.handleApprovalAllowAlways()
-	default: // "deny" or unknown
+	case "deny":
 		decision = permission.Deny
 		cmd = m.handleApproval(decision)
+	default:
+		// #1825 case 2: an UNKNOWN decision value (typo / protocol
+		// evolution) used to fall into Deny - and with the empty-id pass
+		// above, a stale/malformed reply with no id then KILLED the
+		// current pending approval with zero diagnostics. Fail-closed is
+		// for explicit deny; unknown values are dropped loudly.
+		debug.Log("tui", "tunnel approval response with unknown decision %q (id=%q) dropped - pending approval untouched", msg.decision, msg.id)
+		return m, nil
 	}
 
 	return m, cmd


### PR DESCRIPTION
Case 1 (Med): a paired client reconnecting (or landing via the P2P fast path) while StartShare is still executing delivered the connected message **before** `tunnelStartMsg` assigned the session - the nil-session guard dropped it silently, and `OnConnected` fires exactly once per connection, so the QR overlay stayed up and the connected notice never showed. The early event is **cached and replayed** when the session lands.

Case 2 (Med): an unknown decision value (typo / protocol evolution) fell into **Deny**, and the empty-id pass-through let a stale/malformed reply with no id kill whatever approval happened to be pending - zero diagnostics. Explicit deny stays fail-closed; **unknown values and empty-id replies are dropped loudly** (logged, pending untouched).

Isolated worktree (fresh origin/main): tui package full PASS (9.3s), gofmt clean.

🤖 Generated with [ggcode](https://github.com/topcheer/ggcode)