### PR TITLE
chore: remove dead code batch 3 (cron-3 scan)

### DIFF
--- a/internal/agentruntime/mcp_sampling.go
+++ b/internal/agentruntime/mcp_sampling.go
@@ -12,25 +12,9 @@ import (
 	"github.com/topcheer/ggcode/internal/provider"
 )
 
-// mcpSamplingProvider holds the LLM provider used for MCP sampling requests.
-// It is set lazily after the agent (and its provider) are created, since the
-// provider is not available at MCPManager construction time.
-var (
-	samplingProvider   provider.Provider
-	samplingProviderMu sync.RWMutex
-	// samplingMaxTokensMu serializes the shared-provider maxTokens
-	// mutate->chat->restore window (#1612-A).
-	samplingMaxTokensMu sync.Mutex
-)
-
-// SetSamplingProvider sets the LLM provider used to handle MCP sampling
-// (sampling/createMessage) requests. Called after the agent is created.
-func SetSamplingProvider(p provider.Provider) {
-	samplingProviderMu.Lock()
-	samplingProvider = p
-	samplingProviderMu.Unlock()
-	debug.Log("mcp-sampling", "sampling provider set: %T", p)
-}
+// mcpSamplingMaxTokensMu serializes the shared-provider maxTokens
+// mutate->chat->restore window (#1612-A).
+var samplingMaxTokensMu sync.Mutex
 
 // newMCPSamplingHandler binds the sampling handler to ONE runtime's
 // provider getter (#1592-B): the package-global let a second session in
@@ -40,15 +24,6 @@ func newMCPSamplingHandler(providerFn func() provider.Provider) func(ctx context
 	return func(ctx context.Context, params mcp.SamplingParams) (*mcp.SamplingResult, error) {
 		return mcpSamplingHandlerWith(ctx, params, providerFn())
 	}
-}
-
-// mcpSamplingHandler implements mcp.SamplingHandler using the configured provider.
-// If no provider is set, it returns an error.
-func mcpSamplingHandler(ctx context.Context, params mcp.SamplingParams) (*mcp.SamplingResult, error) {
-	samplingProviderMu.RLock()
-	p := samplingProvider
-	samplingProviderMu.RUnlock()
-	return mcpSamplingHandlerWith(ctx, params, p)
 }
 
 func mcpSamplingHandlerWith(ctx context.Context, params mcp.SamplingParams, p provider.Provider) (*mcp.SamplingResult, error) {

--- a/internal/agentruntime/section_collector.go
+++ b/internal/agentruntime/section_collector.go
@@ -20,7 +20,6 @@ import (
 //   - Start launches a goroutine that refreshes every refreshInterval.
 //   - The first refresh runs synchronously in Start so values are available
 //     immediately for the initial prompt build.
-//   - RefreshNow triggers an immediate refresh (useful after file saves).
 //   - If a refresh is slow, the previous cached value remains in use -
 //     prompt construction is never blocked.
 
@@ -221,13 +220,6 @@ func (sc *SectionCollector) loop() {
 			}
 		}
 	}
-}
-
-// RefreshNow triggers an immediate refresh in a non-blocking goroutine.
-// Call this after file edits or git operations to get fresh data without
-// waiting for the next tick.
-func (sc *SectionCollector) RefreshNow() {
-	go safego.Run("agentruntime.sectionCollector.refreshNow", sc.refresh)
 }
 
 // Snapshot returns a point-in-time copy of all cached sections.

--- a/internal/auth/claude_oauth.go
+++ b/internal/auth/claude_oauth.go
@@ -56,13 +56,6 @@ type ClaudeTokenResponse struct {
 	Scope        string `json:"scope"`
 }
 
-// ClaudeProfile holds user profile information from the Anthropic API.
-type ClaudeProfile struct {
-	SubscriptionType string
-	DisplayName      string
-	RateLimitTier    string
-}
-
 // --- PKCE helpers ---
 
 func generateCodeVerifier() (string, error) {
@@ -380,97 +373,6 @@ func RefreshClaudeToken(ctx context.Context, refreshToken string) (*Info, error)
 	}
 
 	return info, nil
-}
-
-// CreateClaudeAPIKey creates a long-lived API key from an OAuth access token.
-func CreateClaudeAPIKey(ctx context.Context, accessToken string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, claudeOAuthAPIKeyURL, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("creating API key: %w", err)
-	}
-	defer resp.Body.Close()
-
-	data, err := util.ReadAll(resp.Body, util.ReadLimitAuth)
-	if err != nil {
-		return "", fmt.Errorf("reading API key response: %w", err)
-	}
-
-	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("API key creation failed [%d]: %s", resp.StatusCode, strings.TrimSpace(string(data)))
-	}
-
-	var result map[string]interface{}
-	if err := json.Unmarshal(data, &result); err != nil {
-		return "", fmt.Errorf("parsing API key response: %w", err)
-	}
-
-	rawKey, _ := result["raw_key"].(string)
-	// Also check nested data structure
-	if rawKey == "" {
-		if d, ok := result["data"].(map[string]interface{}); ok {
-			rawKey, _ = d["raw_key"].(string)
-		}
-	}
-
-	return rawKey, nil
-}
-
-// FetchClaudeProfile fetches the user's profile information.
-func FetchClaudeProfile(ctx context.Context, accessToken string) (*ClaudeProfile, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, claudeOAuthProfileURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetching profile: %w", err)
-	}
-	defer resp.Body.Close()
-
-	data, err := util.ReadAll(resp.Body, util.ReadLimitAuth)
-	if err != nil {
-		return nil, fmt.Errorf("reading profile response: %w", err)
-	}
-
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("profile fetch failed [%d]: %s", resp.StatusCode, strings.TrimSpace(string(data)))
-	}
-
-	var raw map[string]interface{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parsing profile response: %w", err)
-	}
-
-	profile := &ClaudeProfile{}
-	if org, ok := raw["organization"].(map[string]interface{}); ok {
-		orgType, _ := org["organization_type"].(string)
-		switch orgType {
-		case "claude_max":
-			profile.SubscriptionType = "max"
-		case "claude_pro":
-			profile.SubscriptionType = "pro"
-		case "claude_enterprise":
-			profile.SubscriptionType = "enterprise"
-		case "claude_team":
-			profile.SubscriptionType = "team"
-		default:
-			profile.SubscriptionType = orgType
-		}
-	}
-	profile.DisplayName, _ = raw["display_name"].(string)
-	profile.RateLimitTier, _ = raw["rate_limit_tier"].(string)
-
-	return profile, nil
 }
 
 // Close shuts down the callback HTTP server. If another goroutine is

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -50,13 +50,3 @@ func FormatDiff(diff string) string {
 	border := diffHeaderStyle.Render(strings.Repeat("─", 40))
 	return fmt.Sprintf("%s\n%s%s", border, result, border)
 }
