### PR TITLE
fix(tui): QQ share loud failure on oversized names; provider panel key echo masking (#2172, #2173)

### DIFF
--- a/internal/tui/provider_panel.go
+++ b/internal/tui/provider_panel.go
@@ -208,11 +208,26 @@ func (p *providerPanelState) selectedModel() string {
 func (p *providerPanelState) startEditing(field, initialValue string) {
 	ti := textinput.New()
 	ti.Prompt = "❯ "
+	// #2173: API-key-class fields echo masked - the repo's own convention
+	// (onboard.go, stream_panel.go) is EchoPassword for secret inputs; this
+	// panel echoed every typed character in cleartext (shoulder-surfing /
+	// screen-recording over /provider edit and the wizards). The buffer
+	// still holds the real value for saving.
+	if isProviderSecretField(field) {
+		ti.EchoMode = textinput.EchoPassword
+	}
 	ti.SetValue(initialValue)
 	ti.CursorEnd()
 	ti.Focus()
 	p.editingField = field
 	p.editInput = ti
+}
+
+// isProviderSecretField reports whether an edit field holds key
+// material (#2173): api_key-class fields on vendors and endpoints.
+func isProviderSecretField(field string) bool {
+	lower := strings.ToLower(field)
+	return strings.Contains(lower, "api_key") || strings.Contains(lower, "apikey") || strings.Contains(lower, "secret") || strings.Contains(lower, "token") || strings.Contains(lower, "password")
 }
 
 func (m *Model) configView() *ConfigView {
@@ -1054,6 +1069,7 @@ func (m *Model) handleNewVendorStep() (Model, tea.Cmd) {
 		panel.newVendorStep = newVendorStepAPIKey
 		ti := textinput.New()
 		ti.Prompt = "❯ "
+		ti.EchoMode = textinput.EchoPassword // #2173: secret input echo
 		ti.Focus()
 		panel.newVendorInput = ti
 		panel.message = ""
@@ -1145,6 +1161,7 @@ func (m *Model) handleNewEndpointStep() (Model, tea.Cmd) {
 		panel.newEndpointStep = newEndpointStepAPIKey
 		ti := textinput.New()
 		ti.Prompt = "❯ "
+		ti.EchoMode = textinput.EchoPassword // #2173: secret input echo
 		ti.Focus()
 		panel.newVendorInput = ti
 		panel.message = ""

--- a/internal/tui/qq_panel.go
+++ b/internal/tui/qq_panel.go
@@ -297,6 +297,13 @@ func (m *Model) generateQQShareLink(entry qqBindingEntry) tea.Cmd {
 			return qqBindResultMsg{err: err}
 		}
 		callbackData := qqShareCallbackData(m.currentWorkspacePath())
+		// #2172: an over-long (Chinese workspace names hit 33 bytes at 11
+		// chars) target ID used to yield an EMPTY callback silently - the
+		// QR rendered fine and claimed success, but scanning it could never
+		// pair (no workspace identifier in the callback). Fail loudly.
+		if callbackData == "" {
+			return qqBindResultMsg{err: fmt.Errorf("workspace directory name too long for QQ pairing callback (>32 bytes): %s", defaultQQTargetID(m.currentWorkspacePath()))}
+		}
 		link, err := m.imManager.GenerateShareLink(context.Background(), entry.Adapter, callbackData)
 		if err != nil {
 			return qqBindResultMsg{err: err}

--- a/internal/tui/zz_issue2172_2173_test.go
+++ b/internal/tui/zz_issue2172_2173_test.go
@@ -1,0 +1,56 @@
+package tui
+
+// #2172/#2173 regression:
+//   - #2172: an over-long workspace basename (>32 bytes - 11 Chinese
+//     chars) made qqShareCallbackData return "" and the QQ panel
+//     rendered a "successful" QR that could never pair.
+//   - #2173: the provider panel's API-key edit input and the wizards'
+//     API-key steps echoed every typed character in cleartext (the
+//     repo convention is EchoPassword, cf. onboard/stream_panel).
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/textinput"
+)
+
+func TestQQShareCallbackEmptyFailsLoudly(t *testing.T) {
+	long := strings.Repeat("项", 11) // 33 bytes
+	if got := qqShareCallbackData(long); got != "" {
+		t.Fatalf("33-byte basename must yield empty callback (precondition), got %q", got)
+	}
+	// The caller now rejects the empty callback BEFORE generating a QR -
+	// verified by the guard's presence; unit level we pin the helper
+	// boundary that feeds it.
+	if got := qqShareCallbackData("ok-dir"); got != "ok-dir" {
+		t.Fatalf("normal basename must pass through, got %q", got)
+	}
+}
+
+func TestProviderSecretFieldDetection(t *testing.T) {
+	yes := []string{"api_key", "endpoint_api_key", "apiKey", "secret", "token", "password"}
+	for _, f := range yes {
+		if !isProviderSecretField(f) {
+			t.Errorf("isProviderSecretField(%q) = false, want true", f)
+		}
+	}
+	no := []string{"base_url", "display_name", "model", "protocol"}
+	for _, f := range no {
+		if isProviderSecretField(f) {
+			t.Errorf("isProviderSecretField(%q) = true, want false", f)
+		}
+	}
+}
+
+func TestProviderEditSecretEchoMasked(t *testing.T) {
+	p := &providerPanelState{}
+	p.startEditing("api_key", "sk-initial")
+	if p.editInput.EchoMode != textinput.EchoPassword {
+		t.Fatal("api_key edit input must echo masked (EchoPassword)")
+	}
+	p.startEditing("base_url", "https://x")
+	if p.editInput.EchoMode == textinput.EchoPassword {
+		t.Fatal("benign field must echo normally")
+	}
+}


### PR DESCRIPTION
## #2172 — QQ 废码静默降级
中文 workspace basename ≥33 字节（11 汉字，QQ 面板目标受众）→ qqShareCallbackData 返回空 → 二维码照常渲染 + 成功提示 → 扫码永无法配对。空 callback 现**显式报错**（指明 >32 字节约束与目录名）再不出码。

## #2173 — provider 面板 key 明文回显（secret 显示面第三缺口）
startEditing + 双向导 API key 步（newVendor/newEndpoint）全部裸 textinput——对齐 onboard/stream_panel 的 EchoPassword 惯例：api_key/secret/token/password 族字段掩码回显，缓冲保留真值（保存取 Value() 不变）。

## 验证
- 33 字节边界钉住（空 callback 前置 + 正常名透传）+ 守卫存在
- isProviderSecretField 6 命中 4 排除；api_key 编辑输入 EchoPassword / base_url 正常
- tui 全量 9.7s + 全仓 build 通过

请求 @ggcxf_reviewer_agent 复核（重点：isProviderSecretField 与 config/tui 两份 looksLikeSecretField 的三拷贝收敛是否值得后续统一——本 PR 先按面板局部最小修）。