### PR TITLE
chore: remove dead code batch 6 - final (cron-3 scan)

### DIFF
--- a/internal/a2a/handler.go
+++ b/internal/a2a/handler.go
@@ -92,11 +92,6 @@ func WithTimeout(d time.Duration) HandlerOption {
 	return func(h *TaskHandler) { h.timeout = d }
 }
 
-// WithOnTaskEvent sets the callback for task lifecycle events.
-func WithOnTaskEvent(fn func(TaskEventMessage)) HandlerOption {
-	return func(h *TaskHandler) { h.onTaskEvent = fn }
-}
-
 // SetOnTaskEvent sets the callback at runtime.
 func (h *TaskHandler) SetOnTaskEvent(fn func(TaskEventMessage)) {
 	h.mu.Lock()

--- a/internal/agentruntime/sessions.go
+++ b/internal/agentruntime/sessions.go
@@ -324,9 +324,3 @@ func CheckCrashRecovery(sessionID string) string {
 	info := agent.CheckCrashedRun(sessionID)
 	return agent.FormatCrashRecoveryMessage(info)
 }
-
-// CleanupJournals removes stale run journals older than maxAge. Call this at
-// application startup to prevent unbounded journal file accumulation.
-func CleanupJournals(maxAge time.Duration) {
-	agent.CleanupOldJournals(maxAge)
-}

--- a/internal/daemon/background.go
+++ b/internal/daemon/background.go
@@ -8,7 +8,6 @@ import (
 	"github.com/topcheer/ggcode/internal/debug"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -113,11 +112,6 @@ func WritePIDFile(path string, pid int, sessionID, workingDir string) error {
 	// cleanup paths). Caller is responsible for closing the file when the
 	// daemon shuts down.
 	return nil
-}
-
-// RemovePIDFile deletes the PID file.
-func RemovePIDFile(path string) error {
-	return os.Remove(path)
 }
 
 // ReadPIDFile reads daemon info from a PID file.
@@ -383,9 +377,4 @@ func CleanupDaemon(workingDir string) {
 		return
 	}
 	_ = os.Remove(pidPath)
-}
-
-// FormatPID returns a human-readable PID string.
-func FormatPID(pid int) string {
-	return strconv.Itoa(pid)
 }

--- a/internal/mcp/readonly.go
+++ b/internal/mcp/readonly.go
@@ -38,9 +38,6 @@ var writeKeywords = []string{
 	"deploy",
 }
 
-// containsShortRoot reports whether the keyword is a short root (<= 4
-// chars) prone to false positives inside unrelated words ("set" in
-// "dataset", "run" in "truncate", "put" in "output").
 // camelToSnake inserts underscores at uppercase boundaries so camelCase
 // write names ("setValue") segment-match the same roots as their snake_case
 // twins ("set_value") - #997. Lowercases as it goes. Read names split

--- a/internal/security/display_redact.go
+++ b/internal/security/display_redact.go
@@ -1,7 +1,6 @@
 package security
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -128,10 +127,4 @@ func HasSecretPattern(content string) bool {
 		}
 	}
 	return false
-}
-
-// FormatRedactionNotice returns a notice string explaining that secrets were
-// masked in the display. Returns empty if no redaction notice is needed.
-func FormatRedactionNotice() string {
-	return fmt.Sprintf("[显示脱敏: 检测到敏感信息已做掩码处理 / Display redacted: sensitive values masked for safety]\n")
 }

--- a/internal/tool/file_guard.go
+++ b/internal/tool/file_guard.go
@@ -108,7 +108,6 @@ func fsCaseInsensitive() bool {
 	return goos == "darwin" || goos == "windows"
 }
 
