### PR TITLE
fix(tui,agent): masked slack/signal create echoes; causal URL skip (#2178, #2179)

### DIFF
--- a/internal/agent/causal_attribution.go
+++ b/internal/agent/causal_attribution.go
@@ -157,6 +157,14 @@ func extractErrorFiles(output string) []string {
 		// attribution work uniformly on every platform.
 		f = strings.ReplaceAll(f, "\\", "/")
 		f = strings.TrimPrefix(f, "./")
+		// #2179: URL-shaped text satisfies the class wholesale (both
+		// separators plus ':') and was captured as an "error file" - it
+		// never matches any edited file, but a NON-EMPTY errorFiles list
+		// alone earned the recency weight, handing URL-bearing outputs a
+		// free attribution score. Skip http(s) captures outright.
+		if strings.HasPrefix(f, "http://") || strings.HasPrefix(f, "https://") {
+			continue
+		}
 		if !seen[f] {
 			seen[f] = true
 			files = append(files, f)

--- a/internal/agent/zz_issue2179_test.go
+++ b/internal/agent/zz_issue2179_test.go
@@ -1,0 +1,32 @@
+package agent
+
+// #2179 regression: URL-shaped text was captured wholesale as an "error
+// file" - never matching any edited file, but inflating errorFiles past
+// the recency gate for a free attribution score.
+
+import "testing"
+
+func TestCausalErrorFilesSkipsURLs(t *testing.T) {
+	files := extractErrorFiles("see https://x.com/a.go:1: for details")
+	if len(files) != 0 {
+		t.Fatalf("URL-only output must yield no error files, got %v", files)
+	}
+	files = extractErrorFiles("docs at http://cdn.example.com/src/lib.rs:12: more")
+	if len(files) != 0 {
+		t.Fatalf("http URL must be skipped, got %v", files)
+	}
+	// Mixed: the real file survives, the URL does not.
+	files = extractErrorFiles("see https://x.com/a.go:1: and src/a.go:3:1: boom")
+	found := false
+	for _, f := range files {
+		if f == "https://x.com/a.go" {
+			t.Fatalf("URL capture leaked through: %v", files)
+		}
+		if f == "src/a.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("real file must survive next to a URL, got %v", files)
+	}
+}

--- a/internal/tui/signal_panel.go
+++ b/internal/tui/signal_panel.go
@@ -62,6 +62,21 @@ type signalQRCodeMsg struct {
 	err error
 }
 
+// maskSignalCreateEcho masks the create-input echo (#2178 same-shape):
+// the spec is `name base_url account` - the 3rd field is the phone
+// number (PII). First two fields stay readable; later ones are masked.
+func maskSignalCreateEcho(input string) string {
+	fields := strings.Fields(input)
+	if len(fields) <= 2 {
+		return input
+	}
+	masked := []string{fields[0], fields[1]}
+	for _, f := range fields[2:] {
+		masked = append(masked, maskSecret(f))
+	}
+	return strings.Join(masked, " ")
+}
+
 func checkSignalDaemonCmd() tea.Cmd {
 	return func() tea.Msg {
 		err := im.CheckSignalDaemon("")
@@ -247,7 +262,7 @@ func (m Model) renderSignalPanel() string {
 	body = append(body, "", lipgloss.NewStyle().Bold(true).Render(m.t("panel.signal.create")))
 	if panel.createMode {
 		body = append(body,
-			" "+m.t("panel.signal.bot_input", panel.createInput+"█"),
+			" "+m.t("panel.signal.bot_input", maskSignalCreateEcho(panel.createInput)+"█"),
 			" "+m.t("panel.signal.create_format"),
 			" "+m.t("panel.signal.create_example"),
 			renderPasteShortcutHint(m.currentLanguage()),

--- a/internal/tui/slack_panel.go
+++ b/internal/tui/slack_panel.go
@@ -50,6 +50,23 @@ func (m *Model) closeSlackPanel() {
 	m.slackPanel = nil
 }
 
+// maskSlackCreateEcho masks the create-input echo (#2178): the spec is
+// `name botToken appToken` - the tokens are POSITIONAL (2nd/3rd field),
+// so the field name is unknown at render time. The name (first field)
+// stays readable for review; every later field is token material and
+// is masked. The buffer keeps the real value for the Enter parse.
+func maskSlackCreateEcho(input string) string {
+	fields := strings.Fields(input)
+	if len(fields) <= 1 {
+		return input
+	}
+	masked := []string{fields[0]}
+	for _, f := range fields[1:] {
+		masked = append(masked, maskSecret(f))
+	}
+	return strings.Join(masked, " ")
+}
+
 func (m Model) renderSlackPanel() string {
 	panel := m.slackPanel
 	if panel == nil {
@@ -108,7 +125,7 @@ func (m Model) renderSlackPanel() string {
 	body = append(body, "", lipgloss.NewStyle().Bold(true).Render(m.t("panel.slack.create")))
 	if panel.createMode {
 		body = append(body,
-			" "+m.t("panel.slack.bot_input", panel.createInput+"█"),
+			" "+m.t("panel.slack.bot_input", maskSlackCreateEcho(panel.createInput)+"█"),
 			" "+m.t("panel.slack.create_format"),
 			" "+m.t("panel.slack.create_example"),
 			renderPasteShortcutHint(m.currentLanguage()),

--- a/internal/tui/zz_issue2178_test.go
+++ b/internal/tui/zz_issue2178_test.go
@@ -1,0 +1,33 @@
+package tui
+
+// #2178 regression: the slack create input's ONLY purpose is entering
+// bot/app tokens (`name xoxb-... xapp-...`, positional) - the echo was
+// raw, so every keystroke (or a paste) went into the frame verbatim.
+// The signal panel's same-shape input carries a phone number (PII).
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaskSlackCreateEcho(t *testing.T) {
+	in := "mybot xoxb-1234567890-secret xapp-1-abcdef"
+	got := maskSlackCreateEcho(in)
+	if !strings.HasPrefix(got, "mybot ") {
+		t.Fatalf("name field must stay readable: %q", got)
+	}
+	if strings.Contains(got, "xoxb-1234567890") || strings.Contains(got, "xapp-1-abcdef") {
+		t.Fatalf("token fields leaked: %q", got)
+	}
+	// Name-only (mid-typing): verbatim.
+	if got := maskSlackCreateEcho("mybot"); got != "mybot" {
+		t.Fatalf("name-only must echo verbatim: %q", got)
+	}
+	// Buffer keeps the real value for the Enter parse (caller side).
+	if got := maskSignalCreateEcho("mybase http://localhost:5050 +15551234567"); strings.Contains(got, "15551234567") {
+		t.Fatalf("signal account (PII) leaked: %q", got)
+	}
+	if got := maskSignalCreateEcho("mybase http://localhost:5050"); !strings.Contains(got, "localhost:5050") {
+		t.Fatalf("first two signal fields must stay readable: %q", got)
+	}
+}


### PR DESCRIPTION
## #2178 — slack create 输入 token 明文（#2169 修复的明确残余面）
该输入唯一用途即录入 `name xoxb-… xapp-…`（token 位置式，字段语义只在 Enter 解析时存在）——回显原样，触发率 100%。`maskSlackCreateEcho`：首段（name）可读、其余全 mask；signal 面板同形态（第 3 段手机号 PII）`maskSignalCreateEcho`：前两段可读、其余 mask。缓冲保留真值（Enter 解析不变）。

## #2179 — causal 吞吃 URL 白得 recency 分（PR #2174 复核轮探针）
URL 类文本整段被捕获为"错误文件"——不匹配任何被编辑文件但 errorFiles 非空即过 #1528 recency 门白得分。http(s) 前缀捕获跳过；混排输出中真文件存活。

## 验证
- slack 名可读+双 token mask+名中态原样；signal PII mask+前两段可读
- URL-only/混排两形态 + #2099/#2171 系列无回归
- tui 9.7s + agent 21.5s 全量 + 全仓 build

请求 @ggcxf_reviewer_agent 复核（重点：maskSlackCreateEcho 对多空格输入用 Fields+Join 归一化的可接受性——渲染层归一化不影响解析端 Fields 语义）。