### PR TITLE
fix(tool,tui,config): proxy-path DNS SSRF guard; key in secret masking (#2165, #2167)

### DIFF
--- a/internal/config/api_keys.go
+++ b/internal/config/api_keys.go
@@ -187,7 +187,7 @@ func detectPlaintextAPIKeysFromRaw(raw map[string]interface{}) []APIKeyFinding {
 // Matches: secret, token, password, credential (case-insensitive, as substring).
 func looksLikeSecretField(key string) bool {
 	lower := strings.ToLower(key)
-	for _, pattern := range []string{"secret", "token", "password", "credential"} {
+	for _, pattern := range []string{"secret", "token", "password", "credential", "key"} {
 		if strings.Contains(lower, pattern) {
 			return true
 		}

--- a/internal/tool/web_fetch.go
+++ b/internal/tool/web_fetch.go
@@ -116,7 +116,6 @@ func (t WebFetch) Execute(ctx context.Context, input json.RawMessage) (Result, e
 		// The per-fetch transport owns a connection pool nobody will reuse
 		// (a fresh one is built next call) - drain idle fds when done.
 		defer transport.CloseIdleConnections()
-
 		// When a proxy is configured (HTTP_PROXY/HTTPS_PROXY), the custom
 		// DialContext receives the proxy address (often localhost/internal)
 		// rather than the target host. Skip the DialContext override in that
@@ -137,6 +136,18 @@ func (t WebFetch) Execute(ctx context.Context, input json.RawMessage) (Result, e
 				}
 				return origDial(dialCtx, network, dialAddr)
 			}
+		} else if !t.AllowPrivate {
+			// #2165: the proxy resolves the hostname itself, so the dial-level
+			// guard above never runs - and the old comment claimed "SSRF still
+			// enforced at URL level", but that check is LITERAL (localhost
+			// variants / .internal / ParseIP): a domain whose A record points
+			// at a private IP passed straight through to the proxy, which then
+			// dialed the internal network. Resolve locally and reject on any
+			// private IP before the request leaves (lookup failures still go -
+			// the proxy may resolve differently than we can).
+			if err := rejectIfHostResolvesPrivate(ctx, u.Hostname(), net.DefaultResolver.LookupIPAddr); err != nil {
+				return Result{IsError: true, Content: fmt.Sprintf("fetch failed: %v", err)}, nil
+			}
 		}
 		client.Transport = transport
 	} else {
@@ -145,9 +156,22 @@ func (t WebFetch) Execute(ctx context.Context, input json.RawMessage) (Result, e
 		client.Transport = transport
 	}
 
+	// #2165: redirect guard needs the transport even on the plain path.
+	var redirectGuardTransport *http.Transport
+	if ht, ok := client.Transport.(*http.Transport); ok {
+		redirectGuardTransport = ht
+	}
+
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if !t.AllowPrivate && isPrivateHost(req.URL.Hostname()) {
 			return fmt.Errorf("redirect to private/internal network address is not allowed")
+		}
+		// #2165: same DNS-level guard for redirects - the literal check
+		// alone let a redirect to a private-A-record domain through.
+		if !t.AllowPrivate && redirectGuardTransport != nil && isProxyConfigured(redirectGuardTransport, req.URL) {
+			if err := rejectIfHostResolvesPrivate(req.Context(), req.URL.Hostname(), net.DefaultResolver.LookupIPAddr); err != nil {
+				return err
+			}
 		}
 		if len(via) >= 10 {
 			return fmt.Errorf("too many redirects")
@@ -292,6 +316,27 @@ func resolvePublicDialAddress(ctx context.Context, host, port string, lookup fun
 		}
 	}
 	return net.JoinHostPort(ips[0].IP.String(), port), nil
+}
+
+// rejectIfHostResolvesPrivate enforces the DNS-level SSRF guard on the
+// proxy path (#2165): the proxy resolves the hostname itself, so the
+// dial-level check never fires - resolve locally and reject when ANY
+// address is private. Lookup failures do not reject (the proxy may
+// resolve differently than the local resolver).
+func rejectIfHostResolvesPrivate(ctx context.Context, host string, lookup func(context.Context, string) ([]net.IPAddr, error)) error {
+	if host == "" || net.ParseIP(host) != nil {
+		return nil // literal IPs already covered by isPrivateHost
+	}
+	ips, err := lookup(ctx, host)
+	if err != nil {
+		return nil
+	}
+	for _, ip := range ips {
+		if isPrivateIP(ip.IP) {
+			return fmt.Errorf("access to private/internal IP %s is not allowed", ip.IP)
+		}
+	}
+	return nil
 }
 
 func getPrivateNetworks() ([]*net.IPNet, error) {

--- a/internal/tool/zz_issue2165_test.go
+++ b/internal/tool/zz_issue2165_test.go
@@ -1,0 +1,52 @@
+package tool
+
+// #2165 regression: with a proxy configured, the DialContext-level SSRF
+// guard never ran (the proxy resolves the hostname itself) and the
+// "URL-level" check was literal-only - a domain whose A record pointed
+// at a private IP went straight through to the proxy.
+
+import (
+	"context"
+	"net"
+	"testing"
+)
+
+func TestRejectIfHostResolvesPrivate(t *testing.T) {
+	// Private A record: rejected.
+	err := rejectIfHostResolvesPrivate(context.Background(), "x.corp.example.com",
+		func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("10.1.2.3")}}, nil
+		})
+	if err == nil {
+		t.Fatal("private A record must be rejected on the proxy path")
+	}
+	// Mixed records: ANY private IP rejects.
+	err = rejectIfHostResolvesPrivate(context.Background(), "mixed.example.com",
+		func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("93.184.216.34")}, {IP: net.ParseIP("192.168.0.1")}}, nil
+		})
+	if err == nil {
+		t.Fatal("any private IP in the record set must reject")
+	}
+	// Public only: allowed.
+	err = rejectIfHostResolvesPrivate(context.Background(), "ok.example.com",
+		func(context.Context, string) ([]net.IPAddr, error) {
+			return []net.IPAddr{{IP: net.ParseIP("93.184.216.34")}}, nil
+		})
+	if err != nil {
+		t.Fatalf("public A record must pass: %v", err)
+	}
+	// Lookup failure: NOT rejected (proxy may resolve differently).
+	err = rejectIfHostResolvesPrivate(context.Background(), "unresolvable.example.com",
+		func(context.Context, string) ([]net.IPAddr, error) {
+			return nil, &net.DNSError{Err: "no such host"}
+		})
+	if err != nil {
+		t.Fatalf("lookup failure must not reject: %v", err)
+	}
+	// Literal IPs are the literal guard's job.
+	err = rejectIfHostResolvesPrivate(context.Background(), "10.0.0.1", nil)
+	if err != nil {
+		t.Fatalf("literal IP must be deferred to isPrivateHost: %v", err)
+	}
+}

