### PR TITLE
fix(config,tui): lock the IM adapter map end-to-end — Cmd-goroutine reads raced Update-loop writes (#2152)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -276,34 +276,38 @@ type Config struct {
 	// merge re-imports the deleted name on the next read and it "comes back"
 	// as an unconfigured row. Loaded from / persisted to mcp_deleted.yaml in
 	// the external config dir, never the main config file.
-	DeletedMCPServers []string                   `yaml:"-" json:"-"`
-	Hooks             hooks.HookConfig           `yaml:"hooks" json:"hooks"`
-	DefaultMode       string                     `yaml:"default_mode" json:"default_mode"`
-	SubAgents         SubAgentConfig             `yaml:"subagents" json:"subagents"`
-	Impersonation     ImpersonationConfig        `yaml:"impersonation,omitempty" json:"impersonation,omitempty"`
-	KnightConfig      KnightConfig               `yaml:"knight,omitempty" json:"knight,omitempty"`
-	Swarm             SwarmConfig                `yaml:"swarm,omitempty" json:"swarm,omitempty"`
-	Verify            VerifyConfig               `yaml:"verify,omitempty" json:"verify,omitempty"`
-	A2A               A2AConfig                  `yaml:"a2a,omitempty" json:"a2a,omitempty"`
-	LanChat           LanChatConfig              `yaml:"lanchat,omitempty" json:"lanchat,omitempty"`
-	Stream            stream.StreamConfig        `yaml:"stream,omitempty" json:"stream,omitempty"`
-	LSPServers        map[string]LSPServerConfig `yaml:"lsp_servers,omitempty" json:"lsp_servers,omitempty"`
-	ProbeContext      bool                       `yaml:"probe_context,omitempty" json:"probe_context,omitempty"`
-	P2P               P2PConfig                  `yaml:"p2p,omitempty" json:"p2p,omitempty"`
-	OutputStyle       string                     `yaml:"output_style,omitempty" json:"output_style,omitempty"`
-	Notifications     NotificationConfig         `yaml:"notifications,omitempty" json:"notifications,omitempty"`
-	Fallback          FallbackConfig             `yaml:"fallback,omitempty" json:"fallback,omitempty"`
-	Fallbacks         []FallbackConfig           `yaml:"fallbacks,omitempty" json:"fallbacks,omitempty"`
-	FilePath          string                     `yaml:"-" json:"-"`
-	ProtectedPaths    []string                   `yaml:"protected_paths,omitempty" json:"protected_paths,omitempty"`
-	FirstRun          bool                       `yaml:"-" json:"-"`
-	instanceDir       string                     `yaml:"-" json:"-"` // ~/.ggcode/instances/{sha256}/
-	instancePath      string                     `yaml:"-" json:"-"` // instanceDir + "/ggcode.yaml"
-	instanceWS        string                     `yaml:"-" json:"-"` // workspace path for SaveInstance
-	saveScope         string                     `yaml:"-" json:"-"` // current save scope: "global" or "instance"
-	globalSnap        *Config                    `yaml:"-" json:"-"` // deep copy of global config before instance merge
-	instanceFields    map[string]bool            `yaml:"-" json:"-"` // fields that were filled by instance config
-	diskStrSnap       map[string]string          `yaml:"-" json:"-"` // #610: dotted path -> raw string value on disk at Load time (clear/tombstone basis)
+	DeletedMCPServers []string `yaml:"-" json:"-"`
+	// imAdaptersMu guards c.IM.Adapters for runtime read-modify-write
+	// (config_save.go writers) vs. locked readers (im_access.go). Load-time
+	// normalization and expandEnv are single-threaded and unguarded (#2152).
+	imAdaptersMu   sync.RWMutex
+	Hooks          hooks.HookConfig           `yaml:"hooks" json:"hooks"`
+	DefaultMode    string                     `yaml:"default_mode" json:"default_mode"`
+	SubAgents      SubAgentConfig             `yaml:"subagents" json:"subagents"`
+	Impersonation  ImpersonationConfig        `yaml:"impersonation,omitempty" json:"impersonation,omitempty"`
+	KnightConfig   KnightConfig               `yaml:"knight,omitempty" json:"knight,omitempty"`
+	Swarm          SwarmConfig                `yaml:"swarm,omitempty" json:"swarm,omitempty"`
+	Verify         VerifyConfig               `yaml:"verify,omitempty" json:"verify,omitempty"`
+	A2A            A2AConfig                  `yaml:"a2a,omitempty" json:"a2a,omitempty"`
+	LanChat        LanChatConfig              `yaml:"lanchat,omitempty" json:"lanchat,omitempty"`
+	Stream         stream.StreamConfig        `yaml:"stream,omitempty" json:"stream,omitempty"`
+	LSPServers     map[string]LSPServerConfig `yaml:"lsp_servers,omitempty" json:"lsp_servers,omitempty"`
+	ProbeContext   bool                       `yaml:"probe_context,omitempty" json:"probe_context,omitempty"`
+	P2P            P2PConfig                  `yaml:"p2p,omitempty" json:"p2p,omitempty"`
+	OutputStyle    string                     `yaml:"output_style,omitempty" json:"output_style,omitempty"`
+	Notifications  NotificationConfig         `yaml:"notifications,omitempty" json:"notifications,omitempty"`
+	Fallback       FallbackConfig             `yaml:"fallback,omitempty" json:"fallback,omitempty"`
+	Fallbacks      []FallbackConfig           `yaml:"fallbacks,omitempty" json:"fallbacks,omitempty"`
+	FilePath       string                     `yaml:"-" json:"-"`
+	ProtectedPaths []string                   `yaml:"protected_paths,omitempty" json:"protected_paths,omitempty"`
+	FirstRun       bool                       `yaml:"-" json:"-"`
+	instanceDir    string                     `yaml:"-" json:"-"` // ~/.ggcode/instances/{sha256}/
+	instancePath   string                     `yaml:"-" json:"-"` // instanceDir + "/ggcode.yaml"
+	instanceWS     string                     `yaml:"-" json:"-"` // workspace path for SaveInstance
+	saveScope      string                     `yaml:"-" json:"-"` // current save scope: "global" or "instance"
+	globalSnap     *Config                    `yaml:"-" json:"-"` // deep copy of global config before instance merge
+	instanceFields map[string]bool            `yaml:"-" json:"-"` // fields that were filled by instance config
+	diskStrSnap    map[string]string          `yaml:"-" json:"-"` // #610: dotted path -> raw string value on disk at Load time (clear/tombstone basis)
 }
 
 // ImpersonationConfig holds persisted impersonation settings.

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -522,6 +522,8 @@ func (c *Config) AddIMTarget(adapterName string, target IMTargetConfig) error {
 	if c == nil {
 		return fmt.Errorf("config is nil")
 	}
+	c.imAdaptersMu.Lock()
+	defer c.imAdaptersMu.Unlock()
 	adapterName = strings.TrimSpace(adapterName)
 	if adapterName == "" {
 		return fmt.Errorf("adapter name is required")
@@ -560,7 +562,7 @@ func (c *Config) AddIMTarget(adapterName string, target IMTargetConfig) error {
 	targetData, _ := yaml.Marshal(target)
 	targetMap := map[string]interface{}{}
 	yaml.Unmarshal(targetData, &targetMap)
-	return c.PatchIMAdapter(adapterName, func(a map[string]interface{}) {
+	return c.patchIMAdapterUnlocked(adapterName, func(a map[string]interface{}) {
 		targets, _ := a["targets"].([]interface{})
 		// Replace existing target with same ID, or append.
 		found := false
@@ -584,6 +586,8 @@ func (c *Config) AddIMAdapter(name string, adapter IMAdapterConfig) error {
 	if c == nil {
 		return fmt.Errorf("config is nil")
 	}
+	c.imAdaptersMu.Lock()
+	defer c.imAdaptersMu.Unlock()
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return fmt.Errorf("adapter name is required")
@@ -633,6 +637,8 @@ func (c *Config) RemoveIMAdapter(name string) error {
 	if c == nil {
 		return fmt.Errorf("config is nil")
 	}
+	c.imAdaptersMu.Lock()
+	defer c.imAdaptersMu.Unlock()
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return fmt.Errorf("adapter name is required")
@@ -667,6 +673,8 @@ func (c *Config) SetIMAdapterEnabled(name string, enabled bool) error {
 	if c == nil {
 		return fmt.Errorf("config is nil")
 	}
+	c.imAdaptersMu.Lock()
+	defer c.imAdaptersMu.Unlock()
 	name = strings.TrimSpace(name)
 	if c.IM.Adapters == nil {
 		return fmt.Errorf("IM adapter %q not found", name)
@@ -677,7 +685,7 @@ func (c *Config) SetIMAdapterEnabled(name string, enabled bool) error {
 	}
 	adapter.Enabled = enabled
 	c.IM.Adapters[name] = adapter
-	return c.PatchIMAdapter(name, func(a map[string]interface{}) {
+	return c.patchIMAdapterUnlocked(name, func(a map[string]interface{}) {
 		a["enabled"] = enabled
 	})
 }
@@ -688,6 +696,8 @@ func (c *Config) SetIMAdapterExtra(name, key, value string) error {
 	if c == nil {
 		return fmt.Errorf("config is nil")
 	}
+	c.imAdaptersMu.Lock()
+	defer c.imAdaptersMu.Unlock()
 	name = strings.TrimSpace(name)
 	key = strings.TrimSpace(key)
 	if key == "" {
@@ -705,7 +715,7 @@ func (c *Config) SetIMAdapterExtra(name, key, value string) error {
 	}
 	adapter.Extra[key] = value
 	c.IM.Adapters[name] = adapter
-	return c.PatchIMAdapter(name, func(a map[string]interface{}) {
+	return c.patchIMAdapterUnlocked(name, func(a map[string]interface{}) {
 		extra, _ := a["extra"].(map[string]interface{})
 		if extra == nil {
 			extra = map[string]interface{}{}
@@ -723,6 +733,8 @@ func (c *Config) SetIMAdapterEnv(name, key, value string) error {
 	if c == nil {
 		return fmt.Errorf("config is nil")
 	}
+	c.imAdaptersMu.Lock()
+	defer c.imAdaptersMu.Unlock()
 	name = strings.TrimSpace(name)
 	key = strings.TrimSpace(key)
 	if key == "" {
@@ -740,7 +752,7 @@ func (c *Config) SetIMAdapterEnv(name, key, value string) error {
 	}
 	adapter.Env[key] = value
 	c.IM.Adapters[name] = adapter
-	return c.PatchIMAdapter(name, func(a map[string]interface{}) {
+	return c.patchIMAdapterUnlocked(name, func(a map[string]interface{}) {
 		env, _ := a["env"].(map[string]interface{})
 		if env == nil {
 			env = map[string]interface{}{}
@@ -753,7 +765,16 @@ func (c *Config) SetIMAdapterEnv(name, key, value string) error {
 // PatchIMAdapter patches a single IM adapter. For global scope, it operates
 // on im.yaml (external file). For instance scope, it patches the instance
 // ggcode.yaml directly (instance configs keep inline im: section).
+// PatchIMAdapter patches a single IM adapter's persisted form. Public entry
+// takes imAdaptersMu; internal callers already holding the lock (Set*,
+// AddIMTarget) use patchIMAdapterUnlocked (#2152: mutex is not reentrant).
 func (c *Config) PatchIMAdapter(name string, patch func(adapter map[string]interface{})) error {
+	c.imAdaptersMu.Lock()
+	defer c.imAdaptersMu.Unlock()
+	return c.patchIMAdapterUnlocked(name, patch)
+}
+
+func (c *Config) patchIMAdapterUnlocked(name string, patch func(adapter map[string]interface{})) error {
 	// Instance scope: patch instance ggcode.yaml directly (old behavior)
 	if c.saveScope == "instance" {
 		return c.patchConfigFile(func(raw map[string]interface{}) {

--- a/internal/config/im_access.go
+++ b/internal/config/im_access.go
@@ -1,0 +1,93 @@
+package config
+
+// im_access.go — locked read accessors for the IM adapter map (#2152).
+//
+// #1367/#1794 migrated all *writes* to c.IM.Adapters onto the Update loop
+// (configMutationMsg), but the *reads* stayed behind in TUI Cmd goroutines:
+// a bind/create Cmd that lives for seconds (waitForXxxAdapterHealthy polls
+// up to 10s) races an Update-loop "d" toggle (`SetIMAdapterEnabled` map
+// write) — Go fatal "concurrent map read and map write", process death.
+// The same applies to `im.StartNamedAdapter(ctx, m.config.IM, ...)` which
+// hands the live map (by struct copy) to a long-lived adapter.
+//
+// The runtime *writers* in config_save.go take imAdaptersMu for their
+// read-modify-write sections; the accessors below take RLock. Load-time
+// normalization (normalizeIMPlatforms / expandEnv) is single-threaded and
+// intentionally unguarded.
+
+// GetIMAdapter returns a deep copy of the named adapter's config. Safe to
+// call from any goroutine; mutating the copy never touches live config.
+func (c *Config) GetIMAdapter(name string) (IMAdapterConfig, bool) {
+	if c == nil {
+		return IMAdapterConfig{}, false
+	}
+	c.imAdaptersMu.RLock()
+	defer c.imAdaptersMu.RUnlock()
+	adapter, ok := c.IM.Adapters[name]
+	if !ok {
+		return IMAdapterConfig{}, false
+	}
+	return cloneIMAdapterConfig(adapter), true
+}
+
+// IMAdapterEnabled is the hot-path convenience accessor for render code
+// (`Disabled: !m.config.IMAdapterEnabled(name)`).
+func (c *Config) IMAdapterEnabled(name string) bool {
+	adapter, ok := c.GetIMAdapter(name)
+	return ok && adapter.Enabled
+}
+
+// IMSnapshot returns a deep copy of the whole IMConfig. The returned value
+// owns its Adapters map: safe to hand to long-lived consumers such as
+// im.StartNamedAdapter — later config writes never leak into them.
+func (c *Config) IMSnapshot() IMConfig {
+	if c == nil {
+		return IMConfig{}
+	}
+	c.imAdaptersMu.RLock()
+	defer c.imAdaptersMu.RUnlock()
+	snap := c.IM // struct copy; Adapters still aliased below
+	if c.IM.Adapters != nil {
+		snap.Adapters = make(map[string]IMAdapterConfig, len(c.IM.Adapters))
+		for name, adapter := range c.IM.Adapters {
+			snap.Adapters[name] = cloneIMAdapterConfig(adapter)
+		}
+	}
+	return snap
+}
+
+// cloneIMAdapterConfig deep-copies every reference field so callers can
+// never race live config through a handed-out copy.
+func cloneIMAdapterConfig(a IMAdapterConfig) IMAdapterConfig {
+	a.Args = append([]string(nil), a.Args...)
+	a.AllowFrom = append([]string(nil), a.AllowFrom...)
+	if a.Env != nil {
+		a.Env = copyStringMap(a.Env)
+	}
+	if a.Extra != nil {
+		extra := make(map[string]interface{}, len(a.Extra))
+		for k, v := range a.Extra {
+			extra[k] = v
+		}
+		a.Extra = extra
+	}
+	if a.Targets != nil {
+		targets := make([]IMTargetConfig, len(a.Targets))
+		copy(targets, a.Targets)
+		for i := range targets {
+			if targets[i].Metadata != nil {
+				targets[i].Metadata = copyStringMap(targets[i].Metadata)
+			}
+		}
+		a.Targets = targets
+	}
+	return a
+}
+
+func copyStringMap(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/internal/config/instance_test.go
+++ b/internal/config/instance_test.go
@@ -158,40 +158,40 @@ func TestHasInstanceConfig(t *testing.T) {
 func TestMergeInstance_ScalarFields(t *testing.T) {
 	tests := []struct {
 		name      string
-		global    Config
-		instance  Config
+		global    *Config
+		instance  *Config
 		wantModel string
 		wantLang  string
 	}{
 		{
 			name:      "instance no longer fills global Model (session-scoped)",
-			global:    Config{Model: ""},
-			instance:  Config{Model: "gpt-4o-mini"},
+			global:    &Config{Model: ""},
+			instance:  &Config{Model: "gpt-4o-mini"},
 			wantModel: "", // Model is now session-scoped, instance does not override
 		},
 		{
 			name:      "instance does not override non-empty global",
-			global:    Config{Model: "gpt-4o"},
-			instance:  Config{Model: "gpt-4o-mini"},
+			global:    &Config{Model: "gpt-4o"},
+			instance:  &Config{Model: "gpt-4o-mini"},
 			wantModel: "gpt-4o",
 		},
 		{
 			name:     "instance language fills gap",
-			global:   Config{Language: ""},
-			instance: Config{Language: "zh-CN"},
+			global:   &Config{Language: ""},
+			instance: &Config{Language: "zh-CN"},
 			wantLang: "zh-CN",
 		},
 		{
 			name:     "instance language does not override",
-			global:   Config{Language: "en"},
-			instance: Config{Language: "zh-CN"},
+			global:   &Config{Language: "en"},
+			instance: &Config{Language: "zh-CN"},
 			wantLang: "en",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			MergeInstance(&tt.global, &tt.instance)
+			MergeInstance(tt.global, tt.instance)
 			if tt.wantModel != "" && tt.global.Model != tt.wantModel {
 				t.Errorf("Model = %q, want %q", tt.global.Model, tt.wantModel)
 			}

--- a/internal/config/zz_issue2152_test.go
+++ b/internal/config/zz_issue2152_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestIssue2152_LockedReadsRaceWithWriters pins the IM accessors against
+// concurrent map access: N writers hammer the runtime writer methods while
+// M readers use GetIMAdapter / IMAdapterEnabled / IMSnapshot. Before #2152
+// the readers read c.IM.Adapters directly (TUI Cmd goroutines) while the
+// Update loop wrote it — `go test -race` flags it, and production hit the
+// unrecoverable "concurrent map read and map write" fatal.
+func TestIssue2152_LockedReadsRaceWithWriters(t *testing.T) {
+	withTestHome(t)
+	c := &Config{}
+	c.IM.Adapters = map[string]IMAdapterConfig{}
+
+	// Seed one adapter directly (load-time path, single-threaded).
+	c.IM.Adapters["seed"] = IMAdapterConfig{
+		Enabled:  true,
+		Platform: "qq",
+		Args:     []string{"--a", "--b"},
+		Env:      map[string]string{"K": "V"},
+		Targets:  []IMTargetConfig{{ID: "t1", Channel: "c1"}},
+	}
+
+	var writers, readers sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers: toggle enabled + set env (runtime writers from config_save.go).
+	// Iterations kept small: each write round-trips a YAML patch to disk;
+	// the race detector needs interleaving, not volume.
+	for w := 0; w < 2; w++ {
+		writers.Add(1)
+		go func(w int) {
+			defer writers.Done()
+			for i := 0; i < 50; i++ {
+				_ = c.SetIMAdapterEnabled("seed", i%2 == 0)
+				_ = c.SetIMAdapterEnv("seed", "K", "V2")
+			}
+		}(w)
+	}
+
+	// Readers: the locked accessors TUI Cmd goroutines now use.
+	for r := 0; r < 4; r++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if a, ok := c.GetIMAdapter("seed"); ok {
+					_ = a.Platform
+					_ = a.Args[0]
+					_ = a.Env["K"]
+					_ = a.Targets[0].ID
+				}
+				_ = c.IMAdapterEnabled("seed")
+				snap := c.IMSnapshot()
+				if n := len(snap.Adapters); n != 1 {
+					t.Errorf("IMSnapshot adapters = %d, want 1", n)
+					return
+				}
+			}
+		}()
+	}
+
+	// Writers finish first, then readers are released and joined —
+	// readers must NOT share the writers' WaitGroup or close(stop) would
+	// deadlock behind Wait() (this exact hang killed the first version).
+	writers.Wait()
+	close(stop)
+	readers.Wait()
+}
+
+// TestIssue2152_SnapshotIsDeepCopy verifies IMSnapshot hands out an
+// independent copy: mutating the snapshot (or its nested slices/maps) must
+// never leak into live config.
+func TestIssue2152_SnapshotIsDeepCopy(t *testing.T) {
+	c := &Config{}
+	c.IM.Adapters = map[string]IMAdapterConfig{
+		"a1": {
+			Enabled:  true,
+			Platform: "feishu",
+			Args:     []string{"x"},
+			Env:      map[string]string{"K": "V"},
+			Targets:  []IMTargetConfig{{ID: "t", Metadata: map[string]string{"m": "1"}}},
+		},
+	}
+
+	snap := c.IMSnapshot()
+	mut := snap.Adapters["a1"]
+	mut.Enabled = false
+	mut.Args[0] = "mutated"
+	mut.Env["K"] = "mutated"
+	mut.Targets[0].Metadata["m"] = "mutated"
+	delete(snap.Adapters, "a1")
+
+	live, ok := c.GetIMAdapter("a1")
+	if !ok {
+		t.Fatal("live adapter vanished after snapshot mutation")
+	}
+	if !live.Enabled {
+		t.Error("snapshot Enabled mutation leaked into live config")
+	}
+	if live.Args[0] != "x" || live.Env["K"] != "V" || live.Targets[0].Metadata["m"] != "1" {
+		t.Error("snapshot nested mutation leaked into live config")
+	}
+}

--- a/internal/tui/dingtalk_panel.go
+++ b/internal/tui/dingtalk_panel.go
@@ -239,7 +239,7 @@ func (m *Model) bindDingtalkEntry(entry dingtalkBindingEntry) tea.Cmd {
 		// it. Follow the qq pattern: mutate via configMutationMsg, continue
 		// the bind in next().
 		if m.config != nil {
-			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+			if cfg, ok := m.config.GetIMAdapter(entry.Adapter); ok && !cfg.Enabled {
 				return configMutationMsg{
 					apply: func(m *Model) error {
 						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
@@ -340,7 +340,7 @@ func (m *Model) createDingtalkAdapterCmd(spec string) tea.Cmd {
 				// #1794 case 2: auto-enable on the Update loop - the next()
 				// closure's startXXXAdapterIfNeeded used to write the map
 				// from the Cmd goroutine (#1367 family).
-				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+				if cfg, ok := m.config.GetIMAdapter(name); ok && !cfg.Enabled {
 					return m.config.SetIMAdapterEnabled(name, true)
 				}
 				return nil
@@ -381,7 +381,7 @@ func (m *Model) startDingtalkAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return errors.New(m.t("panel.dingtalk.error.not_configured", name))
 	}
@@ -395,7 +395,7 @@ func (m *Model) startDingtalkAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformDingTalk)) {
 		return errors.New(m.t("panel.dingtalk.error.not_dingtalk_adapter", name))
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m Model) dingtalkBindingEntries() []dingtalkBindingEntry {
@@ -421,7 +421,7 @@ func (m Model) dingtalkBindingEntries() []dingtalkBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformDingTalk)) {
 			keys = append(keys, name)
 		}
@@ -442,7 +442,7 @@ func (m Model) dingtalkBindingEntries() []dingtalkBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     dingtalkStatePtr(adapterStates[name]),
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}
@@ -523,7 +523,7 @@ func (m *Model) dingtalkEnableMutation(name string, next func(m *Model) tea.Msg)
 		},
 		next: func(m *Model) tea.Cmd {
 			return func() tea.Msg {
-				if err := im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager); err != nil {
+				if err := im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager); err != nil {
 					return dingtalkBindResultMsg{err: err}
 				}
 				if next == nil {

--- a/internal/tui/discord_panel.go
+++ b/internal/tui/discord_panel.go
@@ -240,7 +240,7 @@ func (m *Model) bindDiscordEntry(entry discordBindingEntry) tea.Cmd {
 		// it. Follow the qq pattern: mutate via configMutationMsg, continue
 		// the bind in next().
 		if m.config != nil {
-			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+			if cfg, ok := m.config.GetIMAdapter(entry.Adapter); ok && !cfg.Enabled {
 				return configMutationMsg{
 					apply: func(m *Model) error {
 						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
@@ -337,7 +337,7 @@ func (m *Model) createDiscordAdapterCmd(spec string) tea.Cmd {
 				// #1794 case 2: auto-enable on the Update loop - the next()
 				// closure's startXXXAdapterIfNeeded used to write the map
 				// from the Cmd goroutine (#1367 family).
-				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+				if cfg, ok := m.config.GetIMAdapter(name); ok && !cfg.Enabled {
 					return m.config.SetIMAdapterEnabled(name, true)
 				}
 				return nil
@@ -374,7 +374,7 @@ func (m *Model) startDiscordAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return errors.New(m.t("panel.discord.error.not_configured", name))
 	}
@@ -390,7 +390,7 @@ func (m *Model) startDiscordAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformDiscord)) {
 		return errors.New(m.t("panel.discord.error.not_discord_adapter", name))
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m Model) discordBindingEntries() []discordBindingEntry {
@@ -416,7 +416,7 @@ func (m Model) discordBindingEntries() []discordBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformDiscord)) {
 			keys = append(keys, name)
 		}
@@ -437,7 +437,7 @@ func (m Model) discordBindingEntries() []discordBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     discordStatePtr(adapterStates[name]),
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/feishu_panel.go
+++ b/internal/tui/feishu_panel.go
@@ -232,7 +232,7 @@ func (m *Model) bindFeishuEntry(entry feishuBindingEntry) tea.Cmd {
 		// it. Follow the qq pattern: mutate via configMutationMsg, continue
 		// the bind in next().
 		if m.config != nil {
-			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+			if cfg, ok := m.config.GetIMAdapter(entry.Adapter); ok && !cfg.Enabled {
 				return configMutationMsg{
 					apply: func(m *Model) error {
 						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
@@ -337,7 +337,7 @@ func (m *Model) createFeishuAdapterCmd(spec string) tea.Cmd {
 				// #1794 case 2: auto-enable on the Update loop - the next()
 				// closure's startXXXAdapterIfNeeded used to write the map
 				// from the Cmd goroutine (#1367 family).
-				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+				if cfg, ok := m.config.GetIMAdapter(name); ok && !cfg.Enabled {
 					return m.config.SetIMAdapterEnabled(name, true)
 				}
 				return nil
@@ -397,7 +397,7 @@ func (m *Model) startFeishuAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return errors.New(m.t("panel.feishu.error.not_configured", name))
 	}
@@ -413,7 +413,7 @@ func (m *Model) startFeishuAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformFeishu)) {
 		return errors.New(m.t("panel.feishu.error.not_feishu_adapter", name))
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m Model) feishuBindingEntries() []feishuBindingEntry {
@@ -439,7 +439,7 @@ func (m Model) feishuBindingEntries() []feishuBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformFeishu)) {
 			keys = append(keys, name)
 		}
@@ -460,7 +460,7 @@ func (m Model) feishuBindingEntries() []feishuBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     feishuStatePtr(adapterStates[name]),
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/im_edit.go
+++ b/internal/tui/im_edit.go
@@ -68,7 +68,7 @@ func (m *Model) enterIMEditSelect(adapterName string) imAdapterEditState {
 	if m.config == nil {
 		return s
 	}
-	adapter, ok := m.config.IM.Adapters[adapterName]
+	adapter, ok := m.config.GetIMAdapter(adapterName)
 	if !ok {
 		return s
 	}
@@ -301,7 +301,7 @@ func (m *Model) saveIMEditField(adapterName, field, value string) tea.Cmd {
 					// down while the user saw "saved".
 					if m.imManager != nil && m.isAdapterRunning(adapterName) {
 						m.imManager.StopAdapter(adapterName)
-						if err := im.StartNamedAdapter(context.Background(), m.config.IM, adapterName, m.imManager); err != nil {
+						if err := im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), adapterName, m.imManager); err != nil {
 							return imEditResultMsg{adapterName: adapterName, field: field, err: fmt.Errorf("saved, but adapter restart failed: %w", err)}
 						}
 					}

--- a/internal/tui/im_panel.go
+++ b/internal/tui/im_panel.go
@@ -418,7 +418,7 @@ func (m *Model) disableAllIMChannels() tea.Cmd {
 		if m.config != nil {
 			return configMutationMsg{
 				apply: func(m *Model) error {
-					for name := range m.config.IM.Adapters {
+					for name := range m.config.IMSnapshot().Adapters {
 						if err := m.config.SetIMAdapterEnabled(name, false); err != nil {
 							return fmt.Errorf("persist disable %s failed: %w", name, err)
 						}
@@ -452,7 +452,7 @@ func (m *Model) enableAllIMChannels() tea.Cmd {
 		if m.config != nil {
 			return configMutationMsg{
 				apply: func(m *Model) error {
-					for name := range m.config.IM.Adapters {
+					for name := range m.config.IMSnapshot().Adapters {
 						if err := m.config.SetIMAdapterEnabled(name, true); err != nil {
 							return fmt.Errorf("persist enable %s failed: %w", name, err)
 						}
@@ -576,7 +576,7 @@ func (m Model) imChannelEntries() []imChannelEntry {
 		// instance changed it, or ApplyAdapterConfig hasn't run yet.
 		configDisabled := false
 		if m.config != nil {
-			if ac, ok := m.config.IM.Adapters[adapterName]; ok {
+			if ac, ok := m.config.GetIMAdapter(adapterName); ok {
 				configDisabled = !ac.Enabled
 			}
 		}

--- a/internal/tui/im_runtime_shared.go
+++ b/internal/tui/im_runtime_shared.go
@@ -33,7 +33,7 @@ func (m *Model) ensureCurrentWorkspaceIMManager(unavailableErr, disabledErr stri
 	}
 
 	adapters := make(map[string]bool)
-	for name, acfg := range m.config.IM.Adapters {
+	for name, acfg := range m.config.IMSnapshot().Adapters {
 		adapters[name] = acfg.Enabled
 	}
 	runtimeInit, err := im.InitRuntime(im.RuntimeInitOptions{
@@ -122,7 +122,7 @@ func (m *Model) startIMRuntimeChain(unavailableErr, disabledErr string, autoEnab
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	if _, err := im.StartCurrentBindingAdapter(ctx, m.config.IM, m.imManager); err != nil {
+	if _, err := im.StartCurrentBindingAdapter(ctx, m.config.IMSnapshot(), m.imManager); err != nil {
 		// Roll back: without this the next call sees imManager != nil and
 		// short-circuits to fake success forever (#1379).
 		mgr := m.imManager

--- a/internal/tui/irc_panel.go
+++ b/internal/tui/irc_panel.go
@@ -331,7 +331,7 @@ func (m *Model) startIRCAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return fmt.Errorf(m.t("panel.irc.error.not_configured"), name)
 	}
@@ -344,7 +344,7 @@ func (m *Model) startIRCAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformIRC)) {
 		return fmt.Errorf(m.t("panel.irc.error.not_irc_adapter"), name)
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m *Model) ensureIRCRuntime() error {
@@ -380,7 +380,7 @@ func (m *Model) bindIRCEntry(entry ircBindingEntry) tea.Cmd {
 			}
 			return ircBindResultMsg{message: m.t("panel.irc.message.bound_success")}
 		}
-		if cfg, ok := m.config.IM.Adapters[entry.Adapter]; m.config != nil && ok && !cfg.Enabled {
+		if cfg, ok := m.config.GetIMAdapter(entry.Adapter); m.config != nil && ok && !cfg.Enabled {
 			return configMutationMsg{
 				apply: func(m *Model) error {
 					return m.config.SetIMAdapterEnabled(entry.Adapter, true)
@@ -454,7 +454,7 @@ func (m Model) ircBindingEntries() []ircBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformIRC)) {
 			keys = append(keys, name)
 		}
@@ -479,7 +479,7 @@ func (m Model) ircBindingEntries() []ircBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     statePtr,
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/matrix_panel.go
+++ b/internal/tui/matrix_panel.go
@@ -363,7 +363,7 @@ func (m *Model) startMatAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return fmt.Errorf(m.t("panel.matrix.error.not_configured"), name)
 	}
@@ -376,7 +376,7 @@ func (m *Model) startMatAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformMatrix)) {
 		return fmt.Errorf(m.t("panel.matrix.error.not_matrix_adapter"), name)
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m *Model) ensureMatRuntime() error {
@@ -410,7 +410,7 @@ func (m *Model) bindMatEntry(entry matrixBindingEntry) tea.Cmd {
 			}
 			return matrixBindResultMsg{message: m.t("panel.matrix.message.bound_success")}
 		}
-		if cfg, ok := m.config.IM.Adapters[entry.Adapter]; m.config != nil && ok && !cfg.Enabled {
+		if cfg, ok := m.config.GetIMAdapter(entry.Adapter); m.config != nil && ok && !cfg.Enabled {
 			return configMutationMsg{
 				apply: func(m *Model) error {
 					return m.config.SetIMAdapterEnabled(entry.Adapter, true)
@@ -481,7 +481,7 @@ func (m Model) matrixBindingEntries() []matrixBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformMatrix)) {
 			keys = append(keys, name)
 		}
@@ -506,7 +506,7 @@ func (m Model) matrixBindingEntries() []matrixBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     statePtr,
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/mattermost_panel.go
+++ b/internal/tui/mattermost_panel.go
@@ -352,7 +352,7 @@ func (m *Model) startMMAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return fmt.Errorf(m.t("panel.mattermost.error.not_configured"), name)
 	}
@@ -365,7 +365,7 @@ func (m *Model) startMMAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformMattermost)) {
 		return fmt.Errorf(m.t("panel.mattermost.error.not_mm_adapter"), name)
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m *Model) ensureMMRuntime() error {
@@ -399,7 +399,7 @@ func (m *Model) bindMMEntry(entry mattermostBindingEntry) tea.Cmd {
 			}
 			return mattermostBindResultMsg{message: m.t("panel.mattermost.message.bound_success")}
 		}
-		if cfg, ok := m.config.IM.Adapters[entry.Adapter]; m.config != nil && ok && !cfg.Enabled {
+		if cfg, ok := m.config.GetIMAdapter(entry.Adapter); m.config != nil && ok && !cfg.Enabled {
 			return configMutationMsg{
 				apply: func(m *Model) error {
 					return m.config.SetIMAdapterEnabled(entry.Adapter, true)
@@ -470,7 +470,7 @@ func (m Model) mattermostBindingEntries() []mattermostBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformMattermost)) {
 			keys = append(keys, name)
 		}
@@ -495,7 +495,7 @@ func (m Model) mattermostBindingEntries() []mattermostBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     statePtr,
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1182,11 +1182,14 @@ func (m *Model) refreshIMRuntimeHooks() {
 		}
 	})
 	// Set up restart callback so UnmuteBinding/EnableBinding can reconnect adapters.
+	// #2152: snapshot the IM config at registration time — the callback outlives
+	// this frame and must not read the live Adapters map concurrently with
+	// Update-loop writers.
 	if m.config != nil {
-		cfg := m.config
+		snap := m.config.IMSnapshot()
 		mgr := m.imManager
 		m.imManager.SetOnRestart(func(adapterName string) error {
-			return im.StartNamedAdapter(context.Background(), cfg.IM, adapterName, mgr)
+			return im.StartNamedAdapter(context.Background(), snap, adapterName, mgr)
 		})
 	}
 }
@@ -1209,7 +1212,7 @@ func (m *Model) bindIMSession() {
 	})
 	if m.config != nil {
 		adapters := make(map[string]bool)
-		for name, cfg := range m.config.IM.Adapters {
+		for name, cfg := range m.config.IMSnapshot().Adapters {
 			adapters[name] = cfg.Enabled
 		}
 		m.imManager.ApplyAdapterConfig(adapters)

--- a/internal/tui/nostr_panel.go
+++ b/internal/tui/nostr_panel.go
@@ -422,7 +422,7 @@ func (m *Model) nostrAdapterNeedsEnable(name string) (bool, error) {
 			return false, nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return false, fmt.Errorf(m.t("panel.nostr.error.not_configured"), name)
 	}
@@ -434,7 +434,7 @@ func (m *Model) nostrAdapterNeedsEnable(name string) (bool, error) {
 
 // startEnabledNostrAdapter brings the (already-enabled) adapter up.
 func (m *Model) startEnabledNostrAdapter(name string) error {
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 // enableNostrAdapterMutation returns the configMutationMsg that performs the
@@ -560,7 +560,7 @@ func (m Model) nostrBindingEntries() []nostrBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformNostr)) {
 			keys = append(keys, name)
 		}
@@ -585,7 +585,7 @@ func (m Model) nostrBindingEntries() []nostrBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     statePtr,
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/pc_panel.go
+++ b/internal/tui/pc_panel.go
@@ -290,7 +290,7 @@ func (m *Model) ensurePCReady() error {
 	if m.pcAdapter() != nil {
 		return nil
 	}
-	_, err := im.StartPCAdapterOnly(context.Background(), m.config.IM, m.imManager)
+	_, err := im.StartPCAdapterOnly(context.Background(), m.config.IMSnapshot(), m.imManager)
 	if err != nil {
 		return fmt.Errorf("starting PrivateClaw adapter: %w", err)
 	}
@@ -430,7 +430,7 @@ func (m *Model) pcAdapter() im.PCAdapterAPI {
 func (m *Model) pcAdapterName() string {
 	// Prefer explicit config adapter name
 	if m.config != nil {
-		for name, adapter := range m.config.IM.Adapters {
+		for name, adapter := range m.config.IMSnapshot().Adapters {
 			if adapter.Enabled && strings.EqualFold(adapter.Platform, string(im.PlatformPrivateClaw)) {
 				return name
 			}

--- a/internal/tui/qq_panel.go
+++ b/internal/tui/qq_panel.go
@@ -269,7 +269,7 @@ func (m *Model) bindQQEntry(entry qqBindingEntry) tea.Cmd {
 		}
 		// #1387-B: a disabled adapter's auto-enable runs on the Update loop
 		// via configMutationMsg; the bind chain continues in next().
-		if cfg, ok := m.config.IM.Adapters[entry.Adapter]; m.config != nil && ok && !cfg.Enabled {
+		if cfg, ok := m.config.GetIMAdapter(entry.Adapter); m.config != nil && ok && !cfg.Enabled {
 			return configMutationMsg{
 				apply: func(m *Model) error {
 					return m.config.SetIMAdapterEnabled(entry.Adapter, true)
@@ -397,7 +397,7 @@ func (m *Model) startQQAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return errors.New(m.t("panel.qq.error.not_configured", name))
 	}
@@ -410,7 +410,7 @@ func (m *Model) startQQAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformQQ)) {
 		return errors.New(m.t("panel.qq.error.not_qq_adapter", name))
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m Model) qqBindingEntries() []qqBindingEntry {
@@ -436,7 +436,7 @@ func (m Model) qqBindingEntries() []qqBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformQQ)) {
 			keys = append(keys, name)
 		}
@@ -457,7 +457,7 @@ func (m Model) qqBindingEntries() []qqBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     qqStatePtr(adapterStates[name]),
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/signal_panel.go
+++ b/internal/tui/signal_panel.go
@@ -480,7 +480,7 @@ func (m *Model) startSigAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return fmt.Errorf(m.t("panel.signal.error.not_configured"), name)
 	}
@@ -496,7 +496,7 @@ func (m *Model) startSigAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformSignal)) {
 		return fmt.Errorf(m.t("panel.signal.error.not_signal_adapter"), name)
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m *Model) ensureSigRuntime() error {
@@ -517,7 +517,7 @@ func (m *Model) startSignalAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return fmt.Errorf(m.t("panel.signal.error.not_configured"), name)
 	}
@@ -533,7 +533,7 @@ func (m *Model) startSignalAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformSignal)) {
 		return fmt.Errorf(m.t("panel.signal.error.not_signal_adapter"), name)
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m *Model) bindSigEntry(entry signalBindingEntry) tea.Cmd {
@@ -550,7 +550,7 @@ func (m *Model) bindSigEntry(entry signalBindingEntry) tea.Cmd {
 		// config map from this Cmd goroutine while the render loop ranged
 		// it. qq pattern: mutate via configMutationMsg, continue in next().
 		if m.config != nil {
-			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+			if cfg, ok := m.config.GetIMAdapter(entry.Adapter); ok && !cfg.Enabled {
 				return configMutationMsg{
 					apply: func(m *Model) error {
 						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
@@ -645,7 +645,7 @@ func (m Model) signalBindingEntries() []signalBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformSignal)) {
 			keys = append(keys, name)
 		}
@@ -670,7 +670,7 @@ func (m Model) signalBindingEntries() []signalBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     statePtr,
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/slack_panel.go
+++ b/internal/tui/slack_panel.go
@@ -240,7 +240,7 @@ func (m *Model) bindSlackEntry(entry slackBindingEntry) tea.Cmd {
 		// it. Follow the qq pattern: mutate via configMutationMsg, continue
 		// the bind in next().
 		if m.config != nil {
-			if cfg, ok := m.config.IM.Adapters[entry.Adapter]; ok && !cfg.Enabled {
+			if cfg, ok := m.config.GetIMAdapter(entry.Adapter); ok && !cfg.Enabled {
 				return configMutationMsg{
 					apply: func(m *Model) error {
 						return m.config.SetIMAdapterEnabled(entry.Adapter, true)
@@ -348,7 +348,7 @@ func (m *Model) createSlackAdapterCmd(spec string) tea.Cmd {
 				// #1794 case 2: auto-enable on the Update loop - the next()
 				// closure's startXXXAdapterIfNeeded used to write the map
 				// from the Cmd goroutine (#1367 family).
-				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+				if cfg, ok := m.config.GetIMAdapter(name); ok && !cfg.Enabled {
 					return m.config.SetIMAdapterEnabled(name, true)
 				}
 				return nil
@@ -413,7 +413,7 @@ func (m *Model) slackEnableMutation(name string, next func(m *Model) tea.Msg) te
 		},
 		next: func(m *Model) tea.Cmd {
 			return func() tea.Msg {
-				if err := im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager); err != nil {
+				if err := im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager); err != nil {
 					return slackBindResultMsg{err: err}
 				}
 				if next == nil {
@@ -442,7 +442,7 @@ func (m *Model) startSlackAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return errors.New(m.t("panel.slack.error.not_configured", name))
 	}
@@ -456,7 +456,7 @@ func (m *Model) startSlackAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformSlack)) {
 		return errors.New(m.t("panel.slack.error.not_slack_adapter", name))
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m Model) slackBindingEntries() []slackBindingEntry {
@@ -482,7 +482,7 @@ func (m Model) slackBindingEntries() []slackBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformSlack)) {
 			keys = append(keys, name)
 		}
@@ -503,7 +503,7 @@ func (m Model) slackBindingEntries() []slackBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     slackStatePtr(adapterStates[name]),
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/tg_panel.go
+++ b/internal/tui/tg_panel.go
@@ -340,7 +340,7 @@ func (m *Model) startTGAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return errors.New(m.t("panel.tg.error.not_configured", name))
 	}
@@ -353,7 +353,7 @@ func (m *Model) startTGAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformTelegram)) {
 		return errors.New(m.t("panel.tg.error.not_tg_adapter", name))
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m Model) tgBindingEntries() []tgBindingEntry {
@@ -379,7 +379,7 @@ func (m Model) tgBindingEntries() []tgBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformTelegram)) {
 			keys = append(keys, name)
 		}
@@ -400,7 +400,7 @@ func (m Model) tgBindingEntries() []tgBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     tgStatePtr(adapterStates[name]),
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/twitch_panel.go
+++ b/internal/tui/twitch_panel.go
@@ -304,7 +304,7 @@ func (m *Model) createTwitchAdapterCmd(spec string) tea.Cmd {
 				if err := m.config.AddIMAdapter(name, adapter); err != nil {
 					return err
 				}
-				if cfg, ok := m.config.IM.Adapters[name]; ok && !cfg.Enabled {
+				if cfg, ok := m.config.GetIMAdapter(name); ok && !cfg.Enabled {
 					return m.config.SetIMAdapterEnabled(name, true)
 				}
 				return nil
@@ -341,7 +341,7 @@ func (m *Model) startTwitchAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return fmt.Errorf(m.t("panel.twitch.error.not_configured"), name)
 	}
@@ -357,7 +357,7 @@ func (m *Model) startTwitchAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformTwitch)) {
 		return fmt.Errorf(m.t("panel.twitch.error.not_twitch_adapter"), name)
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m *Model) ensureTwitchRuntime() error {
@@ -445,7 +445,7 @@ func (m Model) twitchBindingEntries() []twitchBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformTwitch)) {
 			keys = append(keys, name)
 		}
@@ -470,7 +470,7 @@ func (m Model) twitchBindingEntries() []twitchBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     statePtr,
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/view_sidebar.go
+++ b/internal/tui/view_sidebar.go
@@ -297,7 +297,7 @@ func (m Model) sidebarIMAdapters() []im.AdapterState {
 			}
 			result = append(result, state)
 		} else if m.config != nil {
-			if adapter, ok := m.config.IM.Adapters[name]; ok && adapter.Enabled {
+			if adapter, ok := m.config.GetIMAdapter(name); ok && adapter.Enabled {
 				status := m.t("im.status.not_started")
 				if mutedAdapters[name] {
 					status = "muted"

--- a/internal/tui/wechat_panel.go
+++ b/internal/tui/wechat_panel.go
@@ -421,7 +421,7 @@ func (m *Model) saveWechatBotToken(botToken string) tea.Cmd {
 				adapterName := "wechat"
 				n := 2
 				for {
-					if _, exists := m.config.IM.Adapters[adapterName]; !exists {
+					if _, exists := func() (bool, bool) { _, ok := m.config.GetIMAdapter(adapterName); return ok, ok }(); !exists {
 						break
 					}
 					adapterName = fmt.Sprintf("wechat-%d", n)
@@ -445,7 +445,7 @@ func (m *Model) saveWechatBotToken(botToken string) tea.Cmd {
 					adapterName := m.lastWechatAdapterName
 					// Start the adapter (binding happens when the first inbound message triggers pairing)
 					if m.imManager != nil {
-						if err := im.StartNamedAdapter(context.Background(), m.config.IM, adapterName, m.imManager); err != nil {
+						if err := im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), adapterName, m.imManager); err != nil {
 							debug.Log("wechat", "saveWechatBotToken: StartNamedAdapter failed: %v", err)
 							// #1398-C: adapter saved but NOT running - surfacing this as
 							// success made users believe the config was live. The token IS
@@ -484,14 +484,14 @@ func (m *Model) startWechatAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return fmt.Errorf("wechat adapter %s not configured", name)
 	}
 	if !adapterCfg.Enabled {
 		return fmt.Errorf("wechat adapter %s is disabled", name)
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 // This only registers the workspace association — the ChannelID/TargetID
@@ -605,7 +605,7 @@ func (m *Model) wechatBindingEntries() []wechatBindingEntry {
 
 	// List all wechat adapters from config (not just bound ones)
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformWechat)) {
 			keys = append(keys, name)
 		}
@@ -619,7 +619,7 @@ func (m *Model) wechatBindingEntries() []wechatBindingEntry {
 		}
 		entries = append(entries, wechatBindingEntry{
 			Adapter:      name,
-			Disabled:     !m.config.IM.Adapters[name].Enabled,
+			Disabled:     !m.config.IMAdapterEnabled(name),
 			OccupiedBy:   occupied[name],
 			AdapterState: state,
 			Bound:        bound[name],

--- a/internal/tui/wecom_panel.go
+++ b/internal/tui/wecom_panel.go
@@ -365,7 +365,7 @@ func (m *Model) wecomEnableMutation(name string, next func(m *Model) tea.Msg) te
 		},
 		next: func(m *Model) tea.Cmd {
 			return func() tea.Msg {
-				if err := im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager); err != nil {
+				if err := im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager); err != nil {
 					return wecomBindResultMsg{err: err}
 				}
 				if next == nil {
@@ -394,7 +394,7 @@ func (m *Model) startWeComAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return fmt.Errorf(m.t("panel.wecom.error.not_configured"), name)
 	}
@@ -409,7 +409,7 @@ func (m *Model) startWeComAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformWeCom)) {
 		return fmt.Errorf(m.t("panel.wecom.error.not_wecom_adapter"), name)
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m *Model) ensureWeComRuntime() error {
@@ -492,7 +492,7 @@ func (m Model) wecomBindingEntries() []wecomBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformWeCom)) {
 			keys = append(keys, name)
 		}
@@ -517,7 +517,7 @@ func (m Model) wecomBindingEntries() []wecomBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     statePtr,
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}

--- a/internal/tui/whatsapp_panel.go
+++ b/internal/tui/whatsapp_panel.go
@@ -442,7 +442,7 @@ func (m *Model) waEnableMutation(name string, next func(m *Model) tea.Msg) tea.M
 		},
 		next: func(m *Model) tea.Cmd {
 			return func() tea.Msg {
-				if err := im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager); err != nil {
+				if err := im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager); err != nil {
 					return whatsappBindResultMsg{err: err}
 				}
 				if next == nil {
@@ -471,7 +471,7 @@ func (m *Model) startWAAdapterIfNeeded(name string) error {
 			return nil
 		}
 	}
-	adapterCfg, ok := m.config.IM.Adapters[name]
+	adapterCfg, ok := m.config.GetIMAdapter(name)
 	if !ok {
 		return fmt.Errorf("adapter %q not configured", name)
 	}
@@ -486,7 +486,7 @@ func (m *Model) startWAAdapterIfNeeded(name string) error {
 	if !strings.EqualFold(adapterCfg.Platform, string(im.PlatformWhatsApp)) {
 		return fmt.Errorf("adapter %q is not a WhatsApp adapter", name)
 	}
-	return im.StartNamedAdapter(context.Background(), m.config.IM, name, m.imManager)
+	return im.StartNamedAdapter(context.Background(), m.config.IMSnapshot(), name, m.imManager)
 }
 
 func (m Model) waBindingEntries() []whatsappBindingEntry {
@@ -512,7 +512,7 @@ func (m Model) waBindingEntries() []whatsappBindingEntry {
 		}
 	}
 	keys := make([]string, 0, len(m.config.IM.Adapters))
-	for name, adapter := range m.config.IM.Adapters {
+	for name, adapter := range m.config.IMSnapshot().Adapters {
 		if strings.EqualFold(adapter.Platform, string(im.PlatformWhatsApp)) {
 			keys = append(keys, name)
 		}
@@ -536,7 +536,7 @@ func (m Model) waBindingEntries() []whatsappBindingEntry {
 			WorkspaceChannel: workspaceChannel,
 			OccupiedBy:       occupied[name],
 			AdapterState:     statePtr,
-			Disabled:         !m.config.IM.Adapters[name].Enabled,
+			Disabled:         !m.config.IMAdapterEnabled(name),
 			Muted:            bindingByAdapter[name].Muted,
 		})
 	}


### PR DESCRIPTION
Closes #2152

## Root cause
#1367/#1794 migrated all `c.IM.Adapters` **writes** onto the Update loop, but the **reads** stayed in TUI Cmd goroutines — 47 read sites across 16 IM panel files. A bind/create Cmd that lives for seconds (waitForXxxAdapterHealthy polls up to 10s) racing an Update-loop toggle is a Go fatal `concurrent map read and map write`. `Config` had no instance mutex (only file-level locks), so both sides ran bare. `im.StartNamedAdapter(ctx, m.config.IM, ...)` additionally handed the live map to long-lived adapters.

## Changes
- **Config writes**: `imAdaptersMu sync.RWMutex`; six runtime writers in config_save.go take it; `PatchIMAdapter` splits into locked public entry + unlocked core (mutex not reentrant)
- **Config reads**: new im_access.go — GetIMAdapter (deep copy) / IMAdapterEnabled (hot path) / IMSnapshot (whole-config deep copy owning its map)
- **TUI**: 47 reads across 16 panels + im_edit/im_runtime_shared/view_sidebar/pc_panel/model.go → locked accessors; Start*Adapter hands over IMSnapshot(); restart callback snapshots at registration
- Load-time normalize/expandEnv stay unguarded (single-threaded)

## Verification
- `go test -race -run Issue2152 ./internal/config/` clean under -race (first draft deadlocked its own WaitGroups — caught and fixed, noted in test)
- `TestIssue2152_SnapshotIsDeepCopy` — nested mutation never leaks into live config
- `go test ./internal/tui/` green (11s); full build green
- instance_test.go merge table → `*Config` (RWMutex embed; vet: range copies lock)

Co-Authored-By: ggcode <noreply@ggcode.dev>