-
-// IsDiffContent checks if text looks like a unified diff.
-func IsDiffContent(text string) bool {
-	for _, line := range strings.Split(text, "\n") {
-		if strings.HasPrefix(line, "@@") {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/tui/spinner.go
+++ b/internal/tui/spinner.go
@@ -141,47 +141,6 @@ type ToolStatusMsg struct {
 // toolBulletStyle renders the ● prefix for tool call lines.
 var toolBulletStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("14"))
 
-// FormatToolStart formats the header line when a tool begins executing.
-func FormatToolStart(msg ToolStatusMsg) string {
-	var sb strings.Builder
-	sb.WriteString(toolBulletStyle.Render("● "))
-	sb.WriteString(formatToolInline(toolDisplayName(msg), toolDetail(msg)))
-	if msg.Args != "" && toolDetail(msg) == "" {
-		sb.WriteString("\n  │ ")
-		sb.WriteString(relativizeResult(msg.Args))
-	}
-	sb.WriteString("\n")
-	return sb.String()
-}
-
-// FormatToolResult formats the closing line when a tool finishes.
-func FormatToolResult(lang Language, msg ToolStatusMsg) string {
-	var sb strings.Builder
-	if msg.IsError {
-		sb.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render("  └ " + tr(lang, "tool.failed")))
-	} else {
-		sb.WriteString("  └ " + tr(lang, "tool.done"))
-	}
-	if msg.Elapsed > 0 {
-		sb.WriteString(fmt.Sprintf(" (%s)", msg.Elapsed))
-	}
-	summary := summarizeToolResult(lang, msg)
-	if summary != "" {
-		sb.WriteString(": ")
-		sb.WriteString(summary)
-	}
-	sb.WriteString("\n\n")
-	return sb.String()
-}
-
-// FormatToolStatus formats a tool completion message (legacy compat).
-func FormatToolStatus(msg ToolStatusMsg) string {
-	if msg.Running {
-		return ""
-	}
-	return FormatToolResult(LangEnglish, msg)
-}
-
 func summarizeToolResult(lang Language, msg ToolStatusMsg) string {
 	result := relativizeResult(strings.TrimSpace(msg.Result))
 	if msg.IsError {


### PR DESCRIPTION
## 背景

cron-3 批次3。双 oracle 验证（全仓文本 grep + `deadcode` RTA 传递闭包，均 -tags goolm），测试/前端零引用，残留命中均为注释性文档。

## 本批清理（5 文件 / 9 函数 + 1 类型 + 2 包级变量 / 185 行删除）

| 项 | 依据 |
|---|---|
| `FormatToolStart/Result/Status` | Status 唯一调用者是同死的 Result；docs 提及为描述性设计笔记 |
| `IsDiffContent` | 零调用 |
| `SectionCollector.RefreshNow` | 零调用；review-8174 已明确背书删除；同步清理头注释失真行 |
| `SetSamplingProvider` + `mcpSamplingHandler` + `samplingProvider` 全局变量 | 旧包级 wiring 被 #1592-B 注入式 `newMCPSamplingHandler`（interactive_core.go:68）取代；`samplingMaxTokensMu` 保留（活函数在用） |
| `CreateClaudeAPIKey`/`FetchClaudeProfile`/`ClaudeProfile` | 类型与函数成对死（同批次1 RunJournal 先例）；同文件 openBrowser/copyToClipboard 判活未动 |

## 刻意不删（功能级裁决，非死代码范畴）

- **acp client 孤岛**（~50 函数）：链根 `Client.readLoop` RTA 不可达，根因是 acp.Client 生产代码零实例化——是否废弃该功能是产品决策
- **agent 静态检查孤岛**（~60 函数）：同理待链根确认

## 验证

build + vet 零退出码；gofmt 干净；受影响包（tui/agentruntime/auth）测试 ok；全量 `./...` 61 包 ok。

## 库存

三批累计 29 符号 / ~500 行。文本死代码剩余 ~58 项（wailskit 桥接 20 需跨模块独立批次、tunnel 簇 ~21 冷却中、spinner 辅助 5 等）。

Co-Authored-By: ggcode <noreply@ggcode.dev>