### PR TITLE
fix(tui): mask secret env values in the IM adapter edit panel (#2158)

### DIFF
--- a/internal/tui/im_edit.go
+++ b/internal/tui/im_edit.go
@@ -85,7 +85,15 @@ func (m *Model) enterIMEditSelect(adapterName string) imAdapterEditState {
 	for k, v := range adapter.Env {
 		key := "env." + k
 		s.originalExtra[key] = v
-		s.fieldValues[key] = v
+		// #2158: the Extra loop five lines up masks secret-looking keys,
+		// this loop stored the plaintext outright - opening the edit
+		// panel alone leaked every env secret (BOT_TOKEN/API_KEY...),
+		// already ExpandEnv-resolved to real values at load time.
+		if looksLikeSecretField(k) {
+			s.fieldValues[key] = maskSecret(v)
+		} else {
+			s.fieldValues[key] = v
+		}
 	}
 
 	keys := make([]string, 0, len(s.fieldValues))

--- a/internal/tui/zz_issue2158_test.go
+++ b/internal/tui/zz_issue2158_test.go
@@ -1,0 +1,42 @@
+package tui
+
+// #2158 regression: the Env loop in enterIMEditSelect stored secret env
+// values as PLAINTEXT into fieldValues while the Extra loop five lines
+// above masked them - opening the edit panel alone leaked every env
+// secret (already ExpandEnv-resolved to real values at load time) to
+// shoulder-surfing/screen-recording.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/topcheer/ggcode/internal/config"
+)
+
+func TestIMEditSelectMasksEnvSecrets(t *testing.T) {
+	m := newTestModel()
+	m.config = &config.Config{}
+	m.config.IM.Adapters = map[string]config.IMAdapterConfig{}
+	m.config.IM.Adapters["qq-test-2158"] = config.IMAdapterConfig{
+		Env: map[string]string{
+			"BOT_TOKEN": "secret-bot-token-2158",
+			"APP_ID":    "123456",
+		},
+	}
+	s := m.enterIMEditSelect("qq-test-2158")
+
+	v, ok := s.fieldValues["env.BOT_TOKEN"]
+	if !ok {
+		t.Fatal("env field missing from edit state")
+	}
+	if strings.Contains(v, "secret-bot-token-2158") {
+		t.Fatalf("env secret rendered in cleartext: %q", v)
+	}
+	if v == "" {
+		t.Fatal("masked value must not be empty (edit affordance)")
+	}
+	// Benign env keys stay readable.
+	if s.fieldValues["env.APP_ID"] != "123456" {
+		t.Fatalf("benign env value must stay plaintext, got %q", s.fieldValues["env.APP_ID"])
+	}
+}


### PR DESCRIPTION
## 根因
enterIMEditSelect 的 Extra 循环有 `looksLikeSecretField → maskSecret` 脱敏，**Env 循环整体跳过了同一调用**——纯遗漏。config 加载时 Env 已 ExpandEnv 展开为真实 secret 值，打开编辑面板即明文泄露全部 env secret（肩窥/录屏/截图场景，14 平台面板通用）。

## 修复
Env 循环应用与 Extra 完全相同的脱敏分支（3 行实质改动）。 保留原值语义不变（保存路径经 `saveIMEditField` 值比对，与 Extra 一致）。

## 验证
新测试：BOT_TOKEN 入编辑态为 mask（非空保编辑可及性）、APP_ID 明文保持；tui 包全量 10.0s + 全仓 build 通过。

请求 @ggcxf_reviewer_agent 复核（重点：mask 值经 saveIMEditField 回写时与 Extra 字段的同语义处理——两循环现行为完全对齐）。