### PR TITLE
refactor(secretfield): single source for the secret-field-name heuristic (#2180)

### DIFF
--- a/desktop/wailskit/im_secretfield_pin_test.go
+++ b/desktop/wailskit/im_secretfield_pin_test.go
@@ -1,0 +1,30 @@
+package wailskit
+
+// #2180: the desktop registry declares Secret-ness explicitly (best
+// practice), but a name that drifts OUT of the single-source wide table
+// would silently render in cleartext if any code path ever fell back
+// to name heuristics. Pin: every registry Secret field must hit the
+// single source.
+
+import (
+	"testing"
+
+	"github.com/topcheer/ggcode/internal/secretfield"
+)
+
+func TestIMPlatformRegistrySecretFieldsHitSingleSource(t *testing.T) {
+	checked := 0
+	for _, p := range GetIMPlatformRegistry() {
+		for _, f := range p.Fields {
+			if f.Secret {
+				checked++
+				if !secretfield.LooksLikeSecretField(f.Key) {
+					t.Errorf("%s.%s is Secret:true but misses the single-source table - rename or extend secretfield", p.ID, f.Key)
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("registry has no Secret fields - the pin lost its subject")
+	}
+}

--- a/internal/config/api_keys.go
+++ b/internal/config/api_keys.go
@@ -11,6 +11,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/topcheer/ggcode/internal/secretfield"
 	"github.com/topcheer/ggcode/internal/util"
 )
 
@@ -186,13 +187,9 @@ func detectPlaintextAPIKeysFromRaw(raw map[string]interface{}) []APIKeyFinding {
 // looksLikeSecretField returns true if the key name suggests it holds a secret.
 // Matches: secret, token, password, credential (case-insensitive, as substring).
 func looksLikeSecretField(key string) bool {
-	lower := strings.ToLower(key)
-	for _, pattern := range []string{"secret", "token", "password", "credential", "key"} {
-		if strings.Contains(lower, pattern) {
-			return true
-		}
-	}
-	return false
+	// #2180: single source - this was copy #1 of four diverging word
+	// lists (tui, provider panel, desktop registry the others).
+	return secretfield.LooksLikeSecretField(key)
 }
 
 // secretFieldEnvVar builds an env var name for an IM adapter secret field.

--- a/internal/secretfield/secretfield.go
+++ b/internal/secretfield/secretfield.go
@@ -1,0 +1,21 @@
+// Package secretfield is the single source for the "does this field
+// name hold a secret?" heuristic (#2180). Four diverging copies lived
+// in config, tui, the provider panel, and the desktop registry - the
+// #2167 drift (a fix claiming API_KEY coverage while the pattern
+// lacked "key") showed how silently the word lists fork.
+package secretfield
+
+import "strings"
+
+// LooksLikeSecretField reports whether a field NAME suggests it holds
+// secret material (case-insensitive substring). The wide table covers
+// the IM Extra/Env surfaces where arbitrary user keys arrive.
+func LooksLikeSecretField(key string) bool {
+	lower := strings.ToLower(key)
+	for _, pattern := range []string{"secret", "token", "password", "credential", "key"} {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/im_edit.go
+++ b/internal/tui/im_edit.go
@@ -11,6 +11,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/topcheer/ggcode/internal/im"
+	"github.com/topcheer/ggcode/internal/secretfield"
 )
 
 // imAdapterEditMode represents the current editing sub-state.
@@ -412,11 +413,8 @@ func maskSecret(value string) string {
 // looksLikeSecretField checks if a key name suggests it holds a secret.
 // Duplicated from config package to avoid import cycle concerns.
 func looksLikeSecretField(key string) bool {
-	lower := strings.ToLower(key)
-	for _, pattern := range []string{"secret", "token", "password", "credential", "key"} {
-		if strings.Contains(lower, pattern) {
-			return true
-		}
-	}
-	return false
+	// #2180: single source - the former "Duplicated from config package
+	// to avoid import cycle concerns" copy is gone; secretfield is a
+	// leaf package with no cycle risk.
+	return secretfield.LooksLikeSecretField(key)
 }

--- a/internal/tui/provider_panel.go
+++ b/internal/tui/provider_panel.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/topcheer/ggcode/internal/debug"
+	"github.com/topcheer/ggcode/internal/secretfield"
 	"github.com/topcheer/ggcode/internal/util"
 	"strings"
 	"time"
@@ -224,10 +225,15 @@ func (p *providerPanelState) startEditing(field, initialValue string) {
 }
 
 // isProviderSecretField reports whether an edit field holds key
-// material (#2173): api_key-class fields on vendors and endpoints.
+// material (#2173/#2180): an explicit auditable list for the panel's
+// FIXED field set first, then the single-source wide table as fallback
+// so any future key-bearing field name is covered without a copy.
 func isProviderSecretField(field string) bool {
-	lower := strings.ToLower(field)
-	return strings.Contains(lower, "api_key") || strings.Contains(lower, "apikey") || strings.Contains(lower, "secret") || strings.Contains(lower, "token") || strings.Contains(lower, "password")
+	switch field {
+	case "api_key", "apikey", "secret", "token", "password":
+		return true
+	}
+	return secretfield.LooksLikeSecretField(field)
 }
 
 func (m *Model) configView() *ConfigView {


### PR DESCRIPTION
## 按建议方案三步落地
1. **internal/secretfield 叶子包**（零 import cycle）持宽表；config 与 tui 双双委托——tui 的 "Duplicated" 实体重复删除。
2. **isProviderSecretField** 改「显式字段清单 + 单源宽表兜底」——差异从漂移变为构造性。
3. **桌面注册表**保持显式声明（最佳实践），新增钉住测试：所有 Secret:true 字段名必须命中单源——反向漂移直接 fail CI。

## 背景
#2167 已实证漂移代价（声称失实 + nostr 明文）；本 PR 消除的是**隐式重复**而非合并语境差异（IM 任意键宽表/面板固定集窄表/桌面显式元数据各有其位）。

## 验证
注册表钉住测试（含零 Secret 防空转守卫）+ config 12.7s / tui 9.7s / wailskit 10.6s 全量（masking 套件现经委托行使单源）+ 全仓 build。

请求 @ggcxf_reviewer_agent 复核（重点：三消费面委托后语义等价——既有 masking 测试全绿即证；钉住测试的守卫方向）。