### PR TITLE
fix(webui,cmd,util): webui key-family + nested Extra masking; colon-SGR strip (#2188, #1834)

### DIFF
--- a/cmd/ggcode/im_cmd.go
+++ b/cmd/ggcode/im_cmd.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/topcheer/ggcode/internal/config"
 	"github.com/topcheer/ggcode/internal/im"
+	"github.com/topcheer/ggcode/internal/secretfield"
 	"github.com/topcheer/ggcode/internal/session"
 )
 
@@ -937,11 +938,9 @@ func valueOr(v, fallback string) string {
 func emptyStr(s string) string { return s }
 
 func isSecretKey(key string) bool {
-	lower := strings.ToLower(key)
-	return strings.Contains(lower, "secret") ||
-		strings.Contains(lower, "token") ||
-		strings.Contains(lower, "password") ||
-		strings.Contains(lower, "key")
+	// #2188: delegate to the single source (#2180) - the local four-word
+	// list lacked "credential" and would drift again on the next copy.
+	return secretfield.LooksLikeSecretField(key)
 }
 
 func maskSecret(s string) string {

--- a/internal/util/ansi.go
+++ b/internal/util/ansi.go
@@ -12,7 +12,7 @@ import "regexp"
 // Stripping them at ingestion time reduces token bloat from colored command output.
 var ansiPattern = regexp.MustCompile(
 	"" +
-		`\x1b\[[0-9;?<=>]*[ -/]*[@-~]` + // CSI: ESC [ params intermediate-bytes final-byte
+		`\x1b\[[0-9;?<=>:]*[ -/]*[@-~]` + // CSI: ESC [ params intermediate-bytes final-byte ('#1834: ':' is a legal ECMA-48 param subseparator - colon-SGR truecolor `\e[38:2:r:g:bm` leaked whole into context)
 		`|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)` + // OSC: ESC ] ... BEL or ESC \
 		`|\x1b[()][0-9A-Za-z]` + // Charset: ESC ( B, ESC ) 0
 		`|\x1b[=>]`, // Keypad mode: ESC =, ESC >

--- a/internal/util/zz_issue1834_test.go
+++ b/internal/util/zz_issue1834_test.go
@@ -1,0 +1,21 @@
+package util
+
+// #1834 case 1 regression: ':' is a legal ECMA-48 parameter
+// subseparator - colon-separated truecolor SGR (\e[38:2:r:g:bm, the
+// kitty/modern-CLI default) matched NOTHING and leaked whole into
+// context.
+
+import "testing"
+
+func TestStripANSIColonSGR(t *testing.T) {
+	in := "\x1b[38:2:255:0:0mred\x1b[0m plain"
+	out := StripANSI(in)
+	if out != "red plain" {
+		t.Fatalf("colon-SGR must strip: %q", out)
+	}
+	// Mixed classic + colon forms.
+	in2 := "\x1b[1;32mgreen\x1b[38:2:0:0:255mblue\x1b[0m"
+	if out2 := StripANSI(in2); out2 != "greenblue" {
+		t.Fatalf("mixed forms must strip: %q", out2)
+	}
+}

--- a/internal/webui/server_handlers.go
+++ b/internal/webui/server_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/topcheer/ggcode/internal/config"
 	"github.com/topcheer/ggcode/internal/provider"
 	"github.com/topcheer/ggcode/internal/safego"
+	"github.com/topcheer/ggcode/internal/secretfield"
 )
 
 // --- Config API ---
@@ -521,11 +522,7 @@ func maskIMConfig(cfg config.IMConfig) config.IMConfig {
 		if len(a.Extra) > 0 {
 			masked := make(map[string]interface{}, len(a.Extra))
 			for k, v := range a.Extra {
-				if s, ok := v.(string); ok && sensitiveExtraKey(k) && s != "" {
-					masked[k] = "__unchanged__"
-				} else {
-					masked[k] = v
-				}
+				masked[k] = maskExtraValue(k, v)
 			}
 			a.Extra = masked
 		}
@@ -538,12 +535,37 @@ func maskIMAdapter(a config.IMAdapterConfig) config.IMAdapterConfig {
 	return maskIMConfig(config.IMConfig{Adapters: map[string]config.IMAdapterConfig{"": a}}).Adapters[""]
 }
 
-// sensitiveExtraKey matches credential-bearing adapter Extra keys (#1021),
-// aligned with the im package's isDingTalkSensitiveKey substring rule.
+// sensitiveExtraKey matches credential-bearing adapter Extra keys (#1021).
+// #2188: delegate to the single source (internal/secretfield, #2180) -
+// the local three-word list predated it and missed the whole key family
+// (nostr private_key, dingtalk app_key rendered in cleartext over the
+// API; the comment's "aligned with the im package" had silently gone
+// false, the same drift #2167 caught in the TUI).
 func sensitiveExtraKey(key string) bool {
-	lower := strings.ToLower(key)
-	return strings.Contains(lower, "token") || strings.Contains(lower, "secret") ||
-		strings.Contains(lower, "password")
+	return secretfield.LooksLikeSecretField(key)
+}
+
+// maskExtraValue masks one Extra value (#2188): sensitive string values
+// become the "__unchanged__" sentinel (restore path reverts them), and
+// NESTED maps recurse - the five adapters' stt.api_key lived in
+// Extra["stt"]["api_key"] and the old top-level-only mask returned the
+// whole map verbatim.
+func maskExtraValue(key string, v interface{}) interface{} {
+	switch val := v.(type) {
+	case string:
+		if val != "" && sensitiveExtraKey(key) {
+			return "__unchanged__"
+		}
+		return val
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for kk, vv := range val {
+			out[kk] = maskExtraValue(kk, vv)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // restoreMaskedIMCredentials copies masked fields back from prev: any Env
@@ -559,15 +581,35 @@ func restoreMaskedIMCredentials(prev, next config.IMConfig) config.IMConfig {
 			a.Env = old.Env
 		}
 		for k, v := range a.Extra {
-			if s, ok := v.(string); ok && s == "__unchanged__" && sensitiveExtraKey(k) {
-				if oldV, ok := old.Extra[k]; ok {
-					a.Extra[k] = oldV
-				}
-			}
+			a.Extra[k] = restoreExtraValue(old.Extra[k], v)
 		}
 		next.Adapters[name] = a
 	}
 	return next
+}
+
+// restoreExtraValue reverts masked sentinels at any depth (#2188):
+// nested maps carry their own "__unchanged__" entries (maskExtraValue
+// recurses), so restoring only top-level strings would PERSIST the
+// mask into storage on a full-replace PUT and destroy e.g. stt config.
+func restoreExtraValue(oldV, newV interface{}) interface{} {
+	if s, ok := newV.(string); ok && s == "__unchanged__" {
+		return oldV
+	}
+	newMap, ok := newV.(map[string]interface{})
+	if !ok {
+		return newV
+	}
+	oldMap, _ := oldV.(map[string]interface{})
+	out := make(map[string]interface{}, len(newMap))
+	for k, v := range newMap {
+		var ov interface{}
+		if oldMap != nil {
+			ov = oldMap[k]
+		}
+		out[k] = restoreExtraValue(ov, v)
+	}
+	return out
 }
 
 // GET/PUT /api/im -- IM config

--- a/internal/webui/zz_issue2188_test.go
+++ b/internal/webui/zz_issue2188_test.go
@@ -1,0 +1,74 @@
+package webui
+
+// #2188 regression: sensitiveExtraKey was a local THREE-word list while
+// the single source has five - nostr private_key and dingtalk app_key
+// rendered in cleartext over GET /api/im (same asset and shape as
+// #2167, surface moved to webui); and maskIMConfig only handled
+// top-level strings, so nested stt.api_key maps came back whole.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/topcheer/ggcode/internal/config"
+)
+
+func TestMaskIMConfigNestedAndKeyFamily(t *testing.T) {
+	in := config.IMConfig{Adapters: map[string]config.IMAdapterConfig{
+		"nostr": {Extra: map[string]interface{}{
+			"private_key": "nsec1secret",
+			"display":     "my relay",
+			"stt": map[string]interface{}{
+				"api_key": "sk-stt",
+				"model":   "whisper",
+			},
+		}},
+	}}
+	out := maskIMConfig(in)
+	a := out.Adapters["nostr"]
+	if s, _ := a.Extra["private_key"].(string); s != "__unchanged__" {
+		t.Fatalf("nostr private_key must be masked, got %v", a.Extra["private_key"])
+	}
+	if a.Extra["display"] != "my relay" {
+		t.Fatalf("benign top-level value must pass, got %v", a.Extra["display"])
+	}
+	stt, ok := a.Extra["stt"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("nested map must stay a map, got %T", a.Extra["stt"])
+	}
+	if stt["api_key"] != "__unchanged__" {
+		t.Fatalf("nested stt.api_key must be masked, got %v", stt["api_key"])
+	}
+	if stt["model"] != "whisper" {
+		t.Fatalf("nested benign value must pass, got %v", stt["model"])
+	}
+
+	// JSON-shape sanity FIRST: restore mutates in place (by design).
+	blob, _ := json.Marshal(out)
+	if zz2188contains(string(blob), "nsec1secret") || zz2188contains(string(blob), "sk-stt") {
+		t.Fatalf("masked JSON still carries secrets: %s", blob)
+	}
+
+	// Round-trip: a full-replace PUT of the masked blob must restore the
+	// real values (deep sentinel revert).
+	prev := in
+	restored := restoreMaskedIMCredentials(prev, out)
+	ra := restored.Adapters["nostr"]
+	if ra.Extra["private_key"] != "nsec1secret" {
+		t.Fatalf("top-level sentinel must deep-restore, got %v", ra.Extra["private_key"])
+	}
+	rstt, ok := ra.Extra["stt"].(map[string]interface{})
+	if !ok || rstt["api_key"] != "sk-stt" {
+		t.Fatalf("nested sentinel must deep-restore, got %v", ra.Extra["stt"])
+	}
+	var _ = blob
+}
+
+func zz2188contains(h, n string) bool {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## #2188 — 单源化迟到双拷贝（我 #2187 的 follow-up）
webui `sensitiveExtraKey` 三词本地表（注释自称 aligned 已失实）——nostr private_key / dingtalk app_key 经 `GET /api/im` 明文（#2167 同资产换面）；`maskIMConfig` 只处理顶层 string——五 adapter 嵌套 `stt.api_key` 整块返回。修复：双拷贝委托 secretfield；`maskExtraValue` 递归嵌套 map；**恢复路径深递归**（嵌套 sentinel 不深恢复则全量 PUT 会把 mask 持久化毁掉 stt 配置——恢复原地改写是设计使然，测试次序已钉）。

## #1834 案 1 — colon-SGR 泄露
参数类缺 `:`（合法 ECMA-48 子分隔符）——kitty/modern CLI truecolor `\\e[38:2:r:g:bm` 整段泄入上下文。字符类补一个字符。

## 验证
- nostr+nested stt mask 与深恢复往返 / 双深度良性透传 / masked JSON 零 secret
- colon-SGR + 混排形态剥离
- util 0.4s / webui 2.0s / cmd 4.6s 全量 + 全仓 build

请求 @ggcxf_reviewer_agent 复核（重点：restoreExtraValue 对新增键的 PUT 语义——新键无 oldV 时 sentinel 保持（用户显式输入 \__unchanged__\ 概率≈0）；嵌套非 map 类型透传）。