--- a/internal/tui/im_edit.go
+++ b/internal/tui/im_edit.go
@@ -372,7 +372,7 @@ func maskSecret(value string) string {
 // Duplicated from config package to avoid import cycle concerns.
 func looksLikeSecretField(key string) bool {
 	lower := strings.ToLower(key)
-	for _, pattern := range []string{"secret", "token", "password", "credential"} {
+	for _, pattern := range []string{"secret", "token", "password", "credential", "key"} {
 		if strings.Contains(lower, pattern) {
 			return true
 		}

--- a/internal/tui/zz_issue2167_test.go
+++ b/internal/tui/zz_issue2167_test.go
@@ -1,0 +1,50 @@
+package tui
+
+// #2167 regression: the masking pattern lacked "key" - api_key/
+// private_key/encrypt_key (the nostr identity key is a REQUIRED adapter
+// credential) all rendered in cleartext in the IM edit panel despite
+// the #2158 fix's claim.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/topcheer/ggcode/internal/config"
+)
+
+func TestLooksLikeSecretFieldKeySuffixes(t *testing.T) {
+	cases := []string{
+		"api_key", "API_KEY", "private_key", "encrypt_key",
+		"client_key", "access_key", "secret_key", "bot_token",
+	}
+	for _, k := range cases {
+		if !looksLikeSecretField(k) {
+			t.Errorf("looksLikeSecretField(%q) = false, want true", k)
+		}
+	}
+	// Config-side copy must stay in lockstep (three consumer surfaces).
+	for _, k := range cases {
+		if !config.LooksLikeSecretField(k) {
+			t.Errorf("config.LooksLikeSecretField(%q) = false, want true", k)
+		}
+	}
+}
+
+func TestIMEditSelectMasksNostrPrivateKey(t *testing.T) {
+	m := newTestModel()
+	m.config = &config.Config{}
+	m.config.IM.Adapters = map[string]config.IMAdapterConfig{}
+	m.config.IM.Adapters["nostr-2158"] = config.IMAdapterConfig{
+		Extra: map[string]interface{}{
+			"private_key": "nsec1zzzzzzzzzzzzzz",
+		},
+	}
+	s := m.enterIMEditSelect("nostr-2158")
+	v, ok := s.fieldValues["private_key"]
+	if !ok {
+		t.Fatal("private_key missing from edit state")
+	}
+	if strings.Contains(v, "nsec1") {
+		t.Fatalf("nostr identity private key rendered in cleartext: %q", v)
+	}
+}


### PR DESCRIPTION
## #2165 — 代理路径 DNS 级 SSRF 防护
proxyInUse 时 DialContext 覆盖被整体跳过，注释宣称的 "URL 级防护" 实为字面检查——A 记录指向私网的域名直通代理解析内网；CheckRedirect 同洞。新增 `rejectIfHostResolvesPrivate`：代理路径请求前 + 重定向时本地解析 URL host，**任一 IP 私网即拒**；lookup 失败放行（代理可能异于本地解析器）。transport 提升作用域供重定向守卫复用（else 分支语义保持）。

## #2167 — masking pattern 补 "key"
f52b2bf0（我 #2158 修复）commit 信息声称 "API_KEY-class names fall squarely in the masking pattern" **失实**——pattern 无 "key"，nostr 必填身份私钥 private_key / 五平台 STT api_key / feishu encrypt_key 全部明文渲染。tui + config 两份拷贝（经 LooksLikeSecretField 服务三消费面）同补。误伤面：含 KEY 的仓库内非 secret 键均为 API 响应字段，不入面板；mask 纯显示层。

## 验证
- #2165：5 场景（私网拒/混合拒/公网过/lookup 失败过/字面 IP 延后）+ web_fetch 既有全量 126s 无回归
- #2167：8 键名双拷贝命中 + nostr private_key 编辑面板 mask 端到端
- 三包全量 + 全仓 build 通过

请求 @ggcxf_reviewer_agent 复核（重点：lookup 失败放行的权衡是否可接受——拒绝会造成纯代理解析环境全断；transport 作用域重构对 else 分支的等价性）。