### PR TITLE
fix(agent): verify-hint trigger family - race hint severity, sync-removal detection, failure-flag clearing, runner coverage (#1841)

### DIFF
--- a/internal/agent/checks_1841_test.go
+++ b/internal/agent/checks_1841_test.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+// #1841 case 2 pin: sync-primitive REMOVAL with goroutines kept triggers.
+func Test1841SyncRemovalTriggers(t *testing.T) {
+	old := "package a\nimport \"sync\"\nvar mu sync.Mutex\nfunc f(){ mu.Lock(); go work(); mu.Unlock() }\n"
+	new := "package a\nfunc f(){ go work() }\n"
+	if got := checkRaceVerifyHint("a.go", old, new); got == nil {
+		t.Fatal("mutex removal with goroutine kept must trigger the race hint")
+	}
+	// Net-zero primitive count (Mutex->channel style) previously slipped through.
+	old2 := "package a\nimport \"sync\"\nvar mu sync.Mutex\nfunc f(){ mu.Lock(); go work(); mu.Unlock() }\n"
+	new2 := "package a\nfunc f(){ ch := make(chan int); go func(){ <-ch }() }\n"
+	if got := checkRaceVerifyHint("a.go", old2, new2); got == nil {
+		t.Fatal("net-zero primitive rewrite must trigger")
+	}
+	// Pure removal of BOTH sync and goroutines: no trigger.
+	old3 := old
+	new3 := "package a\nfunc f(){}\n"
+	if got := checkRaceVerifyHint("a.go", old3, new3); got != nil {
+		t.Fatal("removing both sync and goroutines should not trigger")
+	}
+}
+
+// #1841 case 3 pin: listing/format commands do not clear the failure flag.
+func Test1841ListingDoesNotClearFailure(t *testing.T) {
+	if isRealTestExecution("make help") {
+		t.Fatal("make help is not a real test execution")
+	}
+	if isRealTestExecution("task --list") {
+		t.Fatal("task --list is not a real test execution")
+	}
+	if isRealTestExecution("gofmt -l .") {
+		t.Fatal("gofmt -l is not a real test execution")
+	}
+	if !isRealTestExecution("go test ./...") {
+		t.Fatal("go test must be a real test execution")
+	}
+	if !isRealTestExecution("make verify-ci") {
+		t.Fatal("make <real-target> must be a real test execution")
+	}
+}
+
+// #1841 case 4 pin: mainstream runners count as verification.
+func Test1841MainstreamRunners(t *testing.T) {
+	for _, cmd := range []string{"bazel test //...", "gradle test", "mvn test", "dotnet test", "yarn test", "pnpm test", "vitest run"} {
+		if !isVerifyCommand(cmd) {
+			t.Fatalf("%q must count as a verify command", cmd)
+		}
+	}
+	_ = strings.TrimSpace
+}
+
+// #1841 case 1 pin: race hint is registered critical.
+func Test1841RaceHintCritical(t *testing.T) {
+	for _, c := range allChecks {
+		if c.Name == "race-verify-hint" && c.Severity != SeverityCritical {
+			t.Fatalf("race-verify-hint must be critical, got %v", c.Severity)
+		}
+	}
+}

--- a/internal/agent/race_verify_hint.go
+++ b/internal/agent/race_verify_hint.go
@@ -83,16 +83,78 @@ func checkRaceVerifyHint(filePath, oldContent, newContent string) []string {
 	oldScore := countConcurrencyPrimitives(oldContent)
 	newScore := countConcurrencyPrimitives(newContent)
 
-	// Delta-aware: only trigger if new concurrency primitives were introduced.
-	if newScore <= oldScore {
-		return nil
+	// Delta-aware: trigger if new concurrency primitives were introduced...
+	if newScore > oldScore {
+		return raceVerifyHintMessages()
 	}
+	// #1841 case 2: ...AND if synchronization primitives were REMOVED while
+	// goroutines stayed (or grew) - deleting a mutex while keeping the
+	// goroutine is the classic race-introducing refactor (Mutex->channel /
+	// Mutex->atomic rewrites with a net-zero primitive count previously
+	// scored 1<=1 and slipped through silently, despite the file header's
+	// "NEWLY introduced or MODIFIED" claim). Sync-removal is a trigger on
+	// its own, decoupled from goroutine delta.
+	{
+		oldSync := countSyncPrimitives(oldContent)
+		newSync := countSyncPrimitives(newContent)
+		if newSync < oldSync {
+			oldGoroutines := countGoroutineLaunches(oldContent)
+			newGoroutines := countGoroutineLaunches(newContent)
+			if newGoroutines >= oldGoroutines && newGoroutines > 0 {
+				return raceVerifyHintMessages()
+			}
+		}
+	}
+	return nil
+}
 
+// countSyncPrimitives counts synchronization constructs (the combined
+// countConcurrencyPrimitives score does not necessarily cover plain
+// sync.Mutex DECLARATIONS, so removal detection needs its own counter).
+func countSyncPrimitives(src string) int {
+	if strings.TrimSpace(src) == "" {
+		return 0
+	}
+	n := 0
+	for _, marker := range []string{
+		"sync.Mutex", "sync.RWMutex", "sync.WaitGroup", "sync.Once",
+		"sync.Cond", "sync.Map",
+		".Lock()", ".Unlock()", ".RLock()", ".RUnlock()",
+		".Wait()", ".Add(", ".Done()",
+		"atomic.", "chan ",
+	} {
+		n += strings.Count(src, marker)
+	}
+	return n
+}
+
+// raceVerifyHintMessages is the single hint body shared by both triggers.
+func raceVerifyHintMessages() []string {
 	return []string{
 		"Concurrency code modified -- data races are invisible to static analysis. " +
 			"Verify with `go test -race ./...` to catch concurrent read/write hazards " +
 			"that compile fine but fail non-deterministically at runtime.",
 	}
+}
+
+// countGoroutineLaunches counts `go ` statement launches via AST.
+func countGoroutineLaunches(src string) int {
+	if strings.TrimSpace(src) == "" {
+		return 0
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", src, 0)
+	if err != nil || file == nil {
+		return strings.Count(src, "go ")
+	}
+	count := 0
+	ast.Inspect(file, func(n ast.Node) bool {
+		if _, ok := n.(*ast.GoStmt); ok {
+			count++
+		}
+		return true
+	})
+	return count
 }
 
 // countConcurrencyPrimitives returns a count of concurrency-relevant patterns

--- a/internal/agent/verify_hint.go
+++ b/internal/agent/verify_hint.go
@@ -778,6 +778,25 @@ var verifyCommands = map[string]bool{
 	"cmake":         true,
 	"ctest":         true,
 	"rake test":     true,
+	// #1841 case 4: mainstream test runners were missing - a bazel/gradle/
+	// maven/dotnet/yarn/pnpm/vitest project that ran its FULL suite green
+	// still kept accumulating edits-until-hint, and the third edit got a
+	// "you've edited 3 source files since last build check" nudge premised
+	// on a false "never verified" - training the agent to ignore hints.
+	"bazel test":       true,
+	"bzl test":         true,
+	"gradle test":      true,
+	"gradlew test":     true,
+	"mvn test":         true,
+	"dotnet test":      true,
+	"yarn test":        true,
+	"pnpm test":        true,
+	"vitest":           true,
+	"jest":             true,
+	"dart test":        true,
+	"composer test":    true,
+	"go test-race":     false, // placeholder guard (never matched; see -race below)
+	"python -m pytest": true,
 	// Lint / format commands also count as verification - running them
 	// resets the post-edit verify hint counter.
 	"golangci-lint": true,
@@ -838,7 +857,13 @@ func (a *Agent) maybeResetVerifyOnCommand(toolName string, args json.RawMessage,
 	defer a.mu.Unlock()
 
 	a.postEditVerify.sourceEditsSinceHint = 0
-	a.postEditVerify.lastBuildFailed = resultErr
+	// #1841 case 3: only a REAL test/build execution may update the
+	// failure flag. `make help`, `task --list`, `gofmt -l` (all exit 0)
+	// used to unconditionally clear lastBuildFailed after a FAILED go
+	// test, so the "(which FAILED)" urgency hint could never appear.
+	if isRealTestExecution(cmd) {
+		a.postEditVerify.lastBuildFailed = resultErr
+	}
 
 	debug.Log("agent", "verify hint counter reset: agent ran build command %q (failed=%v)", cmd, resultErr)
 }
@@ -925,6 +950,46 @@ func isVerifyCommandSegment(seg string) bool {
 		if words[0] == "make" || words[0] == "just" || words[0] == "task" {
 			return true
 		}
+	}
+	return false
+}
+
+// realTestCommands are verify commands that actually EXECUTE the project's
+// tests or build (#1841 case 3). Inspection/format/listing commands in the
+// broader verifyCommands table (gofmt -l, make help, cmake --help) exit 0
+// without testing anything and must not clear a failure flag.
+var realTestCommands = map[string]bool{
+	"go test": true, "go build": true, "go vet": true,
+	"cargo test": true, "cargo build": true,
+	"npm test": true, "npm run test": true, "npm run build": true,
+	"pytest": true, "python -m pytest": true,
+	"flutter test": true, "dart test": true,
+	"ctest": true, "rake test": true,
+	"bazel test": true, "bzl test": true,
+	"gradle test": true, "gradlew test": true,
+	"mvn test": true, "dotnet test": true,
+	"yarn test": true, "pnpm test": true,
+	"vitest": true, "jest": true, "composer test": true,
+}
+
+// isRealTestExecution reports whether the command runs a real test/build
+// target (not a listing/format/no-op invocation of a test-capable runner).
+func isRealTestExecution(cmd string) bool {
+	seg := strings.ToLower(strings.TrimSpace(stripEnvAssignments(cmd)))
+	if strings.Contains(seg, "--help") || strings.Contains(seg, " --list") ||
+		strings.Contains(seg, "help") && strings.HasPrefix(seg, "make ") {
+		return false
+	}
+	for prefix := range realTestCommands {
+		if strings.HasPrefix(seg, prefix+" ") || seg == prefix {
+			return true
+		}
+	}
+	words := strings.Fields(seg)
+	if len(words) >= 2 && (words[0] == "make" || words[0] == "just" || words[0] == "task") {
+		// make <target> runs a target (make help / make list do not).
+		t := words[1]
+		return t != "help" && t != "list" && !strings.HasPrefix(t, "-")
 	}
 	return false
 }

--- a/internal/agent/write_integrity.go
+++ b/internal/agent/write_integrity.go
@@ -435,7 +435,13 @@ func registerAllChecks() {
 		// #571: race-verify-hint — detects newly introduced concurrency primitives
 		// and suggests running `go test -race`. Covers temporal race conditions
 		// invisible to static analysis. Fully implemented + unit tested.
-		{Name: "race-verify-hint", Langs: []Language{LangGo}, Run: sliceCheck(checkRaceVerifyHint)},
+		// #1841 case 1: this check is safety-adjacent (data races), but as a
+		// bare default-severity check registered LAST it lost the single
+		// warning slot to any critical (or any earlier-registered default)
+		// finding on the same write - its effective visibility bore no
+		// relation to its documented purpose. Critical severity keeps it
+		// out of the registration-order tail.
+		{Name: "race-verify-hint", Langs: []Language{LangGo}, Severity: SeverityCritical, Run: sliceCheck(checkRaceVerifyHint)},
 
 		// --- Security (OWASP / CVE-class) ---
 		{Name: "sql-injection", Langs: []Language{LangGo}, Severity: SeverityCritical, Run: sliceCheck(checkSQLInjection)},


### PR DESCRIPTION
## Summary
Closes #1841.

- **Case 1**: race-verify-hint raised to SeverityCritical — as a bare default-severity check registered last it systematically lost the single warning slot, its effective visibility bearing no relation to its documented purpose.
- **Case 2**: sync-primitive REMOVAL with goroutines kept now triggers the race hint (own sync counter; the combined count-only delta missed the classic mutex-deletion refactor and net-zero Mutex→channel rewrites).
- **Case 3**: only real test/build executions clear `lastBuildFailed` — `make help` / `task --list` / `gofmt -l` no longer wipe a failed go test's urgency flag.
- **Case 4**: mainstream test runners (bazel/gradle/mvn/dotnet/yarn/pnpm/vitest/jest/dart/composer/python -m pytest) added — a just-verified suite no longer gets a false "3 files since last build check" nudge.

## Verification evidence (review)
Isolated worktree on latest origin/main: internal/agent **21.9s PASS** (p=1). Pins: mutex-removal-with-goroutine triggers / net-zero rewrite triggers / removing both stays silent; listing/format commands do not clear the failure flag while go test and make-target do; mainstream runners count; race-verify-hint registered critical.

Per team convention: merge only after this PR's CI is green.

Closes #1841

Generated with [ggcode](https://github.com/topcheer/ggcode)
