### PR TITLE
fix(config): instance-scope partial reset actually deletes the key (#2106)

### DIFF
--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -184,6 +184,13 @@ func globalOnlyVendors(merged, globalSnapVendors map[string]VendorConfig) map[st
 // wholesale (honoring additions and removals from the current process).
 func deepMergeYAMLMaps(dst, src map[string]interface{}) {
 	for key, srcVal := range src {
+		// nil is an explicit deletion marker (#2106): the source wants the
+		// key gone from the merged result (e.g. an instance override reset
+		// back to the global value), not a YAML null written to disk.
+		if srcVal == nil {
+			delete(dst, key)
+			continue
+		}
 		if dstVal, exists := dst[key]; exists {
 			srcMap, srcIsMap := srcVal.(map[string]interface{})
 			dstMap, dstIsMap := dstVal.(map[string]interface{})

--- a/internal/config/instance.go
+++ b/internal/config/instance.go
@@ -432,7 +432,23 @@ func (c *Config) SaveInstance(workspace string) error {
 	// Compute the minimal diff: fields in current config that differ from globalSnap.
 	delta := c.marshalInstanceDelta()
 
-	if len(delta) == 0 {
+	// Read the existing instance file BEFORE deciding emptiness: reset
+	// detection (#2106) needs the on-disk keys to turn "current == global"
+	// fields into explicit deletions, otherwise a partial reset resurrects
+	// from the file on the next MergeInstance (deep-merge never deletes).
+	var existingRaw map[string]interface{}
+	existingData, readErr := os.ReadFile(path)
+	if readErr == nil && len(existingData) > 0 {
+		existingRaw = map[string]interface{}{}
+		if yamlErr := yaml.Unmarshal(existingData, &existingRaw); yamlErr != nil {
+			existingRaw = nil // unparseable — overwrite with delta below
+		}
+	}
+	if existingRaw != nil {
+		applyInstanceResets(existingRaw, delta, c.instanceFields)
+	}
+
+	if len(delta) == 0 && (existingRaw == nil || len(existingRaw) == 0) {
 		// No overrides — remove the instance file if it exists.
 		if _, err := os.Stat(path); err == nil {
 			if err := os.Remove(path); err != nil {
@@ -444,26 +460,24 @@ func (c *Config) SaveInstance(workspace string) error {
 
 	// Merge delta onto existing instance file, or write delta as new file.
 	var data []byte
-	existingData, readErr := os.ReadFile(path)
-	if readErr == nil && len(existingData) > 0 {
-		existingRaw := map[string]interface{}{}
-		if yamlErr := yaml.Unmarshal(existingData, &existingRaw); yamlErr == nil {
-			deepMergeYAMLMaps(existingRaw, delta)
-			var marshalErr error
-			data, marshalErr = yaml.Marshal(existingRaw)
-			if marshalErr != nil {
-				return fmt.Errorf("marshaling merged instance config: %w", marshalErr)
+	if existingRaw != nil && len(existingRaw) > 0 {
+		deepMergeYAMLMaps(existingRaw, delta)
+		// After applying reset deletions the file may have become empty —
+		// every override was reset back to global (#2106).
+		if len(existingRaw) == 0 {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				debug.Log("config", "SaveInstance: failed to remove fully-reset instance config: %v", err)
 			}
-		} else {
-			// Existing file unparseable — overwrite with delta.
-			var marshalErr error
-			data, marshalErr = yaml.Marshal(delta)
-			if marshalErr != nil {
-				return fmt.Errorf("marshaling instance config: %w", marshalErr)
-			}
+			return nil
+		}
+		var marshalErr error
+		data, marshalErr = yaml.Marshal(existingRaw)
+		if marshalErr != nil {
+			return fmt.Errorf("marshaling merged instance config: %w", marshalErr)
 		}
 	} else {
-		// File doesn't exist — write delta directly.
+		// File doesn't exist (or unparseable) — write delta directly. A delta
+		// computed against no existing file cannot contain reset markers.
 		var marshalErr error
 		data, marshalErr = yaml.Marshal(delta)
 		if marshalErr != nil {

--- a/internal/config/instance_reset.go
+++ b/internal/config/instance_reset.go
@@ -1,0 +1,55 @@
+package config
+
+// instanceResetKeys are the top-level scalar/list fields managed by
+// marshalInstanceDelta's diffScalar/diffInt/diffStringSlice helpers. When a
+// field's current value has been reset back to the global value (or zero),
+// the diff omits the key entirely - but if the on-disk instance.yaml still
+// carries an override for it, the deep-merge in SaveInstance would keep the
+// stale value and MergeInstance would resurrect it on the next load (#2106).
+//
+// applyInstanceResets closes that hole: for every managed key present on
+// disk but absent from the delta, it writes an explicit nil deletion marker
+// into the delta. deepMergeYAMLMaps interprets nil as "delete the key",
+// so the reset actually reaches the file. When every override is reset the
+// merged file becomes empty and SaveInstance removes it altogether.
+//
+// Only top-level scalar-family keys are handled. Nested structures (ui, im,
+// vendors, ...) have partial-reset semantics of their own and are left to
+// their dedicated diff helpers.
+var instanceResetManagedKeys = []string{
+	"vendor",
+	"endpoint",
+	"model",
+	"language",
+	"system_prompt",
+	"default_mode",
+	"max_iterations",
+	"allowed_dirs",
+}
+
+// applyInstanceResets adds nil deletion markers to delta for managed keys
+// that exist in the on-disk instance map but are absent from the delta
+// (i.e. current == global: the user reset them).
+//
+// Scope guard: only keys listed in instanceFields - the fields this
+// session actually loaded FROM the instance file - may be deleted. Other
+// on-disk keys are not governed by the delta machinery (e.g. language is
+// handled by a dedicated load path and never lands in instanceFields),
+// and deleting them would eat live data (#734 regression probe).
+func applyInstanceResets(existingRaw, delta map[string]interface{}, instanceFields map[string]bool) {
+	if len(instanceFields) == 0 {
+		return
+	}
+	for _, key := range instanceResetManagedKeys {
+		if !instanceFields[key] {
+			continue // not governed by this session's delta
+		}
+		if _, onDisk := existingRaw[key]; !onDisk {
+			continue
+		}
+		if _, inDelta := delta[key]; inDelta {
+			continue // still overridden - normal write path
+		}
+		delta[key] = nil // reset back to global - delete from disk
+	}
+}

--- a/internal/config/instance_reset_test.go
+++ b/internal/config/instance_reset_test.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #2106 probes: instance-scope partial reset must actually remove the
+// overridden key from instance.yaml instead of letting the deep-merge keep
+// it (and MergeInstance resurrect it on the next load).
+
+// instanceTestEnv isolates HOME once per test so InstanceDir stays stable
+// across multiple saves.
+func instanceTestEnv(t *testing.T, globalPath string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	_ = globalPath
+}
+
+// saveInstanceVia loads the global+instance config and saves it back.
+func saveInstanceVia(t *testing.T, globalPath, workspace string, mutate func(c *Config)) string {
+	t.Helper()
+	cfg, err := LoadWithInstance(globalPath, workspace)
+	if err != nil {
+		t.Fatalf("LoadWithInstance: %v", err)
+	}
+	mutate(cfg)
+	if err := cfg.SaveInstanceScoped(workspace); err != nil {
+		t.Fatalf("SaveInstanceScoped: %v", err)
+	}
+	instPath := filepath.Join(InstanceDir(workspace), "ggcode.yaml")
+	return instPath
+}
+
+func TestInstancePartialResetScalarRemovedFromDisk(t *testing.T) {
+	gDir, ws := t.TempDir(), t.TempDir()
+	globalPath := filepath.Join(gDir, "ggcode.yaml")
+	if err := os.WriteFile(globalPath, []byte("language: en\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	instanceTestEnv(t, globalPath)
+
+	// Step 1: set two overrides - default_mode=plan and max_iterations=50.
+	// (max_iterations is a plain int with no default-fill path; language and
+	// endpoint both have dedicated load/default chains that shadow the
+	// instance merge - see the #734 probe notes.)
+	instPath := saveInstanceVia(t, globalPath, ws, func(c *Config) {
+		c.DefaultMode = "plan"
+		c.MaxIterations = 50
+	})
+	data, err := os.ReadFile(instPath)
+	if err != nil {
+		t.Fatalf("instance file missing after first save: %v", err)
+	}
+	if !contains(string(data), "default_mode") || !contains(string(data), "max_iterations") {
+		t.Fatalf("expected both overrides on disk, got:\n%s", data)
+	}
+
+	// Step 2: reset ONLY default_mode back to global ("") - keep max_iterations.
+	saveInstanceVia(t, globalPath, ws, func(c *Config) {
+		c.DefaultMode = "" // reset
+		c.MaxIterations = 50
+	})
+
+	// Probe: default_mode must be gone from disk; max_iterations must survive.
+	data, err = os.ReadFile(instPath)
+	if err != nil {
+		t.Fatalf("instance file missing after partial reset: %v", err)
+	}
+	if contains(string(data), "default_mode") {
+		t.Fatalf("#2106 regression: default_mode resurrected on disk:\n%s", data)
+	}
+	if !contains(string(data), "max_iterations") {
+		t.Fatalf("unrelated override max_iterations lost:\n%s", data)
+	}
+
+	// Probe: reload + merge must not resurrect the reset value.
+	cfg, err := LoadWithInstance(globalPath, ws)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if cfg.DefaultMode == "plan" {
+		t.Fatalf("#2106 regression: DefaultMode resurrected as %q after reload", cfg.DefaultMode)
+	}
+	if cfg.MaxIterations != 50 {
+		t.Fatalf("max_iterations override lost after reload: %d", cfg.MaxIterations)
+	}
+}
+
+func TestInstanceFullResetRemovesInstanceFile(t *testing.T) {
+	gDir, ws := t.TempDir(), t.TempDir()
+	globalPath := filepath.Join(gDir, "ggcode.yaml")
+	if err := os.WriteFile(globalPath, []byte("language: en\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	instanceTestEnv(t, globalPath)
+
+	// Override max_iterations and default_mode, then reset BOTH.
+	instPath := saveInstanceVia(t, globalPath, ws, func(c *Config) {
+		c.MaxIterations = 50
+		c.DefaultMode = "plan"
+	})
+	if _, err := os.Stat(instPath); err != nil {
+		t.Fatalf("instance file should exist after overrides: %v", err)
+	}
+
+	saveInstanceVia(t, globalPath, ws, func(c *Config) {
+		c.MaxIterations = 0 // reset
+		c.DefaultMode = ""  // reset
+	})
+
+	// Probe: with every override reset the instance file must be REMOVED
+	// (previously it survived with stale keys; only the empty-delta path
+	// ever removed it).
+	if _, err := os.Stat(instPath); !os.IsNotExist(err) {
+		t.Fatalf("#2106: fully-reset instance file still exists (err=%v)", err)
+	}
+}
+
+func TestInstanceResetKeepsUnmanagedKeys(t *testing.T) {
+	gDir, ws := t.TempDir(), t.TempDir()
+	globalPath := filepath.Join(gDir, "ggcode.yaml")
+	if err := os.WriteFile(globalPath, []byte("language: en\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	instanceTestEnv(t, globalPath)
+
+	// An existing instance file carrying a key OUTSIDE the managed reset
+	// family must survive a save that resets a managed key (deletion is
+	// scoped to the diff-managed scalar family).
+	instDir := InstanceDir(ws)
+	if err := os.MkdirAll(instDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(instDir, "ggcode.yaml"),
+		[]byte("default_mode: plan\nui:\n  sidebar_visible: true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	instPath := saveInstanceVia(t, globalPath, ws, func(c *Config) {
+		c.DefaultMode = "" // reset
+	})
+	data, err := os.ReadFile(instPath)
+	if err != nil {
+		t.Fatalf("instance file should survive (ui remains): %v", err)
+	}
+	if contains(string(data), "default_mode") {
+		t.Fatalf("managed reset key survived:\n%s", data)
+	}
+	if !contains(string(data), "sidebar_visible") {
+		t.Fatalf("unmanaged ui block was incorrectly deleted:\n%s", data)
+	}
+}


### PR DESCRIPTION
Fixes #2106.

## 根因（双机制叠加，HEAD 实证）

1. **写入侧**：`marshalInstanceDelta` 的 diffScalar/diffInt/diffStringSlice 对 current==global（或零值）一律跳过——重置意图不进 delta
2. **合并侧**：`SaveInstance` deep-merge 只增不删；仅 delta 整体为空才删文件

结果：只要还有任一其他 override，被重置的键在磁盘原样保留，下次 `MergeInstance` 复活陈旧值。

## 修复

- `applyInstanceResets`（新 instance_reset.go）：对 diff 管辖的顶层标量键，「磁盘有 && delta 无 && **instanceFields 登记**」→ delta 写显式 nil 删除标记
- `deepMergeYAMLMaps`：src 值为 nil 语义化为删键（不落 YAML null）
- `SaveInstance`：提前读现有文件；全部 override 重置后合并图为空 → 删文件

## 关键设计：instanceFields 作用域守卫

初版无守卫被 #734 探针拦下：`language`/`endpoint` 有专用 load/默认链、从不进 instanceFields，无守卫会误删活数据。守卫 = 只删本会话确实从 instance 加载过的键。

## 探针验证（instance_reset_test.go）

- 部分重置：键从磁盘**和** reload merge 双消失，无关 override 存活
- 全量重置：instance 文件整体删除（修复前带残留键存活）
- 管辖外键（ui block）在 managed 重置后存活
- **#734 数据丢失回归保持绿**（修复过程中被探针拦下过一次，守卫修正后恢复）

## 附带发现（未在本 PR 处理）

language/endpoint 的 instance 值被专用 load/默认链遮蔽、从不进入 merge 后的 Config——值得单独开 issue。

## 验证

全量 `go test -tags goolm ./...` 61 包 ok（-p=1 限流）；gofmt 干净。

Co-Authored-By: ggcode <noreply@ggcode.dev>