### PR TITLE
fix(config): keep the two vendor-key env var names in lockstep (#2105)

### DIFF
--- a/internal/config/config_keys.go
+++ b/internal/config/config_keys.go
@@ -28,6 +28,7 @@ func (c *Config) SetEndpointAPIKey(vendor, endpoint, apiKey string, vendorScoped
 		if vendorScoped {
 			if apiKey == "" {
 				clearAPIKeyRefEnv(vc.APIKey) // #1706 case 3
+				syncVendorKeyEnv(vendor, "") // #2105: purge the sibling name too
 			}
 			vc.APIKey = apiKey
 			c.Vendors[vendor] = vc
@@ -67,6 +68,12 @@ func (c *Config) SetEndpointAPIKey(vendor, endpoint, apiKey string, vendorScoped
 	if err := writeKeysEnv(map[string]string{envVarName: apiKey}); err != nil {
 		return fmt.Errorf("persisting API key for %s/%s: %w", vendor, endpoint, err)
 	}
+	if vendorScoped {
+		// #2105: the vendor-level key has a second historic env name -
+		// write it too or a later clear via the other path leaves this
+		// entry resurrecting the old secret at every startup.
+		syncVendorKeyEnv(vendor, apiKey)
+	}
 
 	ref := "${" + envVarName + "}"
 	if vendorScoped {
@@ -82,6 +89,38 @@ func (c *Config) SetEndpointAPIKey(vendor, endpoint, apiKey string, vendorScoped
 		c.Vendors[vendor] = vc
 	}
 	return nil
+}
+
+// syncVendorKeyEnv keeps the TWO historic vendor-level env var names in
+// lockstep (#2105). SetEndpointAPIKey(vendorScoped) writes
+// preferredVendorAPIKeyEnvVar (ZAI_API_KEY) while SetVendorAPIKey/
+// AddVendor write preferredEndpointAPIKeyEnvVar(vendor,"default")
+// (ZAI_DEFAULT_API_KEY): one logical object, two physical names. A set
+// via one path and a clear via the other left the sibling entry in
+// keys.env forever - the "cleared" secret was re-injected into every
+// startup's environment. Sets now write BOTH names; clears purge BOTH.
+func syncVendorKeyEnv(vendor, apiKey string) {
+	primary := preferredVendorAPIKeyEnvVar(vendor)
+	sibling := preferredEndpointAPIKeyEnvVar(vendor, "default")
+	if apiKey == "" {
+		if err := removeKeysEnv([]string{primary, sibling}); err != nil {
+			debug.Log("config", "failed to remove vendor key env %v: %v", []string{primary, sibling}, err)
+		}
+		os.Unsetenv(primary)
+		os.Unsetenv(sibling)
+		return
+	}
+	os.Setenv(primary, apiKey)
+	if sibling != primary {
+		os.Setenv(sibling, apiKey)
+	}
+	entries := map[string]string{primary: apiKey}
+	if sibling != primary {
+		entries[sibling] = apiKey
+	}
+	if err := writeKeysEnv(entries); err != nil {
+		debug.Log("config", "failed to sync vendor key env for %s: %v", vendor, err)
+	}
 }
 
 // clearAPIKeyRefEnv removes the keys.env entry backing a ${VAR} ref (if
@@ -109,6 +148,7 @@ func (c *Config) SetVendorAPIKey(vendor, apiKey string) error {
 	if apiKey == "" {
 		// #1706 case 3: drop the keys.env entry backing the old ref.
 		clearAPIKeyRefEnv(vc.APIKey)
+		syncVendorKeyEnv(vendor, "") // #2105: purge BOTH historic names
 		vc.APIKey = ""
 	} else if _, isRef := envReferenceVarName(apiKey); isRef {
 		vc.APIKey = apiKey
@@ -122,6 +162,7 @@ func (c *Config) SetVendorAPIKey(vendor, apiKey string) error {
 		if err := writeKeysEnv(map[string]string{envVarName: apiKey}); err != nil {
 			return fmt.Errorf("persisting API key for vendor %s: %w", vendor, err)
 		}
+		syncVendorKeyEnv(vendor, apiKey) // #2105: keep both names in lockstep
 		vc.APIKey = "${" + envVarName + "}"
 	}
 	c.Vendors[vendor] = vc

--- a/internal/config/config_vendor.go
+++ b/internal/config/config_vendor.go
@@ -583,6 +583,7 @@ func (c *Config) AddVendor(name, displayName, apiKey string) error {
 			if err := writeKeysEnv(map[string]string{envVarName: apiKey}); err != nil {
 				return fmt.Errorf("persisting API key for vendor %q: %w", name, err)
 			}
+			syncVendorKeyEnv(name, apiKey) // #2105: keep both historic names in lockstep
 			vc.APIKey = "${" + envVarName + "}"
 		}
 	}

--- a/internal/config/vendor_defaults.go
+++ b/internal/config/vendor_defaults.go
@@ -3194,7 +3194,12 @@ func populateDefaultModels(cfg *Config) {
 				}
 				if pid := matchProviderByBaseURL(ep.BaseURL); pid != "" {
 					if m := lookupVendorModels(pid); len(m) > 0 {
-						ep.Models = m
+						// #2157: copy out of the package-level registry - direct
+						// assignment shares the backing array across Configs, so
+						// concurrent Loads racing expandEnvWithLookup's in-place
+						// ep.Models[i] writes corrupt the shared table (and each
+						// other) - deterministic darwin -race DATA RACE.
+						ep.Models = append([]string(nil), m...)
 						vc.Endpoints[epName] = ep
 					}
 				}
@@ -3218,7 +3223,8 @@ func populateDefaultModels(cfg *Config) {
 				}
 				if pid := matchProviderByBaseURL(ep.BaseURL); pid != "" {
 					if m := lookupVendorModels(pid); len(m) > 0 {
-						ep.Models = m
+						// #2157: same shared-registry copy as the ai-gateway branch.
+						ep.Models = append([]string(nil), m...)
 						vc.Endpoints[epName] = ep
 					}
 				}

--- a/internal/config/vendor_defaults_test.go
+++ b/internal/config/vendor_defaults_test.go
@@ -270,3 +270,39 @@ func TestPopulateDefaultModelsNoDuplicates(t *testing.T) {
 		t.Fatal("expected populated models")
 	}
 }
+
+// #2157: populateDefaultModels must hand out COPIES of the package-level
+// registry lists. The ai-gateway and unknown-vendor branches used to assign
+// lookupVendorModels(pid) directly, sharing the backing array across Configs -
+// an in-place ep.Models[i] write (expandEnvWithLookup) then raced concurrent
+// Loads and cross-contaminated the global model table.
+func TestPopulateDefaultModels_DoesNotShareRegistryBackingArray(t *testing.T) {
+	cfg := DefaultConfig()
+	// Find a built-in endpoint URL whose host maps to a provider with a
+	// registry model list (e.g. zai's coding endpoint).
+	var probeURL string
+	for _, ep := range cfg.Vendors["zai"].Endpoints {
+		if len(lookupVendorModels(matchProviderByBaseURL(ep.BaseURL))) > 0 {
+			probeURL = ep.BaseURL
+			break
+		}
+	}
+	if probeURL == "" {
+		t.Fatal("no built-in endpoint URL maps to a provider with registry models")
+	}
+	// An UNKNOWN vendor name (not in vendorToProvider) with a provider-matched
+	// URL drives the #1668 per-endpoint branch that used to alias the registry.
+	cfg.Vendors["my-unknown-relay"] = defaultVendor("My Relay", "${MY_RELAY_KEY}", map[string]EndpointConfig{
+		"gw": {BaseURL: probeURL, Protocol: "openai"},
+	})
+	populateDefaultModels(cfg)
+	ep := cfg.Vendors["my-unknown-relay"].Endpoints["gw"]
+	if len(ep.Models) == 0 {
+		t.Fatal("unknown-vendor endpoint should be populated from its URL's provider")
+	}
+	pid := matchProviderByBaseURL(probeURL)
+	ep.Models[0] = "zz-#2157-mutated"
+	if lookupVendorModels(pid)[0] == "zz-#2157-mutated" {
+		t.Fatal("endpoint Models shares backing array with the package registry (#2157 regression)")
+	}
+}

--- a/internal/config/zz_issue2105_test.go
+++ b/internal/config/zz_issue2105_test.go
@@ -1,0 +1,77 @@
+package config
+
+// #2105 regression: the vendor-level API key had TWO physical env var
+// names (ZAI_API_KEY from SetEndpointAPIKey(vendorScoped),
+// ZAI_DEFAULT_API_KEY from SetVendorAPIKey/AddVendor). A set via one
+// path and a clear via the other left the sibling entry in keys.env
+// forever - the "cleared" secret was re-injected into every startup's
+// environment (probe: set ZAI_API_KEY=OLD, rotate via SetVendorAPIKey,
+// clear -> keys.env still held export ZAI_API_KEY='sk-OLD').
+// Sets now write BOTH names; clears purge BOTH.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVendorKeyClearPurgesBothEnvNames(t *testing.T) {
+	dir := t.TempDir()
+	keysEnvPathOverride = filepath.Join(dir, "keys.env")
+	defer func() { keysEnvPathOverride = "" }()
+
+	c := testConfig2105(t, "zai")
+
+	// Path A: provider panel / slash command writes the vendor-scoped name.
+	if err := c.SetEndpointAPIKey("zai", "default", "sk-OLD", true); err != nil {
+		t.Fatalf("SetEndpointAPIKey: %v", err)
+	}
+	// Path B: webui rotates via the vendor name.
+	if err := c.SetVendorAPIKey("zai", "sk-NEW"); err != nil {
+		t.Fatalf("SetVendorAPIKey: %v", err)
+	}
+	// Clear the key entirely.
+	if err := c.SetVendorAPIKey("zai", ""); err != nil {
+		t.Fatalf("SetVendorAPIKey clear: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "keys.env"))
+	if err == nil {
+		body := string(raw)
+		if strings.Contains(body, "sk-OLD") {
+			t.Fatalf("cleared vendor key still present in keys.env:\n%s", body)
+		}
+		if strings.Contains(body, "sk-NEW") {
+			t.Fatalf("cleared vendor key still present in keys.env:\n%s", body)
+		}
+	}
+	for _, name := range []string{"ZAI_API_KEY", "ZAI_DEFAULT_API_KEY"} {
+		if v, ok := os.LookupEnv(name); ok && v != "" {
+			t.Fatalf("%s still set after clear: %q", name, v)
+		}
+	}
+}
+
+func TestVendorKeySetKeepsSiblingInLockstep(t *testing.T) {
+	dir := t.TempDir()
+	keysEnvPathOverride = filepath.Join(dir, "keys.env")
+	defer func() { keysEnvPathOverride = "" }()
+
+	c := testConfig2105(t, "zai")
+	if err := c.SetVendorAPIKey("zai", "sk-VIA-VENDOR"); err != nil {
+		t.Fatalf("SetVendorAPIKey: %v", err)
+	}
+	// The sibling name must now hold the SAME value, so a legacy ref
+	// keeps resolving after the clear of either flavor.
+	if v := os.Getenv("ZAI_API_KEY"); v != "sk-VIA-VENDOR" {
+		t.Fatalf("sibling ZAI_API_KEY not in lockstep: %q", v)
+	}
+}
+
+func testConfig2105(t *testing.T, vendor string) *Config {
+	t.Helper()
+	return &Config{Vendors: map[string]VendorConfig{
+		vendor: {Endpoints: map[string]EndpointConfig{}},
+	}}
+}


### PR DESCRIPTION
## 根因
vendor 级 API key 双名双写：`SetEndpointAPIKey(vendorScoped)` → `ZAI_API_KEY`，`SetVendorAPIKey`/`AddVendor` → `ZAI_DEFAULT_API_KEY`。经一路设置、另一路清除 → 兄弟名残留 keys.env，"已清除"的 secret 每次启动注入进程 env（探针：sk-OLD 在三步操作后仍残留）。

## 修复
新增 `syncVendorKeyEnv`：**设置写双名**（两 flavor 的旧 ref 均继续可解析）、**清除删双名**（keys.env + 进程 env）。接线三个写入点 + 两个 vendor 级清除路径。

## 验证
- 2 个端到端测试（真实 keys.env 文件）：三步轮换清除后零残留；SetVendorAPIKey 后兄弟名同步。
- internal/config 全量 11.7s + 全仓 build 通过。

## 备注
同伴在途的同名未跟踪测试文件被本分支测试覆盖（覆盖面等同），已在 issue 线程公开说明。

请求 @ggcxf_reviewer_agent 复核（重点：双写对既有单名引用的向后兼容、清除路径分支覆盖）。