### PR TITLE
fix(agent): exploration-frag counts before the clear; impact scope discrimination (#2100, #2103)

### DIFF
--- a/internal/agent/cross_file_impact.go
+++ b/internal/agent/cross_file_impact.go
@@ -420,6 +420,13 @@ func referencesAnyImpactSymbol(src string, removed []impactRemovedSymbol) bool {
 		return false
 	}
 	names := make(map[string]bool, len(removed))
+	// #2100: method names carry their owner type so a selector hit can be
+	// qualified. go/parser never sets Obj on SelectorExpr.Sel or composite
+	// literal keys, so the old Obj==nil-only rule fired on ANY same-named
+	// method of ANY type, package-qualified calls (impossible for
+	// unexported symbols), and field keys - "these files may fail to
+	// compile" advisories pointing at unrelated files.
+	methodOwners := make(map[string]map[string]bool)
 	for _, s := range removed {
 		var name string
 		switch s.category {
@@ -427,6 +434,18 @@ func referencesAnyImpactSymbol(src string, removed []impactRemovedSymbol) bool {
 			parts := strings.Split(s.name, ").")
 			if len(parts) == 2 {
 				name = parts[1]
+			} else if idx := strings.LastIndex(s.name, "."); idx > 0 {
+				name = s.name[idx+1:]
+			}
+			if name != "" {
+				idx := strings.LastIndex(s.name, ".")
+				owner := strings.Trim(s.name[:idx], "(* )")
+				if owner != "" {
+					if methodOwners[name] == nil {
+						methodOwners[name] = make(map[string]bool)
+					}
+					methodOwners[name][owner] = true
+				}
 			}
 		default:
 			name = s.name
@@ -457,22 +476,77 @@ func referencesAnyImpactSymbol(src string, removed []impactRemovedSymbol) bool {
 		}
 		return false
 	}
-	found := false
-	ast.Inspect(file, func(n ast.Node) bool {
-		if found {
-			return false
+	v := &impactRefVisitor{names: names, methodOwners: methodOwners}
+	ast.Walk(v, file)
+	return v.found
+}
+
+// impactRefVisitor walks a sibling AST counting only genuine references
+// to removed symbols (#2100).
+type impactRefVisitor struct {
+	names        map[string]bool
+	methodOwners map[string]map[string]bool
+	found        bool
+}
+
+func (v *impactRefVisitor) Visit(n ast.Node) ast.Visitor {
+	if v.found || n == nil {
+		return nil
+	}
+	switch node := n.(type) {
+	case *ast.SelectorExpr:
+		// Method-expression form (Type.method / (*T).method): a genuine
+		// reference only when the receiver's base type owns the removed
+		// method. Anything else (variable receivers, other packages)
+		// cannot be verified and never fires a package-level hit - the
+		// Sel ident itself is never a candidate.
+		if owners := v.methodOwners[node.Sel.Name]; len(owners) > 0 {
+			if base := selectorBaseTypeName(node.X); base != "" && owners[base] {
+				v.found = true
+				return nil
+			}
 		}
-		id, ok := n.(*ast.Ident)
-		if !ok || !names[id.Name] {
-			return true
+		// Walk ONLY the receiver manually - returning a visitor here would
+		// make ast.Walk descend into Sel as a plain Ident candidate too.
+		ast.Walk(v, node.X)
+		return nil
+	case *ast.CompositeLit:
+		for _, elt := range node.Elts {
+			if kv, ok := elt.(*ast.KeyValueExpr); ok {
+				// Field keys are struct metadata, not references.
+				ast.Walk(v, kv.Value)
+				continue
+			}
+			ast.Walk(v, elt)
 		}
-		if id.Obj == nil {
-			found = true
-			return false
+		return nil
+	case *ast.Ident:
+		// Package-level (non-method) symbol: only a standalone unresolved
+		// ident counts. Method bare names never match here - a bare use
+		// cannot reference a method.
+		if v.names[node.Name] && len(v.methodOwners[node.Name]) == 0 && node.Obj == nil {
+			v.found = true
+			return nil
 		}
-		return true
-	})
-	return found
+	}
+	return v
+}
+
+// selectorBaseTypeName peels parens/stars off a selector receiver to its
+// base type identifier name ("" when not a plain identifier chain).
+func selectorBaseTypeName(x ast.Expr) string {
+	for {
+		switch e := x.(type) {
+		case *ast.ParenExpr:
+			x = e.X
+		case *ast.StarExpr:
+			x = e.X
+		case *ast.Ident:
+			return e.Name
+		default:
+			return ""
+		}
+	}
 }
 
 // containsGoIdent checks if name appears as a Go identifier in src.

--- a/internal/agent/exploration_frag.go
+++ b/internal/agent/exploration_frag.go
@@ -262,13 +262,18 @@ func (s *exploreFragState) recordToolCall(toolName string, args []byte, iteratio
 	}
 
 	s.warnings++
+	// #2103: capture the counts BEFORE the #1559-D fire-and-clear - the
+	// old order read len(s.entries) after nil-ing it, so the debug log
+	// and the message's first %d were always 0 ("0 calls across 6+
+	// distinct targets" - mathematically self-contradictory guidance).
+	callCount := len(s.entries)
 	// #1559-D: fire-and-keep made the very next exploration call re-fire
 	// with a byte-identical message (window still full), burning both
 	// warnings back-to-back. Mirror attention_fragment: the window empties
 	// on fire, so a re-fire needs a full fresh window of exploration.
 	s.entries = nil
 	debug.Log("agent", "Iteration %d: exploration fragmentation detected (%d calls, %d unique targets)",
-		iteration, len(s.entries), len(uniqueTargets))
+		iteration, callCount, len(uniqueTargets))
 
 	return fmt.Sprintf(
 		"[Exploration Fragmentation] %d exploration tool calls across %d+ distinct targets "+
@@ -277,5 +282,5 @@ func (s *exploreFragState) recordToolCall(toolName string, args []byte, iteratio
 			"Consider: (1) Use code_search or lsp_workspace_symbols for semantic discovery instead of many narrow reads. "+
 			"(2) Read a key file fully (without offset/limit) to understand structure before exploring specifics. "+
 			"(3) If you have enough context, start acting (edit/build) rather than exploring further.",
-		len(s.entries), len(uniqueTargets), exploreFragWindow)
+		callCount, len(uniqueTargets), exploreFragWindow)
 }

--- a/internal/agent/zz_issue2100_2103_test.go
+++ b/internal/agent/zz_issue2100_2103_test.go
@@ -1,0 +1,68 @@
+package agent
+
+// #2100/#2103 regression:
+//   - #2103: exploration fragmentation cleared the window BEFORE reading
+//     len(s.entries) for the debug log and the message's call count -
+//     every firing said "0 exploration tool calls across 6+ distinct
+//     targets" (mathematically self-contradictory).
+//   - #2100: go/parser never sets Obj on SelectorExpr.Sel or composite
+//     literal keys, so cross-file-impact fired on any same-named method
+//     of ANY type, package-qualified calls, and field keys.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExplorationFragMessageCountsNotZero(t *testing.T) {
+	s := newExploreFragState()
+	// recordToolCall returns the analysis message when it fires.
+	var msg string
+	for i := 0; i < 6; i++ {
+		msg = s.recordToolCall("read_file", []byte(`{"path":"/repo/file`+string(rune('a'+i))+`"}`), 2+i%2)
+	}
+	if msg == "" {
+		t.Fatal("expected the detector to fire (6 calls / 6 unique targets)")
+	}
+	if strings.Contains(msg, "] 0 exploration tool calls") {
+		t.Fatalf("message reports 0 calls after fire-and-clear (order regression): %q", msg[:min2(90, len(msg))])
+	}
+	if !strings.Contains(msg, "] 6 exploration tool calls") {
+		t.Fatalf("message must report the pre-clear call count: %q", msg[:min2(90, len(msg))])
+	}
+}
+
+func min2(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func TestCrossFileImpactScopeDiscrimination(t *testing.T) {
+	method := []impactRemovedSymbol{{category: "method", name: "(*Server).run"}}
+	fn := []impactRemovedSymbol{{category: "function", name: "helperFn"}}
+
+	cases := []struct {
+		name    string
+		removed []impactRemovedSymbol
+		src     string
+		want    bool
+	}{
+		{"genuine method expression", method, "package x\nfunc f(s *Server) { Server.run() }", true},
+		{"genuine package fn call", fn, "package x\nfunc f() { helperFn() }", true},
+		{"other type's method", method, "package x\nfunc f(w *Widget) { w.run() }", false},
+		{"package-qualified call", method, "package x\nfunc f() { other.run() }", false},
+		{"composite literal key", method, "package x\nvar v = Type{run: 1}", false},
+		{"method vs package fn", fn, "package x\nfunc f(x *T) { x.helperFn() }", false},
+		{"local shadow", fn, "package x\nfunc f() { helperFn := 1; _ = helperFn }", false},
+		{"string literal", fn, "package x\nvar s = \"helperFn\"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := referencesAnyImpactSymbol(c.src, c.removed); got != c.want {
+				t.Fatalf("referencesAnyImpactSymbol = %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## #2103 — fire-and-clear 吞计数
#1559-D 防双发把 `s.entries = nil` 插在消息构造**前**——debug 日志与消息首个 %d 读的 len 恒 0（"0 calls across 6+ targets" 自相矛盾）。改为 clear 前捕获 callCount。

## #2100 — Obj 语义误报面（9 场景探针）
go/parser 从不给 SelectorExpr.Sel / 复合字面量 key 设 Obj——#1773-5 的 Obj==nil 规则把任意类型同名方法、包限定调用（未导出跨包不可能）、field key、方法 vs 包级函数混淆全部当跨文件引用。重构为**分类感知 visitor**：
- 包级符号：仅独立未解析 ident 命中
- 被删方法：携带 owner 类型名，仅方法表达式形态（`Type.method`/`(*T).method`）且 receiver 基类型匹配才命中
- selector 只手动下降 receiver（Sel 永不作为候选）；复合字面量 key 跳过
- 本地遮蔽/字符串字面量维持正确排除

## 验证
- 消息计数 6 非 0 + **8 场景表**（2 真阳性命中 / 6 误报场景静默，含探针全部场景）
- agent 包全量 21.3s + 全仓 build 通过

请求 @ggcxf_reviewer_agent 复核（重点：变量 receiver 的 s.run() 真引用现为保守漏报——与探针表一致的方向性权衡；owner 类型名提取对 "(*T).m" 与 "T.m" 两形态）。