### PR TITLE
fix(agent): ghost detector lists annotated; coverage/scopeNarrow same-cmd dedup (#1821)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -3592,6 +3592,12 @@ func (a *Agent) RunStreamWithContent(ctx context.Context, content []provider.Con
 			// but verification command only covers a subset.
 			if covWarn := a.editCoverage.recordToolCall(tc.Name, string(tc.Arguments)); covWarn != "" {
 				debug.Log("agent", "Iteration %d: verification coverage gap detected", i+1)
+				// #1821 case 3: scopeNarrow's message for the SAME command
+				// is near-identical - let it skip once instead of double-
+				// injecting on one tool call.
+				if cmd := extractCommandFromToolCall(tc.Arguments); cmd != "" {
+					a.scopeNarrow.lastCoverageWarnedCmd = cmd
+				}
 				a.contextManager.Add(provider.Message{
 					Role:    "user",
 					Content: []provider.ContentBlock{{Type: "text", Text: covWarn}},

--- a/internal/agent/redundant_reverify.go
+++ b/internal/agent/redundant_reverify.go
@@ -19,8 +19,10 @@ package agent
 // This is distinct from:
 //   - futile_cycle: tracks re-READS (information gathering without mutation)
 //   - phantom_verify: claims verification success without running commands
-//   - verify_scope_decay: progressive narrowing of verification scope
-//   - verify_disconnect: verification failures that get advanced past
+//
+// (#1821 case 2: verify_scope_decay and verify_disconnect were deleted in
+// 387282a6 - the advance-past-failures surface is partially carried by
+// outcomeMisattrib (recordResult) - neither remains a division partner.)
 //
 // This detector specifically catches: "you ran `go test`, it passed, you made
 // no edits, then you ran `go test` again." The second run cannot produce new

--- a/internal/agent/verify_coverage_gap.go
+++ b/internal/agent/verify_coverage_gap.go
@@ -32,12 +32,14 @@ package agent
 // This is distinct from existing detectors:
 //   - bare_edit_streak.go: checks if NO verification was run at all.
 //     This checks whether verification COVERS all edited packages.
-//   - verify_scope_decay.go: tracks narrowing scope over TIME (trajectory).
-//     This checks coverage at each verification point (spatial).
 //   - verify_scope_narrow.go: detects command argument narrowing (gaming).
 //     This checks whether verification scope matches edited scope (mismatch).
 //   - change_reconcile.go: checks stated vs actual file changes.
 //     This checks verified vs edited files (verification mismatch).
+//
+// (#1821 case 2: verify_scope_decay was deleted in 387282a6 - its
+// trajectory-narrowing surface is partially carried by outcomeMisattrib
+// (recordResult) - and is no longer a division partner.)
 //   - test_impact.go: SUGGESTS which tests to run.
 //     This DETECTS when verification didn't cover edited files.
 //

--- a/internal/agent/verify_scope_narrow.go
+++ b/internal/agent/verify_scope_narrow.go
@@ -52,6 +52,11 @@ type scopeNarrowState struct {
 	history []scopeEntry
 	// fired prevents duplicate warnings.
 	fired bool
+	// #1821 case 3: when the coverage-gap detector fires for the SAME
+	// command in the same tool call, its near-identical guidance would
+	// double-inject - remember the command and let scopeNarrow skip
+	// once (set by agent.go when covWarn fires).
+	lastCoverageWarnedCmd string
 }
 
 type scopeEntry struct {
@@ -253,6 +258,13 @@ func extractAfterKeyword(cmd, keyword string) string {
 // Returns a non-empty warning string if scope narrowing is detected.
 func (s *scopeNarrowState) recordVerificationCommand(toolName, cmd string, output string, isError bool) string {
 	if s.fired {
+		return ""
+	}
+	// #1821 case 3: coverage already injected its near-identical guidance
+	// for THIS command in this tool call - skip ours, clear the slot so a
+	// different command still narrows normally.
+	if s.lastCoverageWarnedCmd != "" && s.lastCoverageWarnedCmd == cmd {
+		s.lastCoverageWarnedCmd = ""
 		return ""
 	}
 

--- a/internal/agent/zz_issue1821_test.go
+++ b/internal/agent/zz_issue1821_test.go
@@ -1,0 +1,27 @@
+package agent
+
+// #1821 regression (cases 2+3):
+//   - case 2: two file-header "distinct from" lists still cited the
+//     detectors deleted in 387282a6 as living division partners.
+//   - case 3: the coverage-gap and scope-narrow detectors both injected
+//     near-identical guidance for the SAME verification command in one
+//     tool call (3 injections on a standard narrowing sequence).
+
+import "testing"
+
+func TestScopeNarrowSkipsWhenCoverageFiredForSameCmd(t *testing.T) {
+	s := newScopeNarrowState()
+	s.lastCoverageWarnedCmd = "go test ./internal/config/"
+
+	// Same command: suppressed, slot cleared.
+	if msg := s.recordVerificationCommand("run_command", "go test ./internal/config/", "FAIL", true); msg != "" {
+		t.Fatalf("scopeNarrow must skip when coverage fired for the same cmd, got %q", msg)
+	}
+	if s.lastCoverageWarnedCmd != "" {
+		t.Fatal("slot must clear after one suppression")
+	}
+	// A DIFFERENT command narrows normally afterwards (baseline fires
+	// only on the narrowing pattern; here we just assert no panic and
+	// that suppression is not sticky).
+	_ = s.recordVerificationCommand("run_command", "go test ./...", "ok", false)
+}


### PR DESCRIPTION
## 三案处置
- **案 1（High·scope 文法分歧）：查重零改动**——已被 24f04575（#1784）修复：裸 `go test internal/config/` 现产出正确 scopes（HEAD 逐行核验 + 该路径已有回归测试）。
- **案 2（Med-High·幽灵清单残留）**：agent.go 四处注释已被 #1823 家族清理；本 PR 补齐残留的两处文件头 "distinct from" 清单（verify_coverage_gap.go / redundant_reverify.go）——标注 387282a6 删除 + outcomeMisattrib 部分承接。
- **案 3（Med·同命令双注入）**：agent.go 在 covWarn 触发时记录该命令，scopeNarrow 对同命令**跳过一次**（槽位即清，不同命令正常 narrow）——标准 narrowing 序列 3 注入降为 2。

## 验证
同命令抑制+槽位清除+不粘滞测试 + agent 全量 21.5s + 全仓 build。

请求 @ggcxf_reviewer_agent 复核（重点：案 3 单向协调的充分性——coverage×2 自身因 cmd 串不同仍可双发，但两条文本有编辑包差异信息非纯冗余；若需双向协调请裁定）。