### PR TITLE
fix(util): signal-0 EPERM means alive on Unix (#2190)

### DIFF
--- a/internal/util/process.go
+++ b/internal/util/process.go
@@ -3,6 +3,7 @@
 package util
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"syscall"
@@ -23,7 +24,13 @@ func IsProcessAlive(pid int) bool {
 	if err != nil {
 		return false
 	}
-	if proc.Signal(syscall.Signal(0)) != nil {
+	// #2190: kill(pid, 0) EPERM means the process EXISTS but we lack
+	// permission to signal it (POSIX) - treating it as dead mirrors the
+	// exact bug Windows fixed in #1723 (a privileged daemon probed by an
+	// unprivileged caller: false-dead deletes the PID file and forks a
+	// second instance, or triggers concurrent crash recovery - the Unix
+	// twin of #1490). Only a real error (ESRCH et al.) means dead.
+	if err := proc.Signal(syscall.Signal(0)); err != nil && !errors.Is(err, syscall.EPERM) {
 		return false
 	}
 	return !isZombieUnix(pid)

--- a/internal/util/zz_issue2190_test.go
+++ b/internal/util/zz_issue2190_test.go
@@ -1,0 +1,39 @@
+package util
+
+// #2190 regression: kill(pid,0) EPERM means the process EXISTS but is
+// not signalable by us (POSIX) - it was returned as dead, the Unix twin
+// of the #1723 Windows bug (false-dead deletes PID files and forks
+// second daemons / concurrent crash recovery). The EPERM branch itself
+// needs a cross-privilege process (not unit-testable); these pin the
+// surrounding semantics that must not regress alongside it.
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestIsProcessAliveBasicSemantics(t *testing.T) {
+	if !IsProcessAlive(os.Getpid()) {
+		t.Fatal("self must be alive")
+	}
+	// A definitely-dead PID: spawn and reap one.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Skipf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+	pid, err := syscall.ForkExec("/bin/true", []string{"/bin/true"}, &syscall.ProcAttr{Files: []uintptr{r.Fd(), w.Fd(), w.Fd()}})
+	if err != nil {
+		t.Skipf("forkexec: %v", err)
+	}
+	// Wait for exit; probe until dead (bounded).
+	for i := 0; i < 100; i++ {
+		if !IsProcessAlive(pid) {
+			return // dead, as expected
+		}
+		syscall.Wait4(pid, nil, syscall.WNOHANG, nil)
+	}
+	t.Fatal("reaped child must be reported dead")
+}

--- a/internal/util/zz_issue2190_test.go
+++ b/internal/util/zz_issue2190_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package util
 
 // #2190 regression: kill(pid,0) EPERM means the process EXISTS but is


### PR DESCRIPTION
## 根因
`kill(pid,0)` 的 EPERM = 进程存在但无信号权限（POSIX）——IsProcessAlive 判死，是 #1723 Windows 修复（ACCESS_DENIED→alive，"误判死会删 PID 文件 fork 第二 daemon"）的 Unix 孪生病灶；#1490 同类事故已在 run_journal 注释留档。

## 修复
仅真实错误（ESRCH 等）判死；EPERM 走保守判活（与 isZombieUnix 的保守策略自洽）。调用面（instance_detect PID 清理 / run_journal crash 恢复）不再被跨权限探测误触发。

## 验证
EPERM 分支需跨权限进程对（单测不可构造——注释说明）；周围语义（self-alive / reaped-child-dead）钉住（沙箱环境 fork 受限则 SKIP）；util 全量 + 全仓 build。

请求 @ggcxf_reviewer_agent 复核（重点：EPERM+僵尸组合语义——EPERM 下 isZombieUnix 读不了他户 /proc 返回 false 保守判活，"when in doubt, alive" 与 Windows 侧原则一致）。通过请 approve + CI 绿后 squash merge + issue 评论关闭。另：#1793 经查 f86bdfc7（#2053）已修复案1+2 且收口评论在案，issue 未关——我补关闭。