-// segEqualsFS compares two path segments under the local FS semantics.
 // matchSegFS matches one pattern segment against one path segment under
 // the local FS semantics (fold before filepath.Match on insensitive FSes).
 func matchSegFS(pattern, name string) bool {

--- a/internal/tool/labels.go
+++ b/internal/tool/labels.go
@@ -21,15 +21,11 @@ type ToolResultPresentation struct {
 	PayloadMode string // "", "text", "task_fields", "task_list"
 }
 
-// namedAgentModelResolver returns the model configured for a named agent
-// template, or "" if unknown. Set by the TUI at startup.
+// namedAgentModelResolver resolves a named agent template's model override
+// by name. Returns "" if the template has no model override. (Its historical
+// setter was removed as dead code; the resolver is read by DescribeTool's
+// use_namedagent label and stays nil until re-wired.)
 var namedAgentModelResolver func(name string) string
-
-// SetNamedAgentModelResolver registers a function that resolves the model
-// configured for a named agent template by name.
-func SetNamedAgentModelResolver(fn func(name string) string) {
-	namedAgentModelResolver = fn
-}
 
 // DescribeTool returns a human-readable presentation for a tool call.
 // It picks the key argument(s) for each tool and formats them compactly.

--- a/internal/tool/web_fetch.go
+++ b/internal/tool/web_fetch.go
@@ -252,8 +252,6 @@ func isPrivateHost(host string) bool {
 	return false
 }
 
-// IsPrivateIP returns true if the IP is in a private, loopback, or link-local range.
-// Exported for reuse by the TUI's URL auto-fetch expansion.
 // isPrivateIP returns true if the IP is in a private, loopback, or link-local range.
 func isPrivateIP(ip net.IP) bool {
 	networks, err := getPrivateNetworks()

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -69,20 +69,6 @@ type HelperManifest struct {
 	ExpectedVersion string   `json:"expected_version"`
 }
 
-// ReadStagedBinary reads a manifest file and returns the path to the staged
-// (downloaded) binary. Used by the restart helper to know which file to install.
-func ReadStagedBinary(manifestPath string) (string, error) {
-	data, err := os.ReadFile(manifestPath)
-	if err != nil {
-		return "", fmt.Errorf("read manifest: %w", err)
-	}
-	var manifest HelperManifest
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return "", fmt.Errorf("parse manifest: %w", err)
-	}
-	return manifest.SourceBinary, nil
-}
-
 type cachedCheck struct {
 	CurrentVersion string    `json:"current_version"`
 	LatestVersion  string    `json:"latest_version"`


### PR DESCRIPTION
## 背景

cron-3 六批 dead code 清理战役的**最终批**。7 项均经批次6 只读终扫三重验证（主模块 RTA 死 + wails 程序全域文本零引用 + GOOS 干净）+ 执行时 grep -F 复验 + 删除后零残留确认。

## 本批清理（7 符号 + 3 注释残片 / 9 文件 / 57 行）

| 项 | 备注 |
|---|---|
| a2a `WithOnTaskEvent` | onTaskEvent 字段保留（SetOnTaskEvent 活写入） |
| daemon `RemovePIDFile`/`FormatPID` | strconv import 同步清 |
| security `FormatRedactionNotice` | fmt import 同步清 |
| tool `SetNamedAgentModelResolver` | **终扫纠错案例**：变量被 labels.go:318 活读取（use_namedagent label），变量保留仅删 setter——行为中性（setter 本就零调用） |
| update `ReadStagedBinary` | HelperManifest 类型活保留 |
| agentruntime `CleanupJournals` | agent.CleanupOldJournals 活 |
| 3 注释残片 | 批次5 删除的悬空注释清理 |

## 战役总结（六批）

| PR | 批次 | 符号数 |
|---|---|---|
| #2097 | 1 | 4 |
| #2107 | 2 | 16 |
| #2117 | 3 | 10 |
| #2130 | 4 | 18 |
| #2136 | 5 | 10 |
| 本 PR | 6 | 7 |

**累计 64+ 死符号 / ~960 行**。剩余全部为永久类别（goja 反射簇、tombstone 约定、acp/agent 孤岛待产品决策、测试锚定、死簇纠缠）——可判定死代码库存清零，扫描任务收尾。

## 验证

build+vet 零退出；gofmt 干净；受影响 7 包测试 ok；全量 61 包 ok；7 符号 grep 零残留。

Co-Authored-By: ggcode <noreply@ggcode.dev>