### PR TITLE
fix(tui): serialize ensureCurrentWorkspaceIMManager on the imEnsure guard (#2175)

### DIFF
--- a/internal/tui/im_runtime_shared.go
+++ b/internal/tui/im_runtime_shared.go
@@ -13,6 +13,20 @@ import (
 )
 
 func (m *Model) ensureCurrentWorkspaceIMManager(unavailableErr, disabledErr string, autoEnable bool) error {
+	// #2175: this lazy-ensure runs in Cmd goroutines (ensurePCReady and
+	// 8 panels' key handlers) while the Update loop keeps reading
+	// m.imManager - the entry used to check-and-set with NO guard, so
+	// concurrent panels raced duplicate InitRuntime calls and the
+	// config.IM.Enabled flip + saveConfig fired unlocked from the Cmd
+	// goroutine. Mirror the sister function's guard (#1379/#1417):
+	// serialize the whole ensure on the same imEnsure mutex and re-check
+	// the manager under it. (Field reads elsewhere remain the broader
+	// #2152-family work; this closes the write side.)
+	if m.imEnsure == nil {
+		m.imEnsure = &imEnsureGuard{}
+	}
+	m.imEnsure.mu.Lock()
+	defer m.imEnsure.mu.Unlock()
 	if m.imManager != nil {
 		return nil
 	}

--- a/internal/tui/zz_issue2175_test.go
+++ b/internal/tui/zz_issue2175_test.go
@@ -1,0 +1,37 @@
+package tui
+
+// #2175 regression: ensureCurrentWorkspaceIMManager ran check-and-set
+// with NO guard from Cmd goroutines (ensurePCReady + 8 panels) while
+// the Update loop kept reading m.imManager - duplicate InitRuntime
+// races and an unlocked config.IM.Enabled flip + saveConfig.
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/topcheer/ggcode/internal/config"
+)
+
+func TestEnsureCurrentWorkspaceIMManagerSerialized(t *testing.T) {
+	m := newTestModel()
+	m.config = &config.Config{}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = m.ensureCurrentWorkspaceIMManager("unavailable", "disabled", false)
+		}(i)
+	}
+	wg.Wait()
+	// IM disabled + autoEnable=false: every call must return the
+	// disabled error - run under -race: the serialized check-and-set
+	// must not race the config.IM.Enabled read either.
+	for i, err := range errs {
+		if err == nil || err.Error() != "disabled" {
+			t.Fatalf("call %d: want disabled error, got %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
## 根因
懒初始化入口在 Cmd goroutine（ensurePCReady 五命令 + 8 面板按键）裸 check-and-set，Update loop 同时读 m.imManager——并发面板重复 InitRuntime + config.IM.Enabled 翻转/saveConfig 无锁。姊妹函数 ensureStartedCurrentWorkspaceIMRuntime 自 #1379/#1417 起有 imEnsure guard，本入口漏配。

## 修复
整个 ensure 体上 imEnsure.mu（复用同字段、懒建）+ 锁内重查 imManager：重复 InitRuntime 坍缩为单次、config 写与检查串行化、ensurePCReady 3s 轮询不再叠开。写侧闭环；面板字段读侧仍属 #2152 族广义工作（issue 自述后果轻微无 panic）。

## 验证
8 并发 ensure（-race -count=2）干净返回 disabled 错误零数据竞争 + tui 全量 9.8s + 全仓 build。

请求 @ggcxf_reviewer_agent 复核（重点：imEnsure.mu 与姊妹函数 starting/done 机制共用一把锁是否会与 Start 路径互相阻塞——两条路径语义上确实需要互斥，但请确认无长持锁风险）。