### PR TITLE
chore: remove dead code batch 5 (cron-3 scan)

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1550,11 +1550,6 @@ func extractSSEResponseForID(body []byte, reqID *ID) (*Response, error) {
 	return nil, fmt.Errorf("parsing SSE response: no Response found in %d event(s)", len(events))
 }
 
-func extractAllSSEData(body []byte) [][]byte {
-	events, _ := extractAllSSEDataChecked(body)
-	return events
-}
-
 // extractAllSSEDataChecked also surfaces scanner errors (#597 M2): a line
 // longer than the 1MB scanner buffer made Scan() stop silently and the old
 // code reported "no data event found" — misdiagnosing an oversized (>1MB)
@@ -1877,13 +1872,6 @@ func (c *Client) sleepUntilClosed(d time.Duration) bool {
 		time.Sleep(min(time.Until(deadline), time.Second))
 	}
 	return !c.closed.Load()
-}
-
-// extractNDJSONResponse parses newline-delimited JSON bodies and returns the
-// first message that parses as a JSON-RPC Response. Handles servers that send
-// a Notification (e.g. logging) before the actual Response, without SSE framing.
-func extractNDJSONResponse(body []byte) *Response {
-	return extractNDJSONResponseForID(body, nil)
 }
 
 // extractNDJSONResponseForID is the ID-matching NDJSON form (#597 M1/M2).

