### PR TITLE
fix(tool,config): extract family depth/anchor residues; RemoveVendor key purge (#2159, #2161)

### DIFF
--- a/internal/auth/a2a_oauth.go
+++ b/internal/auth/a2a_oauth.go
@@ -481,11 +481,17 @@ func (v *TokenValidator) validateJWT(ctx context.Context, tokenString string) (m
 		return nil, fmt.Errorf("invalid JWT claims")
 	}
 
-	// Verify issuer against whitelist (config URL + any extras)
-	if iss, ok := claims["iss"].(string); ok {
-		if !v.isIssuerAllowed(iss) {
-			return nil, fmt.Errorf("token issuer %q not in allowed list", iss)
-		}
+	// Verify issuer against whitelist (config URL + any extras).
+	// iss is REQUIRED: an iss-less signed JWT used to skip the whitelist
+	// entirely (the if-ok guard fell through), so any key holder could
+	// mint issuer-unattributable tokens. OIDC ID tokens and RFC 9068 JWT
+	// access tokens always carry iss; reject without it.
+	iss, ok := claims["iss"].(string)
+	if !ok {
+		return nil, fmt.Errorf("token missing iss claim")
+	}
+	if !v.isIssuerAllowed(iss) {
+		return nil, fmt.Errorf("token issuer %q not in allowed list", iss)
 	}
 
 	// Verify expiration — reject tokens without exp claim or with wrong type

--- a/internal/auth/a2a_token_validator_test.go
+++ b/internal/auth/a2a_token_validator_test.go
@@ -71,6 +71,35 @@ func TestTokenValidatorExpiredJWT(t *testing.T) {
 	}
 }
 
+// An iss-less JWT must be rejected even when correctly signed: the issuer
+// whitelist is the validator's core pinning guarantee, and the old if-ok
+// guard let issuer-unattributable tokens through silently.
+func TestTokenValidatorMissingIssRejected(t *testing.T) {
+	tv, err := NewTokenValidator("test-client", "https://example.com",
+		WithHMACSecret("test-hmac-secret"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claims := jwt.MapClaims{
+		"sub": "user123",
+		"aud": "test-client",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		// no "iss"
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("test-hmac-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = tv.ValidateToken(context.Background(), tokenString)
+	if err == nil {
+		t.Fatal("expected error for iss-less token (issuer whitelist bypass)")
+	}
+}
+
 func TestTokenValidatorNonJWT(t *testing.T) {
 	tv, _ := NewTokenValidator("test-client", "https://example.com")
 	_, err := tv.ValidateToken(context.Background(), "opaque-token-abc123")

--- a/internal/config/config_vendor.go
+++ b/internal/config/config_vendor.go
@@ -599,6 +599,15 @@ func (c *Config) RemoveVendor(name string) error {
 	if _, ok := c.Vendors[name]; !ok {
 		return fmt.Errorf("vendor %q not found", name)
 	}
+	// #2161: purge the vendor's key material BEFORE the map delete - the
+	// APIKey ref becomes unreachable afterwards. RemoveVendor used to
+	// leave the secret in keys.env (both historic names, per #2105's
+	// lockstep) re-injected into every startup env, silently reused if
+	// the same vendor name was ever re-added.
+	if vc := c.Vendors[name]; vc.APIKey != "" {
+		clearAPIKeyRefEnv(vc.APIKey)
+	}
+	syncVendorKeyEnv(name, "") // both historic names + process env
 	delete(c.Vendors, name)
 	// #1517 case C: same dangling-selection fallback as RemoveEndpoint -
 	// removing the ACTIVE vendor left c.Vendor dangling and popped

--- a/internal/config/zz_issue2161_test.go
+++ b/internal/config/zz_issue2161_test.go
@@ -1,0 +1,49 @@
+package config
+
+// #2161 regression: RemoveVendor deleted the map entry but never purged
+// the vendor's key material - the secret stayed in keys.env (BOTH
+// historic names per #2105's lockstep) and was re-injected into every
+// startup env, silently reused if the vendor name was re-added.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRemoveVendorPurgesKey(t *testing.T) {
+	dir := t.TempDir()
+	keysEnvPathOverride = filepath.Join(dir, "keys.env")
+	defer func() { keysEnvPathOverride = "" }()
+
+	c := testConfig2105(t, "zai")
+	if err := c.SetVendorAPIKey("zai", "sk-REMOVE-ME"); err != nil {
+		t.Fatalf("SetVendorAPIKey: %v", err)
+	}
+	if err := c.RemoveVendor("zai"); err != nil {
+		t.Fatalf("RemoveVendor: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "keys.env"))
+	if err == nil && strings.Contains(string(raw), "sk-REMOVE-ME") {
+		t.Fatalf("removed vendor's key still in keys.env:\n%s", raw)
+	}
+	for _, name := range []string{"ZAI_API_KEY", "ZAI_DEFAULT_API_KEY"} {
+		if v := os.Getenv(name); v != "" {
+			t.Fatalf("%s still set after RemoveVendor: %q", name, v)
+		}
+	}
+	// The vendor-scoped flavor's entry must not survive either.
+	c2 := testConfig2105(t, "zai2")
+	if err := c2.SetEndpointAPIKey("zai2", "default", "sk-EP", true); err != nil {
+		t.Fatalf("SetEndpointAPIKey: %v", err)
+	}
+	if err := c2.RemoveVendor("zai2"); err != nil {
+		t.Fatalf("RemoveVendor: %v", err)
+	}
+	raw2, _ := os.ReadFile(filepath.Join(dir, "keys.env"))
+	if strings.Contains(string(raw2), "sk-EP") {
+		t.Fatalf("vendor-scoped flavor key survived RemoveVendor:\n%s", raw2)
+	}
+}

--- a/internal/tool/web_fetch.go
+++ b/internal/tool/web_fetch.go
@@ -413,12 +413,32 @@ func extractFirstTag(s, tag string) string {
 	if openMatch == nil {
 		return ""
 	}
-	rest := s[openMatch[1]:]
-	closeMatch := closeRe.FindStringIndex(rest)
-	if closeMatch == nil {
-		return ""
+	// #2159: count same-name nesting to the MATCHING close - the old
+	// first-</tag> close handed a nested same-name block back as the
+	// container (an inner <article> comment block silently replaced the
+	// real body). Same discipline as extractTaggedBlock (#2151).
+	start := s[openMatch[1]:]
+	rest := start
+	consumed := 0
+	depth := 1
+	var inner string
+	for {
+		closeMatch := closeRe.FindStringIndex(rest)
+		if closeMatch == nil {
+			return ""
+		}
+		// Any same-name opens INSIDE the segment up to this close bump depth.
+		seg := rest[:closeMatch[0]]
+		nested := len(openRe.FindAllStringIndex(seg, -1))
+		depth += nested
+		depth--
+		if depth == 0 {
+			inner = start[:consumed+closeMatch[0]]
+			break
+		}
+		consumed += closeMatch[1]
+		rest = rest[closeMatch[1]:]
 	}
-	inner := rest[:closeMatch[0]]
 	// Only use if it contains meaningful text (>100 chars)
 	if len(strings.TrimSpace(stripTagsOnly(inner))) < 100 {
 		return ""
@@ -478,12 +498,18 @@ func extractTaggedBlock(s, attrTailRE string) string {
 
 // extractAttrMatch extracts content from a tag with a specific attribute value.
 func extractAttrMatch(s, attr, val string) string {
-	return extractTaggedBlock(s, `\s*`+regexp.QuoteMeta(attr)+`\s*=\s*["']`+regexp.QuoteMeta(val)+`["']`)
+	// #2159: the attribute must start after a delimiter (space/quote) -
+	// a bare `\s*attr=` tail let `data-role="main"` satisfy role= and
+	// the WRONG container win (and a short one silently starve the real
+	// id container of its retry).
+	return extractTaggedBlock(s, `[\s"']`+regexp.QuoteMeta(attr)+`\s*=\s*["']`+regexp.QuoteMeta(val)+`["']`)
 }
 
 // extractByID extracts content from a tag with a specific id attribute.
 func extractByID(s, id string) string {
-	return extractTaggedBlock(s, `[^>]*\bid\s*=\s*["']`+regexp.QuoteMeta(id)+`["']`)
+	// #2159: `\bid=` matched `data-id=` (\b holds across the hyphen);
+	// the delimited form requires a real attribute boundary.
+	return extractTaggedBlock(s, `[^>]*[\s"']id\s*=\s*["']`+regexp.QuoteMeta(id)+`["']`)
 }
 
 // stripTagsOnly removes HTML tags without any entity decoding or whitespace handling.

--- a/internal/tool/zz_issue2159_test.go
+++ b/internal/tool/zz_issue2159_test.go
@@ -1,0 +1,62 @@
+package tool
+
+// #2159 regression: extractFirstTag closed on the FIRST </tag> with no
+// depth counting - a nested same-name block (HTML5's own article-in-
+// article comment pattern) silently replaced the real body. And the
+// id/attr selector tails had no delimiter anchor: data-id/data-role
+// satisfied id=/role= and the WRONG (or empty) container won, starving
+// the real one of its retry.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractFirstTagNestedSameName(t *testing.T) {
+	inner := "<article><p>" + strings.Repeat("comment ", 20) + "</p></article>"
+	main := "<p>MAINBODY " + strings.Repeat("real ", 40) + "</p>"
+	html := "<article>" + inner + main + "</article>"
+
+	got := extractFirstTag(html, "article")
+	if got == "" {
+		t.Fatal("extraction failed")
+	}
+	if !strings.Contains(got, "MAINBODY") {
+		t.Fatalf("nested same-name comment block replaced the real body: %q...", got[:zz2159min(80, len(got))])
+	}
+	if !strings.Contains(got, "comment") {
+		t.Fatal("inner block must still be INSIDE the capture")
+	}
+}
+
+func zz2159min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func TestExtractByIDDoesNotMatchDataID(t *testing.T) {
+	wrong := `<div data-id="content">` + strings.Repeat("WRONG ", 40) + `</div>`
+	real := `<div id="content">` + strings.Repeat("REAL ", 40) + `</div>`
+	html := "<body>" + wrong + real + "</body>"
+
+	got := extractByID(html, "content")
+	if got == "" {
+		t.Fatal("real id container starved by a data-id false match")
+	}
+	if strings.Contains(got, "WRONG") || !strings.Contains(got, "REAL") {
+		t.Fatalf("data-id container won over the real id container: %q...", got[:zz2159min(60, len(got))])
+	}
+}
+
+func TestExtractAttrMatchDoesNotMatchDataRole(t *testing.T) {
+	wrong := `<div data-role="main">` + strings.Repeat("WRONG ", 40) + `</div>`
+	real := `<div role="main">` + strings.Repeat("REAL ", 40) + `</div>`
+	html := "<body>" + wrong + real + "</body>"
+
+	got := extractAttrMatch(html, "role", "main")
+	if got == "" || !strings.Contains(got, "REAL") || strings.Contains(got, "WRONG") {
+		t.Fatalf("data-role container won: %q", got)
+	}
+}


### PR DESCRIPTION
## #2159 — web_fetch extract 族两残留
1. **extractFirstTag 同名嵌套**：id/attr 路径 #2151 已有深度扫描，tag 路径未同步——首个 `</tag>` 即闭合，article 内嵌评论 article（HTML5 规范示例形态）时内层评论块静默替换正文。现按同名嵌套计数到**配对**闭合。
2. **属性选择器无定界锚**：`\\bid=` 在连字符处成立 → `data-id="content"` 撞名胜出（短误配返回空时真 id 容器**永无重试**）；`\\s*role=` 连 \\b 都没有。两 tail 改要求空格/引号定界符。

## #2161 — RemoveVendor 不清 key（PR #2160 复核轮边界发现）
整删 vendor 只删 map 条目，secret 残留 keys.env（#2105 后是**双名**面）每次启动注入 env、同名重加时静默复用。现删前 clearAPIKeyRefEnv + syncVendorKeyEnv(name, "")。

## 验证
- 4 新测试（同名 article 保 MAINBODY / data-id、data-role 让位真容器 / RemoveVendor 双 flavor 零残留）
- tool 43.5s + config 12.1s 全量 + 全仓 build 通过

请求 @ggcxf_reviewer_agent 复核（重点：extractFirstTag 深度计数的性能面——每闭合段重扫 opens；data-id 排除对既有合法 id 提取的兼容）。