### PR TITLE
fix(agent): case-safe Job ID extraction; causal error files for all claimed toolchains (#2098, #2099)

### DIFF
--- a/internal/agent/bgorphan_detect.go
+++ b/internal/agent/bgorphan_detect.go
@@ -300,6 +300,56 @@ func (s *bgOrphanState) checkOrphanedCommands(iteration int) string {
 	return sb.String()
 }
 
+// indexFoldASCII finds the byte offset of an ASCII needle in s ignoring
+// letter case, WITHOUT building a lowered copy - offsets stay valid on
+// the original string even when ToLower would change byte lengths
+// (#2098: İ 2B->1B, ẞ 3B->2B shifted the slice cut). Returns -1 when
+// absent.
+func indexFoldASCII(s, needle string) int {
+	if needle == "" {
+		return 0
+	}
+	first := needle[0]
+	lo, hi := lowerASCII(first), upperASCII(first)
+	for i := 0; i+len(needle) <= len(s); i++ {
+		c := s[i]
+		if c != lo && c != hi {
+			continue
+		}
+		if equalFoldASCII(s[i:i+len(needle)], needle) {
+			return i
+		}
+	}
+	return -1
+}
+
+func lowerASCII(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c + 'a' - 'A'
+	}
+	return c
+}
+
+func upperASCII(c byte) byte {
+	if c >= 'a' && c <= 'z' {
+		return c - 'a' + 'A'
+	}
+	return c
+}
+
+func equalFoldASCII(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := lowerASCII(a[i]), lowerASCII(b[i])
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}
+
 // extractJobID parses a start_command result to find the returned job_id.
 // The result text typically contains "job_id": "<id>" or "Job ID: <id>".
 func extractJobID(result string) string {
@@ -308,7 +358,13 @@ func extractJobID(result string) string {
 		return id
 	}
 	// Try "Job ID: xxx" format
-	if idx := strings.Index(strings.ToLower(result), "job id:"); idx >= 0 {
+	// #2098: the old strings.Index(strings.ToLower(result), ...) computed
+	// the offset on the LOWERED copy but sliced the ORIGINAL - ToLower
+	// changes byte length for some runes (İ 2B->1B, ẞ 3B->2B), so any
+	// such char in a prepended Rules block shifted the cut onto garbage
+	// (extracted ":" as the job id: orphan detection went blind on the
+	// real job and nudged a fake one).
+	if idx := indexFoldASCII(result, "job id:"); idx >= 0 {
 		rest := result[idx+7:]
 		rest = strings.TrimSpace(rest)
 		// Take first token/quoted string

--- a/internal/agent/causal_attribution.go
+++ b/internal/agent/causal_attribution.go
@@ -93,7 +93,13 @@ var causalEditTools = sourceMutatingTools
 var causalVerifyRe = regexp.MustCompile(`(?i)(go\s+(build|test|vet)|make\s+\w+|npm\s+(test|run)|cargo\s+(build|test)|pytest|jest|\.\/gradlew)`)
 
 // errorFileRe extracts file paths from common build/test error output.
-var causalErrorFileRe = regexp.MustCompile(`(?:^|\s)((?:\./)?[\w\-./]+\.go):(?:\d+)?:`)
+// #2099: causalVerifyRe deliberately covers non-Go toolchains (npm,
+// cargo, pytest, jest, gradlew) but the capture group matched ONLY .go
+// - errorFiles stayed empty on TS/JS/Python/Rust failures, every CRS
+// scoring path (file-match/same-package/same-dir) sat inside the
+// empty-range loop, and the detector never fired once outside Go
+// projects: a silent dead zone for every toolchain it claims to cover.
+var causalErrorFileRe = regexp.MustCompile(`(?:^|\s)((?:\./)?[\w\-./]+\.(?:go|ts|tsx|js|jsx|mjs|py|rs|java|rb|kt|swift|c|cc|cpp|h|hpp)):(?:\d+)?:`)
 
 // recordEdit logs a mutation step.
 func (s *causalAttributionState) recordEdit(toolName, filePath string, iteration int) {

--- a/internal/agent/zz_issue2098_2099_test.go
+++ b/internal/agent/zz_issue2098_2099_test.go
@@ -1,0 +1,58 @@
+package agent
+
+// #2098/#2099 regression:
+//   - #2098: extractJobID computed the "job id:" offset on the ToLower
+//     COPY but sliced the ORIGINAL - length-changing runes (İ 2B->1B,
+//     ẞ 3B->2B) in a prepended Rules block shifted the cut and the
+//     "extracted" id was ":" (orphan detection blind on the real job).
+//   - #2099: causalErrorFileRe matched only .go while causalVerifyRe
+//     deliberately covers npm/cargo/pytest/jest/gradlew - non-Go
+//     failures never produced errorFiles and the detector stayed
+//     silent outside Go projects.
+
+import (
+	"testing"
+)
+
+func TestExtractJobIDUnicodeShift(t *testing.T) {
+	s := "[Rules — learned from past mistakes]\n⚠ Never start jobs in /Users/İbrahim/src and ẞ chars...\n\n" +
+		"Job ID: job-a1b2c3\nStatus: running\n"
+	if got := extractJobID(s); got != "job-a1b2c3" {
+		t.Fatalf("extractJobID = %q, want job-a1b2c3 (offset shifted by length-changing runes)", got)
+	}
+	// Case variants still match (the old path's intent).
+	if got := extractJobID("job id: job-x9\n"); got != "job-x9" {
+		t.Fatalf("lowercase variant: %q", got)
+	}
+	if got := extractJobID("Started. JOB ID: quoted-1\n"); got != "quoted-1" {
+		t.Fatalf("uppercase variant: %q", got)
+	}
+}
+
+func TestCausalErrorFilesNonGoToolchains(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{"jest ts", "FAIL src/api.test.ts\nsrc/api.ts:12:5 - error TS2322", "src/api.ts"},
+		{"pytest py", "FAILED src/test_api.py::test_add\nsrc/test_api.py:12: AssertionError", "src/test_api.py"},
+		{"cargo rs", "error[E0308]: mismatched types\n --> src/lib.rs:12:15", "src/lib.rs"},
+		{"go control", "src/api.go:12:2: undefined: x", "src/api.go"},
+		{"jsx", "src/App.jsx:4:10: Cannot find module", "src/App.jsx"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			files := extractErrorFiles(c.out)
+			found := false
+			for _, f := range files {
+				if f == c.want {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("extractErrorFiles(%q) = %v, want %q present", c.out, files, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## #2098 — ToLower 副本偏移切原文
extractJobID 在 Lowered 副本上算 offset 却切原文——长度变化 rune（İ 2B→1B、ẞ 3B→2B）在 prepend 的 Rules 块中错位，提取出假 job ":"（孤儿检测对真 job 失明 + 假 job 烧 nudge 预算挂到 run 结束）。新增 indexFoldASCII 在**原字节**上大小写不敏感搜索，offset 恒有效。

## #2099 — causal 检测器非 Go 静默死区
causalVerifyRe 明列 npm/cargo/pytest/jest/gradlew，但 causalErrorFileRe 只捕 .go——非 Go 失败 errorFiles 恒空，三条给分路径全在空 range 循环内、recency 被 #1528 守卫归零，CRS 永不到阈值（探针：jest/pytest/cargo 全静默，Go 对照 CRS=60 触发）。后缀类扩至 ts/tsx/js/jsx/mjs/py/rs/java/rb/kt/swift/c/cc/cpp/h/hpp。

## 验证
- 行为对照探针（本地实测：旧法提取 ":" / 新法提取 job-a1b2c3）
- 7 子测试（unicode shift + 大小写变体 + jest/pytest/cargo/jsx 文件提取 + Go 对照）
- agent 全量 21.5s + 全仓 build 通过

请求 @ggcxf_reviewer_agent 复核（重点：indexFoldASCII 的 ASCII 限定对 needle "job id:" 的充分性；后缀类扩大对 Go 项目内 .h/.c 误命中的影响面）。