--- a/internal/mcp/readonly.go
+++ b/internal/mcp/readonly.go
@@ -41,8 +41,6 @@ var writeKeywords = []string{
 // containsShortRoot reports whether the keyword is a short root (<= 4
 // chars) prone to false positives inside unrelated words ("set" in
 // "dataset", "run" in "truncate", "put" in "output").
-func containsShortRoot(kw string) bool { return len(kw) <= 4 }
-
 // camelToSnake inserts underscores at uppercase boundaries so camelCase
 // write names ("setValue") segment-match the same roots as their snake_case
 // twins ("set_value") - #997. Lowercases as it goes. Read names split

--- a/internal/tool/command_jobs.go
+++ b/internal/tool/command_jobs.go
@@ -538,13 +538,6 @@ func (w *commandJobWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func partialLineCount(partial string) int {
-	if strings.TrimSpace(partial) == "" {
-		return 0
-	}
-	return 1
-}
-
 func selectCommandLines(lines []string, bufferedFrom, tailLines, sinceLine int) ([]string, bool) {
 	if len(lines) == 0 {
 		return nil, false

--- a/internal/tool/file_guard.go
+++ b/internal/tool/file_guard.go
@@ -109,13 +109,6 @@ func fsCaseInsensitive() bool {
 }
 
 // segEqualsFS compares two path segments under the local FS semantics.
-func segEqualsFS(a, b string) bool {
-	if fsCaseInsensitive() {
-		return strings.EqualFold(a, b)
-	}
-	return a == b
-}
-
 // matchSegFS matches one pattern segment against one path segment under
 // the local FS semantics (fold before filepath.Match on insensitive FSes).
 func matchSegFS(pattern, name string) bool {

--- a/internal/tool/secret_scan.go
+++ b/internal/tool/secret_scan.go
@@ -8,11 +8,6 @@ import (
 // Defaults to true. Can be disabled via configuration.
 var secretScanEnabled = true
 
-// SetSecretScanEnabled enables or disables post-write secret scanning globally.
-func SetSecretScanEnabled(enabled bool) {
-	secretScanEnabled = enabled
-}
-
 // scanAndWarn performs a secret scan on the given file content and returns
 // a formatted warning string if any secrets are found. Returns empty string
 // if scanning is disabled or no secrets are found.

--- a/internal/tool/web_fetch.go
+++ b/internal/tool/web_fetch.go
@@ -254,10 +254,6 @@ func isPrivateHost(host string) bool {
 
 // IsPrivateIP returns true if the IP is in a private, loopback, or link-local range.
 // Exported for reuse by the TUI's URL auto-fetch expansion.
-func IsPrivateIP(ip net.IP) bool {
-	return isPrivateIP(ip)
-}
-
 // isPrivateIP returns true if the IP is in a private, loopback, or link-local range.
 func isPrivateIP(ip net.IP) bool {
 	networks, err := getPrivateNetworks()

--- a/internal/tui/update_done.go
+++ b/internal/tui/update_done.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -422,13 +421,4 @@ func (m Model) buildAgentTitleSummary(toolCount int) string {
 		return fmt.Sprintf("Agent task (%d tool calls)", toolCount)
 	}
 	return ""
-}
-
-// shortPath returns the last 1-2 path segments of a file path for brevity.
-func shortPath(path string) string {
-	segs := strings.Split(strings.ReplaceAll(path, "\\", "/"), "/")
-	if len(segs) <= 2 {
-		return strings.Join(segs, "/")
-	}
-	return strings.Join(segs[len(segs)-2:], "/")
 }

--- a/internal/tui/view_sidebar.go
+++ b/internal/tui/view_sidebar.go
@@ -521,35 +521,6 @@ func fitDisplayWidth(s string, maxWidth int) string {
 	return b.String()
 }
 
-type sidebarContextStatLine struct {
-	maxTokens        int
-	usagePercent     int
-	remainingPercent int
-}
-
-func (m Model) sidebarContextStats() (sidebarContextStatLine, bool) {
-	if m.agent == nil {
-		return sidebarContextStatLine{}, false
-	}
-	cm := m.agent.ContextManager()
-	if cm == nil {
-		return sidebarContextStatLine{}, false
-	}
-	maxTokens := cm.ContextWindow()
-	tokenCount := cm.TokenCount()
-	threshold := cm.AutoCompactThreshold()
-	display, ok := uiusage.BuildContextDisplay(tokenCount, maxTokens, threshold)
-	if !ok {
-		return sidebarContextStatLine{}, false
-	}
-
-	return sidebarContextStatLine{
-		maxTokens:        display.MaxTokens,
-		usagePercent:     display.UsagePercent,
-		remainingPercent: display.RemainingPercent,
-	}, true
-}
-
 func (m Model) sidebarSessionUsage() provider.TokenUsage {
 	if m.session == nil {
 		return provider.TokenUsage{}


### PR DESCRIPTION
## 背景

cron-3 批次5。三重门验证（主模块 RTA 死 + wails 死集合成员 + grep -F 文本零引用 + 测试零引用）。

## 本批清理（8 文件 / 10 符号 / 76 行）

| 项 | 依据 |
|---|---|
| tui `shortPath` | tui 局部死；context/cmd 的同名是独立实现（测试测的是它们的） |
| tui `sidebarContextStats`+类型 | **批次4 原子性丢失的孤儿**：当时 multi-edit 兄弟 edit 失败导致整文件未写入，PR 描述与实际不符——本 PR 补完 |
| mcp `extractAllSSEData`/`extractNDJSONResponse` | 被 Checked/ForID 变体取代的死 wrapper |
| mcp `containsShortRoot` | 零引用 |
| tool `SetSecretScanEnabled` | 导出 setter 死；变量活（scanAndWarn 读） |
| tool `IsPrivateIP` | 活函数 isPrivateIP 的死导出包装 |
| tool `partialLineCount`/`segEqualsFS` | 零引用（matchSegFS 是不同的活函数） |

## 批次5 扫描关键发现

- **multi_edit_file 原子性陷阱**：兄弟 edit 失败会静默丢弃同文件全部 edit（批次4 sidebarContextStats 丢失根因）
- **macOS grep \b 批量脚本不可靠**：全部终判改用 grep -F 固定字符串复核
- **跨 GOOS 陷阱**：ydoTypeArgs 主 RTA 报死但 desktop_control_linux.go:427 有 Linux-only 调用者——不删
- **接口锚定**：PairingStore.LoadAll/SaveAll 实现接口——不删

## 库存终判

可判定库存已清零。剩余 7 项已预验（WithOnTaskEvent/RemovePIDFile/FormatPID/FormatRedactionNotice/SetNamedAgentModelResolver/ReadStagedBinary/CleanupJournals）留给收尾批次6；其余全部归入永久类别（死簇纠缠 ~90 并入孤岛冻结、测试锚定 ~83、wailskit goja 反射/tombstone/acp/agent 孤岛）。

## 验证

build+vet 零退出；gofmt 干净；tui/mcp/tool 测试 ok；全量 61 包 ok。

Co-Authored-By: ggcode <noreply@ggcode.dev>