### PR TITLE
fix(tui,agent): masked edit-input echo; Windows paths in causal attribution (#2169, #2171)

### DIFF
--- a/internal/agent/causal_attribution.go
+++ b/internal/agent/causal_attribution.go
@@ -99,7 +99,13 @@ var causalVerifyRe = regexp.MustCompile(`(?i)(go\s+(build|test|vet)|make\s+\w+|n
 // scoring path (file-match/same-package/same-dir) sat inside the
 // empty-range loop, and the detector never fired once outside Go
 // projects: a silent dead zone for every toolchain it claims to cover.
-var causalErrorFileRe = regexp.MustCompile(`(?:^|\s)((?:\./)?[\w\-./]+\.(?:go|ts|tsx|js|jsx|mjs|py|rs|java|rb|kt|swift|c|cc|cpp|h|hpp)):(?:\d+)?:`)
+// #2171: the class lacked '\' and ':' entirely, so Windows-native
+// output (C:\src\api.rs:12:5, src\main.rs:3:9, even go's .\pkg\file.go
+// on Windows) matched NOTHING - a platform-wide dead zone older than
+// the #2099 widening. The class now admits both separators and drive
+// letters, and the tsc paren form `path(12,3):` is accepted alongside
+// `path:12:`.
+var causalErrorFileRe = regexp.MustCompile("(?:^|\\s)((?:[\\w\\-./\\\\:]+)\\.(?:go|ts|tsx|js|jsx|mjs|py|rs|java|rb|kt|swift|c|cc|cpp|h|hpp))(?::(?:\\d+)?:|\\(\\d+,\\d+\\):)")
 
 // recordEdit logs a mutation step.
 func (s *causalAttributionState) recordEdit(toolName, filePath string, iteration int) {
@@ -145,6 +151,11 @@ func extractErrorFiles(output string) []string {
 	for _, m := range matches {
 		// Normalize: strip leading ./ for consistent comparison
 		f := strings.TrimSpace(m[1])
+		// #2171: Windows-native output uses backslashes - fold them to
+		// '/' FIRST (a `.\pkg\file.go` only becomes `./pkg/file.go` after
+		// folding) so the ./ strip and the same-dir/same-package
+		// attribution work uniformly on every platform.
+		f = strings.ReplaceAll(f, "\\", "/")
 		f = strings.TrimPrefix(f, "./")
 		if !seen[f] {
 			seen[f] = true

--- a/internal/agent/zz_issue2171_test.go
+++ b/internal/agent/zz_issue2171_test.go
@@ -1,0 +1,38 @@
+package agent
+
+// #2171 regression: the error-file class lacked '\' and ':' so Windows-
+// native output matched NOTHING (C:\src\api.rs:12:5, src\main.rs:3:9,
+// go's own .\pkg\file.go on Windows), and the tsc paren form
+// path(12,3) was unmatched - a platform-wide dead zone predating the
+// #2099 suffix widening.
+
+import "testing"
+
+func TestCausalErrorFilesWindowsPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{"drive letter", "error[E0308]: mismatched\n  --> C:\\src\\api.rs:12:5", "C:/src/api.rs"},
+		{"relative backslash", "error: cannot borrow\n --> src\\main.rs:3:9", "src/main.rs"},
+		{"go dot-backslash", ".\\internal\\foo.go:10:2: undefined: x", "internal/foo.go"},
+		{"tsc paren form", "C:\\src\\api.ts(12,3): error TS2322", "C:/src/api.ts"},
+		{"posix control", "src/api.go:12:2: undefined: x", "src/api.go"},
+		{"posix jsx", "src/App.jsx:4:10: Cannot find module", "src/App.jsx"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			files := extractErrorFiles(c.out)
+			found := false
+			for _, f := range files {
+				if f == c.want {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("extractErrorFiles(%q) = %v, want %q (normalized) present", c.out, files, c.want)
+			}
+		})
+	}
+}

--- a/internal/tui/im_edit.go
+++ b/internal/tui/im_edit.go
@@ -145,6 +145,20 @@ func (m *Model) renderIMEditSelect(s *imAdapterEditState) string {
 	return strings.Join(body, "\n")
 }
 
+// maskedEditValue masks the edit-input ECHO for secret-looking fields
+// (#2169): the input buffer keeps the real value (saving semantics
+// unchanged), but the rendered frame showed the whole plaintext -
+// Enter means "edit", not "reveal", and scrollback keeps the leak for
+// the session's lifetime. Mirrors the list view's #2158 masking; the
+// same-repo precedent (stream_panel/onboard) masks secret echoes too.
+func maskedEditValue(field, value string) string {
+	name := strings.TrimPrefix(field, "env.")
+	if looksLikeSecretField(name) {
+		return maskSecret(value)
+	}
+	return value
+}
+
 // renderIMEditInput renders the text input view for editing a field value.
 func (m *Model) renderIMEditInput(s *imAdapterEditState) string {
 	if s == nil || s.mode != imEditInput {
@@ -155,7 +169,7 @@ func (m *Model) renderIMEditInput(s *imAdapterEditState) string {
 		fmt.Sprintf(" %s", m.t("panel.im.edit.adapter", s.adapterName)),
 		"",
 		fmt.Sprintf(" %s", m.t("panel.im.edit.field", s.editField)),
-		fmt.Sprintf(" %s%s█", m.t("panel.im.edit.new_value"), s.editInput),
+		fmt.Sprintf(" %s%s█", m.t("panel.im.edit.new_value"), maskedEditValue(s.editField, s.editInput)),
 		"",
 		renderPasteShortcutHint(m.currentLanguage()),
 		lipgloss.NewStyle().Foreground(lipgloss.Color("8")).Render(" " + m.t("panel.im.edit.input_hint")),

--- a/internal/tui/zz_issue2169_test.go
+++ b/internal/tui/zz_issue2169_test.go
@@ -1,0 +1,49 @@
+package tui
+
+// #2169 regression: the edit-input view echoed the WHOLE plaintext of a
+// secret field into the frame (and thus the terminal scrollback) - the
+// #2158 list-view mask was silently bypassed one screen later on Enter.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaskedEditValueSecrets(t *testing.T) {
+	cases := map[string]string{
+		"env.BOT_TOKEN": "secret-token-value",
+		"env.API_KEY":   "sk-12345",
+		"private_key":   "nsec1abc",
+		"password":      "hunter2",
+	}
+	for field, val := range cases {
+		got := maskedEditValue(field, val)
+		if strings.Contains(got, val) {
+			t.Fatalf("maskedEditValue(%q) leaked the plaintext: %q", field, got)
+		}
+		if got == "" {
+			t.Fatalf("maskedEditValue(%q) must keep a non-empty echo", field)
+		}
+	}
+	// Benign fields echo verbatim.
+	if got := maskedEditValue("env.APP_ID", "123456"); got != "123456" {
+		t.Fatalf("benign field must echo verbatim, got %q", got)
+	}
+	if got := maskedEditValue("display_name", "my adapter"); got != "my adapter" {
+		t.Fatalf("benign field must echo verbatim, got %q", got)
+	}
+}
+
+func TestRenderIMEditInputMasksSecretEcho(t *testing.T) {
+	m := newTestModel()
+	s := &imAdapterEditState{
+		adapterName: "x",
+		editField:   "env.BOT_TOKEN",
+		editInput:   "super-secret-token",
+		mode:        imEditInput,
+	}
+	out := m.renderIMEditInput(s)
+	if strings.Contains(out, "super-secret-token") {
+		t.Fatalf("edit-input frame leaked the secret into scrollback: %q", out)
+	}
+}


### PR DESCRIPTION
## #2169 — 编辑态明文回显（我 #2158 域 follow-up）
renderIMEditInput 以裸 %s 渲染 editInput（originalExtra 明文）——列表面 mask 在 Enter 的下一屏被无声绕过，scrollback 持久留存。新增 `maskedEditValue`：secret 字段回显 mask（env. 前缀剥离后走同一 pattern 族），**输入缓冲保留真值**（保存语义不变）。同仓先例（stream_panel/onboard EchoPassword）对齐。

## #2171 — causal Windows 路径死区（我 #2099 域 follow-up）
字符类缺 \\ 与 : —— Windows 原生输出（C:\src\api.rs、go 自己的 .\pkg\file.go）全零匹配；**先于 #2099 存在的平台级盲区**（Go 分支同样受害）。类补两字符 + tsc 括号形态 path(12,3) + 收集时先折叠 \\→/ 再剥 ./（归一化次序钉测试）。

## 验证
- #2169：单元（secret mask 非空/benign 原样）+ 渲染 frame 无明文端到端
- #2171：6 形态（盘符/相对反斜杠/点反斜杠/tsc 括号/posix 对照×2）+ #2099 既有 5 场景无回归
- agent 22.4s + tui 14.7s 全量 + 全仓 build 通过

请求 @ggcxf_reviewer_agent 复核（重点：masked echo 下用户改 secret 的输入体验——追加字符时显示 mask 的新值，保存取缓冲真值+追加，请裁定可接受性；正则类含 : 后对 URL 形容文本的吞吃面）。